### PR TITLE
fix: Properly handle anchor tags without href fields

### DIFF
--- a/lib/parsers/markdown/compilers/json.js
+++ b/lib/parsers/markdown/compilers/json.js
@@ -13,7 +13,7 @@ function parseAsJSON (node, parent) {
     /**
      * Replace a tag with nuxt-link if relative
      */
-    if (node.tagName === 'a' && node.properties.href.startsWith('/')) {
+    if (node.tagName === 'a' && (node.properties.href || '').startsWith('/')) {
       node.tagName = 'nuxt-link'
       node.properties.to = node.properties.href
       delete node.properties.href


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->
This pull request updates the nuxt-content JSON parser to properly handle anchor tags which are missing an `href` attribute. Here is an example of a Markdown file which triggers the issue:
```markdown
---
title: Repro
---
<a name="foo"></a>Hello, world
```
The problem is that [this line](https://github.com/nuxt/content/blob/c5a11fc166fdec2d5cd4cbcc6880917ff861c047/lib/parsers/markdown/compilers/json.js#L16) crashes, since there is no `href` attribute. This pull request changes the behavior to gracefully handle situations like this.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)

I did not add any tests, since I felt this was a very minor change. If a test is desired, I can add one.