### PR TITLE
feat: reduce page jank

### DIFF
--- a/packages/create-nuxt-content-docs/template/content/en/index.md
+++ b/packages/create-nuxt-content-docs/template/content/en/index.md
@@ -9,8 +9,8 @@ features:
   - Feature 3
 ---
 
-<img src="/preview.png" class="light-img" />
-<img src="/preview-dark.png" class="dark-img" />
+<img src="/preview.png" class="light-img" width="1280" height="640" alt=""/>
+<img src="/preview-dark.png" class="dark-img" width="1280" height="640" alt=""/>
 
 [Module]() for [NuxtJS](https://nuxtjs.org).
 


### PR DESCRIPTION
By adding a height/width, modern browsers can reserve space for the responsive image.

https://deltener.com/blog/how-to-fix-image-jank-to-improve-your-cumulative-layout-shift-score/