### PR TITLE
Fix mismatched function names in feed example code

### DIFF
--- a/docs/content/en/advanced.md
+++ b/docs/content/en/advanced.md
@@ -189,7 +189,7 @@ export default {
     return Object.values(feedFormats).map(({ file, type }) => ({
       path: `${baseLinkFeedArticles}/${file}`,
       type: type,
-      create: feedCreateArticles,
+      create: createFeedArticles,
     }))
   }
 }


### PR DESCRIPTION
The function on line 166 is supposed to be referenced on line 192. But, the function name doesn't match. This corrects the problem.