### PR TITLE
docs: fix dynamic routing snipet

### DIFF
--- a/docs/content/en/snippets.md
+++ b/docs/content/en/snippets.md
@@ -178,18 +178,16 @@ Let's say you want to create an app with routes following the `content/` file st
 ```vue[pages/_.vue]
 <script>
 export default {
-  async asyncData ({ $content, app, params, error }) {
-    let article
-    try {
-      [article] = await $content({ deep: true }).where({ path: `/${params.pathMatch || 'index'}` }).fetch()
-    } catch (e) {
-      return error({ statusCode: 404, message: 'Page not found' })
-    }
+  async asyncData ({ $content, params, error }) {
+    const slug = params.pathMatch || 'index'
+    const page = await $content(slug).fetch()
+      .then(res => Array.isArray(res) ? res.find(({ slug }) => slug === 'index') : res)
+      .catch(e => error({ statusCode: 404, message: 'Page not found' }))
 
     return {
-      article
+      page
     }
-  }
+  },
 }
 </script>
 ```


### PR DESCRIPTION
Hi,
I'm currently making a site where the routing is guided by the content files.

I made a way to achieve that, before seeing your snipet in the doc.

Howevere, I've tried to replace my piece of code by yours, but It didn't work.

The non working expected behaviour is that when you hit a folder, it should show the index file in this folder. For now, the page is just `undefined`.

Actually I don't know the difference between `$content('foo')` and `$contact().where({path: foo})`, and why we would need the `deep: true` option here, so maybe my way is not the best one to do that, but.. it works!

Thougths ?

(Ping @benjamincanac as you're the one who wrote that)

Thanks for your work!


