### PR TITLE
fix(theme-docs): use twitter and github accounts from settings in default layout

### DIFF
--- a/packages/theme-docs/src/layouts/default.vue
+++ b/packages/theme-docs/src/layouts/default.vue
@@ -41,7 +41,8 @@
                 <ul class="flex items-center ml-2">
                   <li class="flex items-center mr-4">
                     <a
-                      href="https://twitter.com/nuxt_js"
+                      v-if="settings.twitter"
+                      :href="`https://twitter.com/${settings.twitter}`"
                       target="_blank"
                       rel="noopener noreferrer"
                       title="Twitter"
@@ -53,7 +54,8 @@
                   </li>
                   <li class="flex items-center mr-4">
                     <a
-                      href="https://github.com/nuxt/content"
+                      v-if="settings.github"
+                      :href="`https://github.com/${settings.github}`"
                       target="_blank"
                       rel="noopener noreferrer"
                       title="Github"


### PR DESCRIPTION
## Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
The `nuxt/content` Twitter and GitHub account were hard coded. This PR fixes that issue.

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
