### PR TITLE
docs: add missing deep in routes generation

### DIFF
--- a/docs/content/en/advanced.md
+++ b/docs/content/en/advanced.md
@@ -50,7 +50,7 @@ export default {
   generate: {
     async routes () {
       const { $content } = require('@nuxt/content')
-      const files = await $content().only(['path']).fetch()
+      const files = await $content({ deep: true }).only(['path']).fetch()
 
       return files.map(file => file.path === '/index' ? '/' : file.path)
     }


### PR DESCRIPTION
Hi,
Only root routes was generated, now all of them are.

Thanks.
Mathieu