### PR TITLE
fix(theme-docs): handle slug index replace after localePath execution

### DIFF
--- a/packages/theme-docs/src/components/global/app/AppNav.vue
+++ b/packages/theme-docs/src/components/global/app/AppNav.vue
@@ -20,7 +20,7 @@
           <ul>
             <li v-for="doc of docs" :key="doc.slug" class="text-gray-700 dark:text-gray-300">
               <NuxtLink
-                :to="localePath(doc.to).replace(/index$/, '')"
+                :to="localeTo(doc.to)"
                 class="px-2 rounded font-medium py-1 hover:text-primary-500 flex items-center justify-between"
                 exact-active-class="text-primary-500 bg-primary-100 hover:text-primary-500 dark:bg-primary-900"
               >

--- a/packages/theme-docs/src/components/global/app/AppNav.vue
+++ b/packages/theme-docs/src/components/global/app/AppNav.vue
@@ -20,7 +20,7 @@
           <ul>
             <li v-for="doc of docs" :key="doc.slug" class="text-gray-700 dark:text-gray-300">
               <NuxtLink
-                :to="localePath(doc.to)"
+                :to="localePath(doc.to).replace(/index$/, '')"
                 class="px-2 rounded font-medium py-1 hover:text-primary-500 flex items-center justify-between"
                 exact-active-class="text-primary-500 bg-primary-100 hover:text-primary-500 dark:bg-primary-900"
               >

--- a/packages/theme-docs/src/components/global/app/AppPrevNext.vue
+++ b/packages/theme-docs/src/components/global/app/AppPrevNext.vue
@@ -8,7 +8,7 @@
   >
     <NuxtLink
       v-if="prev"
-      :to="localePath(prev.to)"
+      :to="localePath(prev.to).replace(/index$/, '')"
       class="text-primary-500 font-bold hover:underline flex items-center justify-start"
     >
       <IconArrowLeft class="w-4 h-4 mr-1 flex-shrink-0" />
@@ -18,7 +18,7 @@
 
     <NuxtLink
       v-if="next"
-      :to="localePath(next.to)"
+      :to="localePath(next.to).replace(/index$/, '')"
       class="text-primary-500 font-bold hover:underline flex items-center justify-end"
     >
       <span class="truncate">{{ next.title }}</span>

--- a/packages/theme-docs/src/components/global/app/AppPrevNext.vue
+++ b/packages/theme-docs/src/components/global/app/AppPrevNext.vue
@@ -8,7 +8,7 @@
   >
     <NuxtLink
       v-if="prev"
-      :to="localePath(prev.to).replace(/index$/, '')"
+      :to="localeTo(prev.to)"
       class="text-primary-500 font-bold hover:underline flex items-center justify-start"
     >
       <IconArrowLeft class="w-4 h-4 mr-1 flex-shrink-0" />
@@ -18,7 +18,7 @@
 
     <NuxtLink
       v-if="next"
-      :to="localePath(next.to).replace(/index$/, '')"
+      :to="localeTo(next.to)"
       class="text-primary-500 font-bold hover:underline flex items-center justify-end"
     >
       <span class="truncate">{{ next.title }}</span>

--- a/packages/theme-docs/src/components/global/app/AppSearch.vue
+++ b/packages/theme-docs/src/components/global/app/AppSearch.vue
@@ -39,7 +39,7 @@
         @mousedown="go"
       >
         <NuxtLink
-          :to="localePath(result.to)"
+          :to="localePath(result.to).replace(/index$/, '')"
           class="flex px-4 py-2 items-center leading-5 transition ease-in-out duration-150"
           :class="{
             'text-primary-500 bg-gray-200 dark:bg-gray-800': focusIndex === index
@@ -115,7 +115,7 @@ export default {
         return
       }
       const result = this.focusIndex === -1 ? this.results[0] : this.results[this.focusIndex]
-      this.$router.push(this.localePath(result.to))
+      this.$router.push(this.localePath(result.to).replace(/index$/, ''))
       // Unfocus the input and reset the query.
       this.$refs.search.blur()
       this.q = ''

--- a/packages/theme-docs/src/components/global/app/AppSearch.vue
+++ b/packages/theme-docs/src/components/global/app/AppSearch.vue
@@ -39,7 +39,7 @@
         @mousedown="go"
       >
         <NuxtLink
-          :to="localePath(result.to).replace(/index$/, '')"
+          :to="localeTo(result.to)"
           class="flex px-4 py-2 items-center leading-5 transition ease-in-out duration-150"
           :class="{
             'text-primary-500 bg-gray-200 dark:bg-gray-800': focusIndex === index
@@ -115,7 +115,7 @@ export default {
         return
       }
       const result = this.focusIndex === -1 ? this.results[0] : this.results[this.focusIndex]
-      this.$router.push(this.localePath(result.to).replace(/index$/, ''))
+      this.$router.push(this.localeTo(result.to))
       // Unfocus the input and reset the query.
       this.$refs.search.blur()
       this.q = ''

--- a/packages/theme-docs/src/index.js
+++ b/packages/theme-docs/src/index.js
@@ -96,9 +96,9 @@ export default (userConfig) => {
   config.hooks['content:file:beforeInsert'] = (document) => {
     const regexp = new RegExp(`^/(${config.i18n.locales.map(locale => locale.code).join('|')})`, 'gi')
     const dir = document.dir.replace(regexp, '')
-    const slug = document.slug.replace(/^index/, '')
+    const slug = document.slug
 
-    document.to = `${dir}/${slug}`
+    document.to = [dir, slug].join('/') || '/'
   }
 
   return config

--- a/packages/theme-docs/src/index.js
+++ b/packages/theme-docs/src/index.js
@@ -26,6 +26,7 @@ const defaultConfig = {
   plugins: [
     '@/plugins/markdown',
     '@/plugins/init',
+    '@/plugins/global',
     '@/plugins/i18n.client',
     '@/plugins/vue-scrollactive',
     '@/plugins/menu.client'

--- a/packages/theme-docs/src/plugins/global.js
+++ b/packages/theme-docs/src/plugins/global.js
@@ -1,0 +1,7 @@
+import Vue from 'vue'
+
+export default function ({ app }) {
+  Vue.prototype.localeTo = (to) => {
+    return app.localePath(to).replace(/index$/, '')
+  }
+}


### PR DESCRIPTION
It seems that [nuxt-i18n](https://github.com/nuxt-community/i18n-module) `localePath` method has issues with trailing slashes when not on default locale.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->
Resolves: #412 

Since we need to remove the `/index` path, the replace was done in the `content:file:beforeInsert` hook. However when using `localePath` method on FR locale for example with `/` path, it returns `/fr` instead of `/fr/`. To solve this, a global `localeTo` method has been created to handle the `localePath` call then to replace the `/index` from the generated path.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
