### PR TITLE
fix(types): fix typing error

### DIFF
--- a/packages/content/types/index.d.ts
+++ b/packages/content/types/index.d.ts
@@ -1,9 +1,9 @@
 import '@nuxt/types'
 import './vuex'
 
-import { DumpOptions as yamlOptions } from "js-yaml";
+import { DumpOptions as yamlOptions } from 'js-yaml'
 import { OptionsV2 as xmlOptions } from 'xml2js'
-import { CSVParseParam as csvOptions } from "node-csvtojson/v2/Parameters";
+import { CSVParseParam as csvOptions } from 'csvtojson/v2/Parameters'
 
 interface NuxtContentInstance {
   only(keys: string | string[]): NuxtContentInstance
@@ -38,7 +38,7 @@ declare module '@nuxt/types' {
   }
 
   interface Configuration {
-    content: {
+    content?: {
       watch?: boolean,
       liveEdit?: boolean,
       apiPrefix?: string,


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
Since PR #327 was merged, `tsc` throws the following error:
```
node_modules/@nuxt/content/types/index.d.ts:6:45 - error TS2307: Cannot find module 'node-csvtojson/v2/Parameters' or its corresponding type declarations.

6 import { CSVParseParam as csvOptions } from "node-csvtojson/v2/Parameters";
                                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Found 1 error.
```
Probably `node-csvtojson` is a typo of `csvtojson`.

And, PR #327 forces you to add an empty `content` property in configuration file.

This PR fixes module name typo, and set `content` property as optional.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)

No need tests because this PR only changes typing.