### PR TITLE
fix: order of query execution

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -55,6 +55,29 @@ module.exports = ({ ws, database, dir, watch }) => async (req, res) => {
 
   // Build query from query / body
   let query = database.query(url, { deep: params.deep, text: params.text })
+  if (params.where) {
+    const where = {}
+
+    for (const [key, value] of Object.entries(params.where)) {
+      const [field, operator] = key.split('_')
+
+      if (operator) {
+        where[field] = {
+          [`$${operator}`]: value
+        }
+      } else {
+        where[field] = value
+      }
+    }
+    query = query.where(where)
+  }
+  if (params.search) {
+    if (typeof params.search === 'object') {
+      query = query.search(params.search.query, params.search.value)
+    } else {
+      query = query.search(params.search)
+    }
+  }
   if (params.sortBy) {
     if (typeof params.sortBy === 'object') {
       if (Array.isArray(params.sortBy)) {
@@ -78,40 +101,17 @@ module.exports = ({ ws, database, dir, watch }) => async (req, res) => {
       query = query.sortBy(key, value)
     }
   }
-  if (params.skip) {
-    query = query.skip(params.skip)
-  }
-  if (params.limit) {
-    query = query.limit(params.limit)
-  }
   if (params.only) {
     query = query.only(params.only)
   }
   if (params.without) {
     query = query.without(params.without)
   }
-  if (params.where) {
-    const where = {}
-
-    for (const [key, value] of Object.entries(params.where)) {
-      const [field, operator] = key.split('_')
-
-      if (operator) {
-        where[field] = {
-          [`$${operator}`]: value
-        }
-      } else {
-        where[field] = value
-      }
-    }
-    query = query.where(where)
+  if (params.skip) {
+    query = query.skip(params.skip)
   }
-  if (params.search) {
-    if (typeof params.search === 'object') {
-      query = query.search(params.search.query, params.search.value)
-    } else {
-      query = query.search(params.search)
-    }
+  if (params.limit) {
+    query = query.limit(params.limit)
   }
   if (params.surround) {
     query = query.surround(params.surround.slug, params.surround.options)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->
Within #95 we recognized some odd behavior for the search results in the provided example.
In this issue, a possible solution was provided - it seemed like the order the in which the query is executed had some unpredicted impact on the results.
With this fix, the provided example works as expected.
The examples within this module work as expected too.

Feedback is very welcome.
If you're using advanced queries with this module, double-checking if this fix causes issues would be awesome!


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
