### PR TITLE
docs(theme): fix alert type values

### DIFF
--- a/docs/content/en/themes/docs.md
+++ b/docs/content/en/themes/docs.md
@@ -413,7 +413,7 @@ The theme comes with some default Vue.js components you can use directly in your
 - `type`
   - Type: `String`
   - Default: `'info'`
-  - Values: `['info', 'success', 'warning', 'error']`
+  - Values: `['info', 'success', 'warning', 'danger']`
 
 **Example**
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->
`<alert>` component don't have `error` type, but `danger` instead :
https://github.com/nuxt/content/blob/dev/packages/theme-docs/src/components/global/base/Alert.vue#L17


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
