### PR TITLE
feat(theme-docs): add default `generate` property in config

### DIFF
--- a/docs/nuxt.config.js
+++ b/docs/nuxt.config.js
@@ -5,10 +5,6 @@ export default theme({
     GITHUB_TOKEN: process.env.GITHUB_TOKEN
   },
   loading: { color: '#00CD81' },
-  generate: {
-    fallback: '404.html', // for Netlify
-    routes: ['/'] // give the first url to start crawling
-  },
   i18n: {
     locales: () => [{
       code: 'ru',

--- a/packages/theme-docs/src/index.js
+++ b/packages/theme-docs/src/index.js
@@ -13,6 +13,10 @@ const defaultConfig = {
       { name: 'viewport', content: 'width=device-width, initial-scale=1' }
     ]
   },
+  generate: {
+    fallback: '404.html',
+    routes: ['/']
+  },
   transpile: [
     __dirname // transpile node_modules/@nuxt/content-theme-docs
   ],


### PR DESCRIPTION
The `generate` property with default routes to `['/']` and fallback needs to be defined almost everytime for documentation, so we moved it to the theme by default.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)