### PR TITLE
docs: add automatic meta generation snippet

### DIFF
--- a/docs/content/en/snippets.md
+++ b/docs/content/en/snippets.md
@@ -23,6 +23,34 @@ export default {
 }
 ```
 
+### meta
+
+Add automatic meta generation based on title and description defined in [Front matter](https://content.nuxtjs.org/writing#front-matter). 
+
+```js
+export default {
+  async asyncData({ $content, params }) {
+    const article = await $content('articles', params.slug).fetch()
+
+    return {
+      article
+    }
+  },
+  head() {
+    return {
+      title: this.article.title,
+      meta: [
+        {
+          hid: 'description',
+          name: 'description',
+          content: this.article.description,
+        },
+      ],
+    }
+  },
+}
+```
+
 ## Features
 
 ### Search


### PR DESCRIPTION
Added automatic meta generation snippet

<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->
It helps quicker do the meta description without searching for it. Probably everyone had to do it so it is nice to have this snippet in the docs.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
