### PR TITLE
feat: add .yml support for YAML

### DIFF
--- a/example/content/yml.yml
+++ b/example/content/yml.yml
@@ -1,0 +1,2 @@
+title: Yml
+description: This is a .yml file

--- a/example/pages/index.vue
+++ b/example/pages/index.vue
@@ -14,6 +14,8 @@
     <pre>{{ csv }}</pre>
     <h2>YAML</h2>
     <pre>{{ yaml }}</pre>
+    <h2>YML</h2>
+    <pre>{{ yml }}</pre>
   </div>
 </template>
 
@@ -26,13 +28,15 @@ export default {
     const json5 = await $content('json5').fetch()
     const csv = await $content('csv').fetch()
     const yaml = await $content('yaml').fetch()
+    const yml = await $content('yml').fetch()
 
     return {
       markdown,
       json,
       json5,
       csv,
-      yaml
+      yaml,
+      yml
     }
   }
 }

--- a/lib/database.js
+++ b/lib/database.js
@@ -12,7 +12,7 @@ const Markdown = require('./parsers/markdown')
 const Yaml = require('./parsers/yaml')
 const Csv = require('./parsers/csv')
 const QueryBuilder = require('./query-builder')
-const EXTENSIONS = ['.md', '.json', '.json5', '.yaml', '.csv']
+const EXTENSIONS = ['.md', '.json', '.json5', '.yaml', '.yml', '.csv']
 
 LokiFullTextSearch.register()
 
@@ -173,7 +173,8 @@ class Database extends Hookable {
       '.json5': file => JSON5.parse(file),
       '.md': file => this.markdown.toJSON(file),
       '.csv': file => this.csv.toJSON(file),
-      '.yaml': file => this.yaml.toJSON(file)
+      '.yaml': file => this.yaml.toJSON(file),
+      '.yml': file => this.yaml.toJSON(file)
     })[extension]
     // Collect data from file
     let data = {}

--- a/test/fixture/content/formats/yml.yml
+++ b/test/fixture/content/formats/yml.yml
@@ -1,0 +1,2 @@
+title: Yml
+description: This is a .yml file


### PR DESCRIPTION
The `.yml` extension for YAML is pretty popular from what I've seen. Perhaps it's partially because it's pretty often used in DevOps tools? 

Tried to search around for a consensus regarding this, but seems like there are avid supporters on both sides. The [YAML official site](https://yaml.org/faq.html) does mention to use `.yaml` when possible as pointed out when I was googling about it, but FWIW [Jekyll Data Files](https://jekyllrb.com/docs/datafiles/) that does similar thing with nuxt/content also supports both `.yml` and `.yaml` extensions so I figured no harm in adding this. 

Tested this in the example project as seen in the commit and it works.