### PR TITLE
fix(theme-docs): fix syntax highlighting in alert

### DIFF
--- a/packages/theme-docs/src/components/global/base/Alert.vue
+++ b/packages/theme-docs/src/components/global/base/Alert.vue
@@ -51,6 +51,10 @@ export default {
   @apply text-current;
 }
 
+.alert-content pre code {
+  background-color: inherit !important;
+}
+
 /* Info */
 
 .alert-info {
@@ -68,11 +72,11 @@ export default {
 .dark-mode .alert-info {
   @apply bg-blue-900 border-blue-700;
 }
+.dark-mode .alert-info code {
+  @apply bg-blue-800;
+}
 .dark-mode .alert-info .alert-content {
   @apply text-blue-300;
-}
-.dark-mode .alert-info .alert-content code {
-  @apply bg-blue-800 !important;
 }
 
 /* Success */
@@ -92,11 +96,11 @@ export default {
 .dark-mode .alert-success {
   @apply bg-green-900 border-green-700;
 }
+.dark-mode .alert-success code {
+  @apply bg-green-800;
+}
 .dark-mode .alert-success .alert-content {
   @apply text-green-300;
-}
-.dark-mode .alert-success .alert-content code {
-  @apply bg-green-800 !important;
 }
 
 /* Warning */
@@ -116,11 +120,11 @@ export default {
 .dark-mode .alert-warning {
   @apply bg-yellow-900 border-yellow-700;
 }
+.dark-mode .alert-warning code {
+  @apply bg-yellow-800;
+}
 .dark-mode .alert-warning .alert-content {
   @apply text-orange-300;
-}
-.dark-mode .alert-warning .alert-content code {
-  @apply bg-yellow-800 !important;
 }
 
 /* Danger */
@@ -140,10 +144,10 @@ export default {
 .dark-mode .alert-danger {
   @apply bg-red-900 border-red-700;
 }
+.dark-mode .alert-danger code {
+  @apply bg-red-800;
+}
 .dark-mode .alert-danger .alert-content {
   @apply text-red-300;
-}
-.dark-mode .alert-danger .alert-content code {
-  @apply bg-red-800 !important;
 }
 </style>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->
In dark mode, the syntax highlighting inside alert does not work well.

Before:
![bug-syntax-alert](https://user-images.githubusercontent.com/2152968/91488392-86666600-e8af-11ea-9a09-893304954542.png)

After:
![fix-syntax-alert](https://user-images.githubusercontent.com/2152968/91488403-8b2b1a00-e8af-11ea-85f7-e2cb771644d9.png)

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
