### PR TITLE
feat(theme-docs): support `release-it` default release syntax

### DIFF
--- a/packages/theme-docs/src/store/index.js
+++ b/packages/theme-docs/src/store/index.js
@@ -67,7 +67,7 @@ export const actions = {
       }).then(res => res.json())
       releases = data.filter(r => !r.draft).map((release) => {
         return {
-          name: release.name || release.tag_name,
+          name: (release.name || release.tag_name).replace('Release ', ''),
           date: release.published_at,
           body: this.$markdown(release.body)
         }


### PR DESCRIPTION
## Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)


## Description
Where a GitHub release name or tag includes the phrase `Release ` this will be removed. This shortens the rendering of the release in the header and on the releases page. Although a breaking change I can't imagine that this would be undesirable behaviour, but I'm happy to do some additional checking if it's felt that would be better.

Note that there is still the issue of some duplicated content:
![Screenshot from 2020-08-01 11-47-30](https://user-images.githubusercontent.com/28706372/89100151-c3dcee00-d3ec-11ea-8734-e8c0a14e502a.png)

It would be possible to address the issue of duplicated content and/or only adjust the release name if a `release-it` project is detected, if desired.

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
