### PR TITLE
Can't reassign obj on line 17 for v-bind key

### DIFF
--- a/packages/content/templates/nuxt-content.js
+++ b/packages/content/templates/nuxt-content.js
@@ -5,7 +5,7 @@ const rootKeys = ['class-name', 'class', 'style']
 function propsToData (props, doc) {
   return Object.keys(props).reduce(function (data, key) {
     const k = key.replace(/.*:/, '')
-    const obj = rootKeys.includes(k) ? data : data.attrs
+    let obj = rootKeys.includes(k) ? data : data.attrs
     const value = props[key]
     const { attribute } = info.find(info.html, key)
 


### PR DESCRIPTION
## Types of changes
bug fix

## Description
I would like to use a v-bind to bind an object to a vue component but the obj constant here is preventing the v-bind key from being used.

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
