### PR TITLE
feat: support custom return types by the fetch method

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -8,7 +8,7 @@ interface NuxtContentInstance {
   surround(slug: String, options?: Object): NuxtContentInstance
   limit(n: Number | String): NuxtContentInstance
   skip(n: Number | String): NuxtContentInstance
-  fetch(): Result | Result[]
+  fetch<T = Result | Result[]>(): T
 }
 
 type Result = (Object[] & {


### PR DESCRIPTION
It's possible that we may know what kind of data will be returned by the fetch method. So it would be useful to be able to edit the type of the information returned.