### PR TITLE
Content distribution via templates and slots

### DIFF
--- a/docs/content/en/writing.md
+++ b/docs/content/en/writing.md
@@ -288,7 +288,30 @@ These components will be rendered using the `<nuxt-content>` component, see [dis
 
 </base-alert>
 
-Also note that you **cannot use** `<template>` tags in your markdown (eg: when using with `v-slot`).
+#### Templates
+
+You can use `template` tags for content distribution inside your Vue.js components:
+
+```html
+<my-component>
+  <template #named-slot>
+    <p>Named slot content.</p>
+  </template>
+</my-component>
+```
+
+However, you cannot render
+[dynamic content](https://vuejs.org/v2/guide/syntax.html) nor use
+[slot props](https://vuejs.org/v2/guide/components-slots.html#Scoped-Slots). I.e.,
+**this wont work**:
+
+```html
+<my-component>
+  <template #named-slot="slotProps">
+    <p>{{ slotProps.someProperty }}</p>
+  </template>
+</my-component>
+```
 
 ### Table of contents
 

--- a/example/components/MovieInfo.vue
+++ b/example/components/MovieInfo.vue
@@ -1,10 +1,15 @@
 <template>
-  <span>Hello {{ name }}</span>
+  <section>
+    <strong>{{ name }}</strong>
+    <slot name="summary">
+      <p>No info available.</p>
+    </slot>
+  </section>
 </template>
 
 <script>
 export default {
-  name: 'Hello',
+  name: 'MovieInfo',
   props: {
     name: {
       type: String,

--- a/example/content/markdown.md
+++ b/example/content/markdown.md
@@ -9,7 +9,18 @@ description: This is a .md file
 
 ## Custom components
 
-<hello name="Custom Component"></hello>
+<movie-info name="Porco Rosso">
+  <template #summary>
+
+Porco Rosso (Japanese: 紅の豚, Hepburn: _Kurenai no Buta_, lit. _Crimson Pig_) is a
+1992 Japanese animated comedy-adventure film written and directed by
+[Hayao Miyazaki]. It is based on _Hikōtei Jidai_ ("The Age of the Flying Boat"), a
+three-part 1989 watercolor manga by Miyazaki.
+
+[Hayao Miyazaki]: https://en.wikipedia.org/wiki/Hayao_Miyazaki
+
+  </template>
+</movie-info>
 
 ## Links
 

--- a/example/plugins/components.js
+++ b/example/plugins/components.js
@@ -1,5 +1,5 @@
 import Vue from 'vue'
 
-import Hello from '~/components/hello'
+import MovieInfo from '~/components/MovieInfo'
 
-Vue.component(Hello.name, Hello)
+Vue.component(MovieInfo.name, MovieInfo)

--- a/lib/parsers/markdown/compilers/json.js
+++ b/lib/parsers/markdown/compilers/json.js
@@ -19,12 +19,21 @@ function parseAsJSON (node, parent) {
       delete node.properties.href
     }
 
-    parent.push({
+    const filtered = {
       type: 'element',
       tag: node.tagName,
       props: node.properties,
       children: childs
-    })
+    }
+
+    // Unwrap contents of the template, saving the root level inside content.
+    if (node.tagName === 'template') {
+      const templateContent = []
+      node.content.children.forEach(templateNode => parseAsJSON(templateNode, templateContent))
+      filtered.content = templateContent
+    }
+
+    parent.push(filtered)
 
     if (node.children) {
       node.children.forEach(child => parseAsJSON(child, childs))

--- a/lib/templates/nuxt-content.js
+++ b/lib/templates/nuxt-content.js
@@ -29,6 +29,29 @@ function propsToData (props, doc) {
   }, { attrs: {} })
 }
 
+/**
+ * Create the scoped slots from `node` template children. Templates for default
+ * slots are processed as regular children in `processNode`.
+ */
+function slotsToData (node, h, doc) {
+  const data = {}
+  const children = node.children || []
+
+  children.forEach(child => {
+    // Regular children and default templates are processed inside `processNode`.
+    if (!isTemplate(child) || isDefaultTemplate(child)) { return }
+
+    // Non-default templates are converted into slots.
+    data.scopedSlots = data.scopedSlots || {}
+    const template = child
+    const name = getSlotName(template)
+    const vDomTree = template.content.map(tmplNode => processNode(tmplNode, h, doc))
+    data.scopedSlots[name] = function () { return vDomTree }
+  })
+
+  return data
+}
+
 function processNode (node, h, doc) {
   /**
    * Return raw value as it is
@@ -37,7 +60,43 @@ function processNode (node, h, doc) {
     return node.value
   }
 
-  return h(node.tag, propsToData(node.props, doc), node.children.map((child) => processNode(child, h, doc)))
+  const slotData = slotsToData(node || {}, h, doc)
+  const propData = propsToData(node.props, doc)
+  const data = Object.assign({}, slotData, propData)
+
+  /**
+   * Process child nodes, flat-mapping templates pointing to default slots.
+   */
+  const children = []
+  for (const child of node.children) {
+    // Template nodes pointing to non-default slots are processed inside `slotsToData`.
+    if (isTemplate(child) && !isDefaultTemplate(child)) { continue }
+
+    const processQueue = isDefaultTemplate(child) ? child.content: [child]
+    children.push(...processQueue.map((node) => processNode(node, h, doc)))
+  }
+
+  return h(node.tag, data, children)
+}
+
+const DEFAULT_SLOT = 'default'
+
+function isDefaultTemplate (node) {
+  return isTemplate(node) && getSlotName(node) === DEFAULT_SLOT
+}
+
+function isTemplate (node) {
+  return node.tag === 'template'
+}
+
+function getSlotName (node) {
+  let name = ''
+  for (const propName of Object.keys(node.props)) {
+    if (!propName.startsWith('#') && !propName.startsWith('v-slot:')) { return }
+    name = propName.split(/[:#]/, 2)[1]
+    break
+  }
+  return name || DEFAULT_SLOT
 }
 
 export default {

--- a/test/component.test.js
+++ b/test/component.test.js
@@ -7,7 +7,6 @@ describe('component', () => {
   beforeAll(async () => {
     ({ nuxt } = (await setup(loadConfig(__dirname))))
     browser = await createBrowser('puppeteer')
-    page = await browser.page(url('/'))
   }, 60000)
 
   afterAll(async () => {
@@ -16,8 +15,18 @@ describe('component', () => {
   })
 
   test('nuxt-content has generated html', async () => {
+    page = await browser.page(url('/home'))
     const html = await page.getHtml()
 
     expect(html).toContain('<h1>Home</h1> <div class="nuxt-content"><p>This is the home page!</p></div>')
+  })
+
+  test('nuxt-content has rendered a Vue.js component', async () => {
+    page = await browser.page(url('/vue-component'))
+    const html = await page.getHtml()
+
+    expect(html).toMatch(
+      new RegExp(/<div>\s*<h1><\/h1>\s*<div class="nuxt-content">\s*<div>\s*<header>Header content<\/header>\s*<main>\s*Main content\s*<\/main>\s*<footer>Footer content<\/footer><\/div><\/div><\/div>/)
+    )
   })
 })

--- a/test/fixture/components/AppLayout.vue
+++ b/test/fixture/components/AppLayout.vue
@@ -1,0 +1,11 @@
+<template>
+  <div>
+    <header><slot name="header" /></header>
+    <main><slot>Default content</slot></main>
+    <footer><slot name="footer" /></footer>
+  </div>
+</template>
+
+<script>
+export default { name: 'AppLayout' }
+</script>

--- a/test/fixture/content/vue-component.md
+++ b/test/fixture/content/vue-component.md
@@ -1,0 +1,5 @@
+<app-layout>
+  <template #header>Header content</template>
+  Main content
+  <template #footer>Footer content</template>
+</app-layout>

--- a/test/fixture/pages/_slug.vue
+++ b/test/fixture/pages/_slug.vue
@@ -1,0 +1,23 @@
+<template>
+  <div>
+    <h1>{{ page.title }}</h1>
+    <nuxt-content :document="page" />
+  </div>
+</template>
+
+<script>
+import AppLayout from '../components/AppLayout'
+
+export default {
+  components: {
+    AppLayout // eslint-disable-line vue/no-unused-components
+  },
+  async asyncData ({ $content, params }) {
+    const page = await $content(params.slug || 'home').fetch()
+
+    return {
+      page
+    }
+  }
+}
+</script>


### PR DESCRIPTION
Fix #48

This PR modifies the JSON serializer to include the `content` AST from `template` tags and use it to create the [`scopedSlots` property](https://vuejs.org/v2/guide/render-function.html#createElement-Arguments) for the `createElement` function. Due to parser limitations, the content cannot use templating nor [slot props](https://vuejs.org/v2/guide/components-slots.html#Scoped-Slots).

This PR also updates the documentation and example to illustrate this feature.

I'm still working on the tests.