### PR TITLE
feat: support github custom domain

### DIFF
--- a/docs/content/en/themes/docs.md
+++ b/docs/content/en/themes/docs.md
@@ -360,7 +360,10 @@ You can create a `content/settings.json` file to configure the theme.
   - The logo of your project, can be an `Object` to set a logo per [color mode](https://github.com/nuxt-community/color-mode-module)
 - `github` (`String`)
   - The GitHub repository of your project `owner/name` to display the last version, the releases page, the link at the top and the `Edit this page on GitHub link` on each page Example: `nuxt/content`.
-  - For GitHub Enterprise, you can assign full url of your project. Example: `https://domain/repos/owner/name`.
+  - For GitHub Enterprise, you have to assign a full url of your project without a trailing slash. Example: `https://hostname/repos/owner/name`.
+- `githubApi` (`String`)
+  - For GitHub Enterprise, in addition to `github`, you have to assign a API full url of your project without a trailing slash. Example: `https://hostname/api/v3/repos/owner/name`.
+  - Releases are fetched from `${githubApi}/releases`.
 - `twitter` (`String`)
   - The Twitter username `@username` you want to link. Example: `@nuxt_js`
 - `defaultBranch` (`String`) <badge>v0.2.0+</badge>

--- a/docs/content/en/themes/docs.md
+++ b/docs/content/en/themes/docs.md
@@ -359,7 +359,8 @@ You can create a `content/settings.json` file to configure the theme.
 - `logo` (`String` | `Object`)
   - The logo of your project, can be an `Object` to set a logo per [color mode](https://github.com/nuxt-community/color-mode-module)
 - `github` (`String`)
-  - The GitHub repository of your project `owner/name` to display the last version, the releases page, the link at the top and the `Edit this page on GitHub link` on each page. Example: `nuxt/content`
+  - The GitHub repository of your project `owner/name` to display the last version, the releases page, the link at the top and the `Edit this page on GitHub link` on each page Example: `nuxt/content`.
+  - For GitHub Enterprise, you can assign full url of your project. Example: `https://domain/repos/owner/name`.
 - `twitter` (`String`)
   - The Twitter username `@username` you want to link. Example: `@nuxt_js`
 - `defaultBranch` (`String`) <badge>v0.2.0+</badge>

--- a/packages/create-nuxt-content-docs/src/saofile.js
+++ b/packages/create-nuxt-content-docs/src/saofile.js
@@ -19,7 +19,7 @@ module.exports = {
       },
       {
         name: 'github',
-        message: 'GitHub repository (owner/name):',
+        message: 'GitHub repository (owner/name) or GitHub Enterprise repository (https://domain/repos/owner/name):',
         default: 'nuxt/content'
       },
       {

--- a/packages/create-nuxt-content-docs/src/saofile.js
+++ b/packages/create-nuxt-content-docs/src/saofile.js
@@ -19,7 +19,7 @@ module.exports = {
       },
       {
         name: 'github',
-        message: 'GitHub repository (owner/name) or GitHub Enterprise repository (https://domain/repos/owner/name):',
+        message: 'GitHub repository (owner/name):',
         default: 'nuxt/content'
       },
       {

--- a/packages/create-nuxt-content-docs/test/cli.test.js
+++ b/packages/create-nuxt-content-docs/test/cli.test.js
@@ -3,21 +3,42 @@ const sao = require('sao')
 
 const generator = path.join(__dirname, '../src')
 
-test('should write files with good answers', async () => {
-  const answers = {
-    name: 'nuxt-content-docs',
-    title: 'Nuxt Content',
-    url: 'https://content.nuxtjs.org',
-    github: 'nuxt/content',
-    twitter: 'nuxt_js'
-  }
-  const stream = await sao.mock({ generator }, answers)
+describe('create-nuxt-content', () => {
+  test('should write files with good answers (GitHub)', async () => {
+    const answers = {
+      name: 'nuxt-content-docs',
+      title: 'Nuxt Content',
+      url: 'https://content.nuxtjs.org',
+      github: 'nuxt/content',
+      twitter: 'nuxt_js'
+    }
+    const stream = await sao.mock({ generator }, answers)
 
-  const pkg = await stream.readFile('package.json')
+    const pkg = await stream.readFile('package.json')
 
-  expect(JSON.parse(pkg)).toEqual(expect.objectContaining({
-    name: 'nuxt-content-docs',
-    version: '1.0.0',
-    private: true
-  }))
+    expect(JSON.parse(pkg)).toEqual(expect.objectContaining({
+      name: 'nuxt-content-docs',
+      version: '1.0.0',
+      private: true
+    }))
+  })
+
+  test('should write files with good answers (GitHub Enterprise)', async () => {
+    const answers = {
+      name: 'nuxt-content-docs',
+      title: 'Nuxt Content',
+      url: 'https://content.nuxtjs.org',
+      github: 'https://api.ghe.com/repos/me/project',
+      twitter: 'nuxt_js'
+    }
+    const stream = await sao.mock({ generator }, answers)
+
+    const pkg = await stream.readFile('package.json')
+
+    expect(JSON.parse(pkg)).toEqual(expect.objectContaining({
+      name: 'nuxt-content-docs',
+      version: '1.0.0',
+      private: true
+    }))
+  })
 })

--- a/packages/create-nuxt-content-docs/test/cli.test.js
+++ b/packages/create-nuxt-content-docs/test/cli.test.js
@@ -3,42 +3,21 @@ const sao = require('sao')
 
 const generator = path.join(__dirname, '../src')
 
-describe('create-nuxt-content', () => {
-  test('should write files with good answers (GitHub)', async () => {
-    const answers = {
-      name: 'nuxt-content-docs',
-      title: 'Nuxt Content',
-      url: 'https://content.nuxtjs.org',
-      github: 'nuxt/content',
-      twitter: 'nuxt_js'
-    }
-    const stream = await sao.mock({ generator }, answers)
+test('should write files with good answers (GitHub)', async () => {
+  const answers = {
+    name: 'nuxt-content-docs',
+    title: 'Nuxt Content',
+    url: 'https://content.nuxtjs.org',
+    github: 'nuxt/content',
+    twitter: 'nuxt_js'
+  }
+  const stream = await sao.mock({ generator }, answers)
 
-    const pkg = await stream.readFile('package.json')
+  const pkg = await stream.readFile('package.json')
 
-    expect(JSON.parse(pkg)).toEqual(expect.objectContaining({
-      name: 'nuxt-content-docs',
-      version: '1.0.0',
-      private: true
-    }))
-  })
-
-  test('should write files with good answers (GitHub Enterprise)', async () => {
-    const answers = {
-      name: 'nuxt-content-docs',
-      title: 'Nuxt Content',
-      url: 'https://content.nuxtjs.org',
-      github: 'https://api.ghe.com/repos/me/project',
-      twitter: 'nuxt_js'
-    }
-    const stream = await sao.mock({ generator }, answers)
-
-    const pkg = await stream.readFile('package.json')
-
-    expect(JSON.parse(pkg)).toEqual(expect.objectContaining({
-      name: 'nuxt-content-docs',
-      version: '1.0.0',
-      private: true
-    }))
-  })
+  expect(JSON.parse(pkg)).toEqual(expect.objectContaining({
+    name: 'nuxt-content-docs',
+    version: '1.0.0',
+    private: true
+  }))
 })

--- a/packages/theme-docs/src/components/app/AppGithubLink.vue
+++ b/packages/theme-docs/src/components/app/AppGithubLink.vue
@@ -25,6 +25,7 @@ export default {
   computed: {
     ...mapGetters([
       'settings',
+      'githubUrls',
       'lastRelease'
     ]),
     link () {
@@ -33,8 +34,7 @@ export default {
       }
 
       return [
-        'https://github.com',
-        this.settings.github,
+        this.githubUrls.repo,
         'edit',
         this.settings.defaultBranch,
         this.settings.defaultDir,

--- a/packages/theme-docs/src/components/app/AppHeader.vue
+++ b/packages/theme-docs/src/components/app/AppHeader.vue
@@ -53,7 +53,7 @@
             </a>
             <a
               v-if="settings.github"
-              :href="`https://github.com/${settings.github}`"
+              :href="githubUrls.repo"
               target="_blank"
               rel="noopener noreferrer"
               title="Github"
@@ -93,6 +93,7 @@ export default {
   computed: {
     ...mapGetters([
       'settings',
+      'githubUrls',
       'lastRelease'
     ]),
     menu: {

--- a/packages/theme-docs/src/components/app/AppNav.vue
+++ b/packages/theme-docs/src/components/app/AppNav.vue
@@ -51,7 +51,7 @@
             </a>
             <a
               v-if="settings.github"
-              :href="`https://github.com/${settings.github}`"
+              :href="githubUrls.repo"
               target="_blank"
               rel="noopener noreferrer"
               title="Github"
@@ -76,7 +76,8 @@ import { mapGetters } from 'vuex'
 export default {
   computed: {
     ...mapGetters([
-      'settings'
+      'settings',
+      'githubUrls'
     ]),
     menu: {
       get () {

--- a/packages/theme-docs/src/store/index.js
+++ b/packages/theme-docs/src/store/index.js
@@ -17,11 +17,27 @@ export const getters = {
     return state.settings
   },
   githubUrls (state) {
-    const { github } = state.settings
+    const { github = '', githubApi = '' } = state.settings
 
-    return github.startsWith('http')
-      ? { repo: github, releases: `${github}/releases` }
-      : { repo: `https://api.github.com/repos/${github}`, releases: `https://api.github.com/repos/${github}/releases` }
+    // GitHub Enterprise
+    if (github.startsWith('http') && githubApi.startsWith('http')) {
+      return {
+        repo: github,
+        api: {
+          repo: githubApi,
+          releases: `${githubApi}/releases`
+        }
+      }
+    }
+
+    // GitHub
+    return {
+      repo: `https://github.com/repos/${github}`,
+      api: {
+        repo: `https://api.github.com/repos/${github}`,
+        releases: `https://api.github.com/repos/${github}/releases`
+      }
+    }
   },
   releases (state) {
     return state.releases
@@ -72,7 +88,7 @@ export const actions = {
     }
     let releases = []
     try {
-      const data = await fetch(getters.githubUrls.releases, options).then((res) => {
+      const data = await fetch(getters.githubUrls.api.releases, options).then((res) => {
         if (!res.ok) {
           throw new Error(res.statusText)
         }
@@ -110,7 +126,7 @@ export const actions = {
     }
     let defaultBranch
     try {
-      const data = await fetch(getters.githubUrls.repo, options).then((res) => {
+      const data = await fetch(getters.githubUrls.api.repo, options).then((res) => {
         if (!res.ok) {
           throw new Error(res.statusText)
         }

--- a/packages/theme-docs/src/store/index.js
+++ b/packages/theme-docs/src/store/index.js
@@ -16,6 +16,13 @@ export const getters = {
   settings (state) {
     return state.settings
   },
+  githubUrls (state) {
+    const { github } = state.settings
+
+    return github.startsWith('http')
+      ? { repo: github, releases: `${github}/releases` }
+      : { repo: `https://api.github.com/repos/${github}`, releases: `https://api.github.com/repos/${github}/releases` }
+  },
   releases (state) {
     return state.releases
   },
@@ -54,7 +61,7 @@ export const actions = {
 
     commit('SET_CATEGORIES', categories)
   },
-  async fetchReleases ({ commit, state }) {
+  async fetchReleases ({ commit, state, getters }) {
     if (!state.settings.github) {
       return
     }
@@ -65,7 +72,7 @@ export const actions = {
     }
     let releases = []
     try {
-      const data = await fetch(`https://api.github.com/repos/${state.settings.github}/releases`, options).then((res) => {
+      const data = await fetch(getters.githubUrls.releases, options).then((res) => {
         if (!res.ok) {
           throw new Error(res.statusText)
         }
@@ -92,7 +99,7 @@ export const actions = {
 
     commit('SET_RELEASES', releases)
   },
-  async fetchDefaultBranch ({ commit, state }) {
+  async fetchDefaultBranch ({ commit, state, getters }) {
     if (!state.settings.github || state.settings.defaultBranch) {
       return
     }
@@ -103,7 +110,7 @@ export const actions = {
     }
     let defaultBranch
     try {
-      const data = await fetch(`https://api.github.com/repos/${state.settings.github}`, options).then((res) => {
+      const data = await fetch(getters.githubUrls.repo, options).then((res) => {
         if (!res.ok) {
           throw new Error(res.statusText)
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->

This PR implements #439, and lets us fetch repositories hosted on GitHub Enterprise, whose API has other domain than `api.github.com`.

I defined a Vuex getter `githubUrls` that returns an object whose values are full urls to get data of repository and its releases.

In addition, I modified related part of docs and SAO prompts.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes (if not applicable, please state why)

### What and how I tested my changes

#### `create-nuxt-content`

First, I added a test case to check whether it creates files correctly when developer assign full url of repository instead of `owner/repo` string.

Second, I ran `yarn test` in the project root and all the tests were passed.

#### `theme-docs` 

First, I ran `yarn link` for all the packages (`@nuxt/content`, `@nuxt/theme-docs`, and `create-nuxt-content`). 

Second, I ran the linked `create-nuxt-content` to get `theme-docs` files. 

Third, I replaced the installed `@nuxt/theme-docs` with my local one, and ran `yarn run dev`, resulting in that releases are correctly fetched.

<img width="1160" alt="Screen Shot 2020-09-06 at 0 15 54" src="https://user-images.githubusercontent.com/16436160/92308084-29b52a80-efd6-11ea-8a65-ac77d5680d82.png">

It would be fine to test the full-url case with GitHub repository instead of GitHub Enterprise, because what is different is only the form of the original string, not actual reachability of the API.

---

P.S. This is my very first PR for open source project in my life. 👶 