### PR TITLE
fix: prevent options merging fn exec without default value

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -36,7 +36,7 @@ const mergeConfig = (content, defaults, options = {}) => {
     if (value && typeof value !== 'function' && Array.isArray(defaultValue)) {
       // Merge value with default value if array
       value = defaultValue.concat(value)
-    } else if (typeof value === 'function') {
+    } else if (typeof value === 'function' && defaultValue) {
       // Executed value functions and provide default value as param
       value = value(defaultValue)
     } else if (typeof value === 'object') {

--- a/test/options.test.js
+++ b/test/options.test.js
@@ -147,7 +147,7 @@ describe('options', () => {
     const config = {
       content: {
         extendParser: {
-          '.txt': file => body => ({ body })
+          '.txt': file => ({ body: file })
         }
       }
     }


### PR DESCRIPTION
Functions in configuration are meant to allow merging default values. Now, functions are only executed if the value already exists in the configuration.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->

When using `extendParser` with a function `'.txt': (file) => ({ body: file })`, the function was executed.


