### PR TITLE
fix(content): use `property-information` to convert hast attributes

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "lint": "eslint --ext .js,.vue .",
     "release": "yarn test && lerna publish",
     "test": "yarn lint && yarn test:packages",
+    "test:watch": "jest packages --watch",
     "test:packages": "jest packages -i",
-    "test:packages:watch": "jest packages --watch",
     "test:packages:content": "jest packages/content -i",
     "test:packages:create-nuxt-content-docs": "jest packages/create-nuxt-content-docs"
   },

--- a/packages/content/test/component.test.js
+++ b/packages/content/test/component.test.js
@@ -45,6 +45,15 @@ describe('component', () => {
         new RegExp(/<div>\s*<h1><\/h1>\s*<div class="nuxt-content">\s*<div>\s*<header>Header content<\/header>\s*<main>\s*Main content\s*<\/main>\s*<footer>Footer content<\/footer><\/div><\/div><\/div>/)
       )
     })
+
+    test('has rendered html props correctly', async () => {
+      page = await browser.page(url('/html'))
+      const html = await page.getHtml()
+
+      expect(html).toMatch(
+        new RegExp(/<div>\s*<h1><\/h1>\s*<div class="nuxt-content">\s*<h2 id="header">\s*<a aria-hidden="true" href="#header" tabindex="-1">\s*<span class="icon icon-link">\s*<\/span>\s*<\/a>Header<\/h2>\s*<p>\s*<video autoplay="autoplay" loop="loop" playsinline="true" controls="controls"><\/video><\/p>\s*<\/div><\/div>/)
+      )
+    })
   })
 
   describe('in dev mode', () => {

--- a/packages/content/test/fixture/content/html.md
+++ b/packages/content/test/fixture/content/html.md
@@ -1,0 +1,3 @@
+## Header
+
+<video autoplay loop playsinline controls></video>


### PR DESCRIPTION
Fix props rendering in `nuxt-content` component.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

The issue is in the `nuxt-content` component when rendering the AST tree with Vue.js, specific prop needed to stay in camelCase when others needed to be transformed back to kebab-case.

To fix #139, we forced `camelCase` props to kebab-case to ensure `ariaHidden` was rendered as `aria-hidden`. But then with #309, `<video autoplay ...>` was transformed to `{ autoPlay: true }` in the tree (HAST spec, see also [property-information code](https://github.com/wooorm/property-information/blob/main/lib/html.js#L41)) and then rendered to `auto-play` because of the module forcing kebab-case.

To transform markdown to AST, we use `remark` and `rehype`, to handle embedded HTML we use [rehype-raw](https://github.com/rehypejs/rehype-raw) which under the hood use [property-information](https://github.com/wooorm/property-information) that allows to convert HAST properties.

This PR takes advantage of the `property-information` package to render props as their original html name. It adds 30kb inside the client package but I feel like we don't have a choice here.

<img width="1030" alt="Screenshot 2020-08-06 at 12 24 52" src="https://user-images.githubusercontent.com/739984/89522075-e56d1980-d7e0-11ea-8236-5b65d5155a1d.png">
