### PR TITLE
Add feed-module integration in documentation

### DIFF
--- a/docs/content/en/advanced.md
+++ b/docs/content/en/advanced.md
@@ -132,3 +132,64 @@ export default {
 
 Now everytime you will update a file in your `content/` directory, it will also dispatch the `fetchCategories` method.
 This documentation use it actually, you can learn more by looking at [plugins/categories.js](https://github.com/nuxt/content/blob/master/docs/plugins/categories.js).
+
+## Integration with @nuxtjs/feed module
+
+In the case of articles, the content can be used to generate news feeds
+using the Nuxt.js [feed-module](https://github.com/nuxt-community/feed-module).
+
+**Example**
+
+```js
+const contentArticles = async () => {
+  const { $content } = require('@nuxt/content')
+  return await $content('articles').fetch()
+}
+
+export default {
+  modules: [,
+    '@nuxt/content',
+    '@nuxtjs/feed',
+  ],
+
+  feed: () => {
+    const baseUrlArticles = 'https://mywebsite.com/articles'
+    const baseLinkFeedArticles = '/feed/articles'
+    const feedFormats = {
+      rss: { type: 'rss2', file: 'rss.xml' },
+      atom: { type: 'atom1', file: 'atom.xml' },
+      json: { type: 'json1', file: 'feed.json' },
+    }
+
+    async function feedCreateArticles(feed) {
+      feed.options = {
+        title: 'My Blog',
+        description: 'I write about technology',
+        link: baseUrlArticles,
+      }
+
+      const articles = await contentArticles()
+
+      articles.forEach((article) => {
+        const url = `${baseUrlArticles}/${article.slug}`
+
+        feed.addItem({
+          title: article.title,
+          id: url,
+          link: url,
+          date: article.published,
+          description: article.summary,
+          content: article.summary,
+          author: article.authors,
+        })
+      })
+    }
+
+    return Object.values(feedFormats).map((f) => ({
+      path: `${baseLinkFeedArticles}/${f.file}`,
+      type: f.type,
+      create: feedCreateArticles,
+    }))
+  },
+}
+```

--- a/docs/content/en/advanced.md
+++ b/docs/content/en/advanced.md
@@ -138,7 +138,6 @@ This documentation use it actually, you can learn more by looking at [plugins/ca
 In the case of articles, the content can be used to generate news feeds
 using [@nuxtjs/feed](https://github.com/nuxt-community/feed-module) module.
 
-
 <base-alert type="info">
 
 Note that in order to use `$content` inside the `feed` option, you need to add `@nuxt/content` before `@nuxtjs/feed` in the `modules` property.

--- a/docs/content/en/advanced.md
+++ b/docs/content/en/advanced.md
@@ -140,7 +140,7 @@ using [@nuxtjs/feed](https://github.com/nuxt-community/feed-module) module.
 
 <base-alert type="info">
 
-Note that in order to use `$content` inside the `feed` option, you need to add `@nuxt/content` before `@nuxtjs/feed` in the `modules` property.
+To use `$content` inside the `feed` option, you need to add `@nuxt/content` before `@nuxtjs/feed` in the `modules` property.
 
 </base-alert>
 

--- a/docs/content/en/advanced.md
+++ b/docs/content/en/advanced.md
@@ -133,26 +133,28 @@ export default {
 Now everytime you will update a file in your `content/` directory, it will also dispatch the `fetchCategories` method.
 This documentation use it actually, you can learn more by looking at [plugins/categories.js](https://github.com/nuxt/content/blob/master/docs/plugins/categories.js).
 
-## Integration with @nuxtjs/feed module
+## Integration with @nuxtjs/feed
 
 In the case of articles, the content can be used to generate news feeds
-using the Nuxt.js [feed-module](https://github.com/nuxt-community/feed-module).
+using [@nuxtjs/feed](https://github.com/nuxt-community/feed-module) module.
+
+
+<base-alert type="info">
+
+Note that in order to use `$content` inside the `feed` option, you need to add `@nuxt/content` before `@nuxtjs/feed` in the `modules` property.
+
+</base-alert>
 
 **Example**
 
 ```js
-const contentArticles = async () => {
-  const { $content } = require('@nuxt/content')
-  return await $content('articles').fetch()
-}
-
 export default {
-  modules: [,
+  modules: [
     '@nuxt/content',
-    '@nuxtjs/feed',
+    '@nuxtjs/feed'
   ],
 
-  feed: () => {
+  feed () {
     const baseUrlArticles = 'https://mywebsite.com/articles'
     const baseLinkFeedArticles = '/feed/articles'
     const feedFormats = {
@@ -160,15 +162,15 @@ export default {
       atom: { type: 'atom1', file: 'atom.xml' },
       json: { type: 'json1', file: 'feed.json' },
     }
+    const { $content } = require('@nuxt/content')
 
-    async function feedCreateArticles(feed) {
+    const createFeedArticles = async function (feed) {
       feed.options = {
         title: 'My Blog',
         description: 'I write about technology',
         link: baseUrlArticles,
       }
-
-      const articles = await contentArticles()
+      const articles = await $content('articles').fetch()
 
       articles.forEach((article) => {
         const url = `${baseUrlArticles}/${article.slug}`
@@ -185,11 +187,11 @@ export default {
       })
     }
 
-    return Object.values(feedFormats).map((f) => ({
-      path: `${baseLinkFeedArticles}/${f.file}`,
-      type: f.type,
+    return Object.values(feedFormats).map(({ file, type }) => ({
+      path: `${baseLinkFeedArticles}/${file}`,
+      type: type,
       create: feedCreateArticles,
     }))
-  },
+  }
 }
 ```


### PR DESCRIPTION
As discussed in issue #82 with @philipithomas and @Atinux, this PR adds an example of integration between `@nuxt/content` and the Nuxt.js feed-module `@nuxtjs/feed`.
