### PR TITLE
fix(ignore): comply with possible custom dir

### DIFF
--- a/packages/content/lib/index.js
+++ b/packages/content/lib/index.js
@@ -41,6 +41,7 @@ module.exports = async function (moduleOptions) {
 
   const mergedConfig = mergeConfig(content, defaults)
   const options = defu(mergedConfig, defaults)
+  const relativeDir = options.dir
   options.dir = resolve(this.options.srcDir, options.dir)
 
   // Load markdown plugins
@@ -64,7 +65,7 @@ module.exports = async function (moduleOptions) {
       global: true
     })
   })
-  this.nuxt.hook('generate:cache:ignore', ignore => ignore.push('content'))
+  this.nuxt.hook('generate:cache:ignore', ignore => ignore.push(relativeDir))
 
   const ws = new WS({
     apiPrefix: options.apiPrefixWithBase


### PR DESCRIPTION
Instead of always ignoring the `content` dir for `nuxt generate`, the module should take config changes into account as well.

## Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
