### PR TITLE
feat(theme-docs): allow customising default branch

### DIFF
--- a/docs/content/en/themes-docs.md
+++ b/docs/content/en/themes-docs.md
@@ -212,7 +212,7 @@ You can create a `content/settings.json` file to configure the theme:
   - *The GitHub repository of your project `${org}/${name}` to display the last version, the releases page, the link at the top and the `Edit this page on GitHub link` on each page*
 - `defaultBranch`
   - Type: `String`
-  - *The default branch for the GitHub repository of your project, used in the `Edit this page on GitHub link` on each page.*
+  - *The default branch for the GitHub repository of your project, used in the `Edit this page on GitHub link` on each page (defaults to `main` if it cannot be detected).*
 - `twitter`
   - Type: `String`
   - *The Twitter username you want to link*

--- a/docs/content/en/themes-docs.md
+++ b/docs/content/en/themes-docs.md
@@ -210,6 +210,9 @@ You can create a `content/settings.json` file to configure the theme:
 - `github`
   - Type: `String`
   - *The GitHub repository of your project `${org}/${name}` to display the last version, the releases page, the link at the top and the `Edit this page on GitHub link` on each page*
+- `defaultBranch`
+  - Type: `String`
+  - *The default branch for the GitHub repository of your project, used in the `Edit this page on GitHub link` on each page.*
 - `twitter`
   - Type: `String`
   - *The Twitter username you want to link*

--- a/packages/theme-docs/src/components/global/app/AppGithubLink.vue
+++ b/packages/theme-docs/src/components/global/app/AppGithubLink.vue
@@ -32,7 +32,7 @@ export default {
         return
       }
 
-      return `https://github.com/${this.settings.github}/edit/dev/docs/content${this.document.path}${this.document.extension}`
+      return `https://github.com/${this.settings.github}/edit/${this.settings.defaultBranch}/docs/content${this.document.path}${this.document.extension}`
     }
   }
 }

--- a/packages/theme-docs/src/plugins/init.js
+++ b/packages/theme-docs/src/plugins/init.js
@@ -3,6 +3,7 @@ export default async function ({ store, app }) {
     await store.dispatch('fetchSettings')
     await store.dispatch('fetchCategories')
     await store.dispatch('fetchReleases')
+    await store.dispatch('fetchDefaultBranch')
   }
   // Spa Fallback
   if (process.client && !store.state.settings) {
@@ -14,12 +15,16 @@ export default async function ({ store, app }) {
   if (process.client && !store.state.releases.length) {
     await store.dispatch('fetchReleases')
   }
+  if (process.client && !store.state.settings.defaultBranch) {
+    await store.dispatch('fetchDefaultBranch')
+  }
   // Hot reload on development
   if (process.client && process.dev) {
     window.onNuxtReady(() => {
       window.$nuxt.$on('content:update', async () => {
         await store.dispatch('fetchSettings')
         await store.dispatch('fetchReleases')
+        await store.dispatch('fetchDefaultBranch')
         await store.dispatch('fetchCategories')
       })
     })

--- a/packages/theme-docs/src/store/index.js
+++ b/packages/theme-docs/src/store/index.js
@@ -110,7 +110,7 @@ export const actions = {
       defaultBranch = data.default_branch
     } catch (e) {}
 
-    commit('SET_DEFAULT_BRANCH', defaultBranch || 'dev')
+    commit('SET_DEFAULT_BRANCH', defaultBranch || 'main')
   },
   async fetchSettings ({ commit }) {
     try {

--- a/packages/theme-docs/src/store/index.js
+++ b/packages/theme-docs/src/store/index.js
@@ -5,7 +5,8 @@ export const state = () => ({
   categories: {},
   releases: [],
   settings: {
-    title: 'Nuxt Content Docs'
+    title: 'Nuxt Content Docs',
+    defaultBranch: ''
   }
 })
 
@@ -28,6 +29,9 @@ export const mutations = {
   },
   SET_RELEASES (state, releases) {
     state.releases = releases
+  },
+  SET_DEFAULT_BRANCH (state, branch) {
+    state.settings.defaultBranch = branch
   },
   SET_SETTINGS (state, settings) {
     state.settings = Object.assign({}, settings)
@@ -85,6 +89,28 @@ export const actions = {
     })
 
     commit('SET_RELEASES', releases)
+  },
+  async fetchDefaultBranch ({ commit, state }) {
+    if (!state.settings.github || state.settings.defaultBranch) {
+      return
+    }
+
+    const options = {}
+    if (process.env.GITHUB_TOKEN) {
+      options.headers = { Authorization: `token ${process.env.GITHUB_TOKEN}` }
+    }
+    let defaultBranch
+    try {
+      const data = await fetch(`https://api.github.com/repos/${state.settings.github}`, options).then((res) => {
+        if (!res.ok) {
+          throw new Error(res.statusText)
+        }
+        return res
+      }).then(res => res.json())
+      defaultBranch = data.default_branch
+    } catch (e) {}
+
+    commit('SET_DEFAULT_BRANCH', defaultBranch || 'dev')
   },
   async fetchSettings ({ commit }) {
     try {


### PR DESCRIPTION
## Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)


## Description
Not everyone will be preparing PRs against `dev`. It may be directly against `main` or against another branch. This PR allows customising this in settings (or automatically fetching the branch from GitHub). It defaults to `dev`, although this will be a breaking change in the (unlikely) case that users *prefer* a diff against `dev` even though they actually have a different default branch.

## Checklist:
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
