### PR TITLE
fix(theme-docs): remove useless alert styles

### DIFF
--- a/packages/theme-docs/src/components/global/base/Alert.vue
+++ b/packages/theme-docs/src/components/global/base/Alert.vue
@@ -69,7 +69,7 @@ export default {
   @apply bg-blue-900 border-blue-700;
 }
 .dark-mode .alert-info .alert-content {
-  @apply text-blue-300 bg-blue-900 border-blue-700;
+  @apply text-blue-300;
 }
 .dark-mode .alert-info .alert-content code {
   @apply bg-blue-800 !important;
@@ -93,7 +93,7 @@ export default {
   @apply bg-green-900 border-green-700;
 }
 .dark-mode .alert-success .alert-content {
-  @apply text-green-300 bg-green-900 border-green-700;
+  @apply text-green-300;
 }
 .dark-mode .alert-success .alert-content code {
   @apply bg-green-800 !important;
@@ -117,7 +117,7 @@ export default {
   @apply bg-yellow-900 border-yellow-700;
 }
 .dark-mode .alert-warning .alert-content {
-  @apply text-orange-300 bg-yellow-900 border-yellow-700;
+  @apply text-orange-300;
 }
 .dark-mode .alert-warning .alert-content code {
   @apply bg-yellow-800 !important;
@@ -141,7 +141,7 @@ export default {
   @apply bg-red-900 border-red-700;
 }
 .dark-mode .alert-danger .alert-content {
-  @apply text-red-300 bg-red-900 border-red-700;
+  @apply text-red-300;
 }
 .dark-mode .alert-danger .alert-content code {
   @apply bg-red-800 !important;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->
`.alert-content` in dark mode has too many styles.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
