### PR TITLE
fix(theme-docs): improve TOC hover

### DIFF
--- a/packages/theme-docs/src/components/global/app/AppToc.vue
+++ b/packages/theme-docs/src/components/global/app/AppToc.vue
@@ -22,7 +22,7 @@
           >
             <a
               :href="`#${link.id}`"
-              class="block text-sm scrollactive-item transition-transform ease-in-out duration-300 transform hover:translate-x-1"
+              class="block text-sm scrollactive-item transition-padding ease-in-out duration-300 hover:pl-1"
               :class="{
                 'py-2': link.depth === 2,
                 'ml-2 pb-2': link.depth === 3

--- a/packages/theme-docs/src/tailwind.config.js
+++ b/packages/theme-docs/src/tailwind.config.js
@@ -37,6 +37,9 @@ module.exports = {
       },
       inset: {
         16: '4rem'
+      },
+      transitionProperty: {
+        padding: 'padding'
       }
     },
     typography: theme => ({
@@ -149,6 +152,7 @@ module.exports = {
   },
   variants: {
     margin: ['responsive', 'last'],
+    padding: ['hover'],
     backgroundColor: ['responsive', 'hover', 'focus', 'dark', 'dark-focus'],
     textColor: ['responsive', 'hover', 'focus', 'dark', 'dark-hover', 'dark-focus'],
     borderColor: ['responsive', 'hover', 'focus', 'dark', 'dark-focus'],

--- a/packages/theme-docs/src/tailwind.config.js
+++ b/packages/theme-docs/src/tailwind.config.js
@@ -152,7 +152,7 @@ module.exports = {
   },
   variants: {
     margin: ['responsive', 'last'],
-    padding: ['hover'],
+    padding: ['responsive', 'hover'],
     backgroundColor: ['responsive', 'hover', 'focus', 'dark', 'dark-focus'],
     textColor: ['responsive', 'hover', 'focus', 'dark', 'dark-hover', 'dark-focus'],
     borderColor: ['responsive', 'hover', 'focus', 'dark', 'dark-focus'],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->
I propose to replace the transform transition by a padding transition on TOC items.

Current behavior with transform transition:
![bug-hover-toc](https://user-images.githubusercontent.com/2152968/91432550-285f6180-e862-11ea-9584-e943fc4a3b6c.gif)

Behavior with padding transition:
![fix-hover-toc](https://user-images.githubusercontent.com/2152968/91432804-93109d00-e862-11ea-8bc2-c01abd30f269.gif)


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
