### PR TITLE
feat: add database as second argument for beforeInsert

### DIFF
--- a/docs/content/en/advanced.md
+++ b/docs/content/en/advanced.md
@@ -103,7 +103,7 @@ export default {
 
 **Example**
 
-You might want to parse markdown inside a `.json` file. You can access the parsers from the `database` object::
+You might want to parse markdown inside a `.json` file. You can access the parsers from the `database` object:
 
 ```js
 export default {

--- a/docs/content/en/advanced.md
+++ b/docs/content/en/advanced.md
@@ -103,7 +103,7 @@ export default {
 
 **Example**
 
-You might want to parse markdown inside a `.json` file. This one is a bit tricky but has been requested a lot, so here is an example:
+You might want to parse markdown inside a `.json` file. You can access the parsers from the `database` object::
 
 ```js
 export default {
@@ -111,11 +111,7 @@ export default {
     '@nuxt/content'
   ],
   hooks: {
-    'content:file:beforeInsert': async (document) => {
-      const { Database, getOptions } = require('@nuxt/content')
-
-      const database = new Database(getOptions())
-
+    'content:file:beforeInsert': async (document, database) => {
       if (document.extension === '.json' && document.body) {
         const data = await database.markdown.toJSON(document.body)
 

--- a/example/content/json.json
+++ b/example/content/json.json
@@ -1,4 +1,5 @@
 {
   "title": "JSON",
-  "description": "This is a .json file"
+  "description": "This is a .json file",
+  "body": "Hello *Markdown*"
 }

--- a/example/nuxt.config.js
+++ b/example/nuxt.config.js
@@ -4,11 +4,7 @@ export default {
   ],
   components: true,
   hooks: {
-    'content:file:beforeInsert': async (document) => {
-      const { Database, getOptions } = require('@nuxt/content')
-
-      const database = new Database(getOptions())
-
+    'content:file:beforeInsert': async (document, database) => {
       if (document.extension === '.json' && document.body) {
         const data = await database.markdown.toJSON(document.body)
 

--- a/packages/content/lib/index.js
+++ b/packages/content/lib/index.js
@@ -91,7 +91,7 @@ module.exports = async function (moduleOptions) {
 
   // Database hooks
   database.hook('file:beforeInsert', item =>
-    this.nuxt.callHook('content:file:beforeInsert', item)
+    this.nuxt.callHook('content:file:beforeInsert', item, database)
   )
   database.hook('file:updated', event => ws.broadcast(event))
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->

Add `database` as second argument for beforeInsert hook to simplify extending document, see https://content.nuxtjs.org/advanced#contentfilebeforeinsert

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
