### PR TITLE
fix(theme-docs): remove duplicate tailwind classes

### DIFF
--- a/packages/theme-docs/src/components/global/app/AppHeader.vue
+++ b/packages/theme-docs/src/components/global/app/AppHeader.vue
@@ -33,7 +33,7 @@
           <NuxtLink
             v-if="lastRelease"
             to="/releases"
-            class="font-semibold leading-none text-gray-700 dark:text-gray-300 hover:text-primary-500 dark-hover:text-primary-500 font-medium text-base mr-4"
+            class="font-semibold leading-none text-gray-700 dark:text-gray-300 hover:text-primary-500 dark-hover:text-primary-500 text-base mr-4"
             exact-active-class="text-primary-500"
           >{{ lastRelease.name }}</NuxtLink>
           <div class="flex items-center">

--- a/packages/theme-docs/src/components/global/app/AppLangSwitcher.vue
+++ b/packages/theme-docs/src/components/global/app/AppLangSwitcher.vue
@@ -2,7 +2,7 @@
   <AppDropdown v-if="availableLocales.length" class="inline-flex">
     <template #trigger="{ open, toggle }">
       <button
-        class="rounded-md hover:text-primary-500 focus:outline-none focus:outline-none"
+        class="rounded-md hover:text-primary-500 focus:outline-none"
         :class="{ 'text-primary-500': open }"
         @touchstart.stop.prevent="toggle"
       >

--- a/packages/theme-docs/src/layouts/default.vue
+++ b/packages/theme-docs/src/layouts/default.vue
@@ -20,7 +20,7 @@
                   <li v-for="doc of docs" :key="doc.slug" class="text-gray-700 dark:text-gray-300">
                     <NuxtLink
                       :to="toLink(doc.slug)"
-                      class="px-2 rounded font-medium py-1 block hover:text-primary-500 flex items-center justify-between"
+                      class="px-2 rounded font-medium py-1 hover:text-primary-500 flex items-center justify-between"
                       exact-active-class="text-primary-500 bg-primary-100 hover:text-primary-500 dark:bg-primary-900"
                     >
                       {{ doc.title }}


### PR DESCRIPTION
## Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
Some Tailwind classes are present targeting same selectors. I've made a best-guess as to which you wanted to be in effect (based around which styles were overriding my browser). Please feel free to correct!

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
