### PR TITLE
fix: ensure `path` and `extension` on dev mode

### DIFF
--- a/lib/query-builder.js
+++ b/lib/query-builder.js
@@ -207,6 +207,10 @@ class QueryBuilder {
     let data = this.query.data({ removeMeta: true })
     // Handle only keys
     if (this.onlyKeys) {
+      // Add `path` and `extension` to onlyKeys if watch to ensure live edit
+      if (this.options.watch) {
+        this.onlyKeys.push('path', 'extension')
+      }
       // Map data and returns object picked by keys
       const fn = data => data.map(item => pick(item, this.onlyKeys))
       // Apply pick during postprocess
@@ -214,6 +218,10 @@ class QueryBuilder {
     }
     // Handle without keys
     if (this.withoutKeys) {
+      // Remove `path` and `extension` from withoutKeys if watch to ensure live edit
+      if (this.options.watch) {
+        this.withoutKeys = this.withoutKeys.filter(key => !['path', 'extension'].includes(key))
+      }
       // Map data and returns object picked by keys
       const fn = data => data.map(item => omit(item, this.withoutKeys))
       // Apply pick during postprocess


### PR DESCRIPTION
Ensure `path` and `extension` keys on dev mode when using `.only()` and `.without()` methods.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)