### PR TITLE
fix(theme-docs): appLangSwitcher wrap every Chinese characters

### DIFF
--- a/packages/theme-docs/src/components/global/app/AppLangSwitcher.vue
+++ b/packages/theme-docs/src/components/global/app/AppLangSwitcher.vue
@@ -15,7 +15,7 @@
         <nuxt-link
           v-if="$i18n.locale !== locale.code"
           :to="switchLocalePath(locale.code)"
-          class="flex px-4 items-center hover:text-primary-500 leading-7"
+          class="flex px-4 items-center hover:text-primary-500 leading-7 whitespace-no-wrap"
         >{{ locale.name }}</nuxt-link>
       </li>
     </ul>


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->
appLangSwitcher wrap every Chinese characters in availableLocales only one Chinese option

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
