### PR TITLE
Allow override for createdAt and updatedAt properties

### DIFF
--- a/docs/content/en/writing.md
+++ b/docs/content/en/writing.md
@@ -28,6 +28,8 @@ This module will parse `.md`, `.yaml`, `.yml`, `.csv`, `.json`, `.json5`, `.xml`
 - `createdAt`
 - `updatedAt`
 
+The `createdAt` and `updatedAt` properties are based on the file's actual created & updated datetime, but you can override them by defining your own `createdAt` and `updatedAt` values. This is especially useful if you are migrating your past blog posts where the `createdAt` can be months or years ago.
+
 ## Markdown
 
 This module converts your `.md` files into a JSON AST tree structure, stored in a `body` variable.

--- a/lib/database.js
+++ b/lib/database.js
@@ -193,14 +193,22 @@ class Database extends Hookable {
     const split = normalizedPath.split('/')
     const dir = split.slice(0, split.length - 1).join('/')
 
+    // Overrides createdAt & updatedAt if it exists in the document
+    const existingCreatedAt = data.createdAt && new Date(data.createdAt)
+    const existingUpdatedAt = data.updatedAt && new Date(data.updatedAt)
+    // validate the existing dates to avoid wrong date format or typo
+    const isValidDate = (date) => {
+      return date instanceof Date && !isNaN(date)
+    }
+
     return {
       ...data,
       dir: dir || '/',
       path: normalizedPath,
       extension,
       slug: split[split.length - 1],
-      createdAt: stats.birthtime,
-      updatedAt: stats.mtime
+      createdAt: isValidDate(existingCreatedAt) ? existingCreatedAt : stats.birthtime,
+      updatedAt: isValidDate(existingUpdatedAt) ? existingUpdatedAt : stats.mtime
     }
   }
 


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->
Resolves: #252 

This stems from the linked issue, but I did also thought about this a while ago when considering to retain the datetime if I'm migrating the posts to nuxt/content. 

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)

I have mentioned that the `createdAt` and `updatedAt` properties can be overrided in the docs [over here](https://github.com/nuxt/content/pull/254/commits/cbc006807d7f88f7b438d5f14f91e2b65d17b62f#diff-f520622309ad3e5bd5578a5b42164b37R31).

I'm not particular sure how we can add tests for this since the original createdAt & updatedAt of the files can be different if I make a new fork of the repo. With that said, I did do some tests myself and here are the test results:

|value in content/document|generated value when fetching|
|---|---|
|2019-02-10|2019-02-10T00:00:00.000Z|
|20x19-02-10|Falls back to original creation datetime|
|2019-02-10 10:00|2019-02-10T02:00:00.000Z|
|2019-02-10 10:00 PM|2019-02-10T14:00:00.000Z|
|Feb 2019|2019-01-31T16:00:00.000Z|
|2 2019|Falls back to original creation datetime|

Note that my timezone is UTC +8, so there's 8 hours offset for the results with time.