### PR TITLE
fix(types): remark plugins and rehype plugins should accept options in array syntax

### DIFF
--- a/packages/content/types/index.d.ts
+++ b/packages/content/types/index.d.ts
@@ -27,8 +27,8 @@ interface IContentOptions {
   fullTextSearchFields?: extendOrOverwrite<Array<string>>;
   nestedProperties?: extendOrOverwrite<Array<string>>;
   markdown?: {
-    remarkPlugins?: extendOrOverwrite<Array<string>>;
-    rehypePlugins?: extendOrOverwrite<Array<string>>;
+    remarkPlugins?: extendOrOverwrite<Array<string | [string, Record<string, unknown>]>>;
+    rehypePlugins?: extendOrOverwrite<Array<string | [string, Record<string, unknown>]>>;
     prism?: {
       theme?: string | false;
     };
@@ -76,4 +76,3 @@ declare module '@nuxt/types/config/hooks' {
     };
   }
 }
-


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->
According to this code:

https://github.com/nuxt/content/blob/711913c4772a9aad442f093eb4ddc822771e873f/packages/content/lib/utils.js#L46-L48

it should accept options with `[<plugin-name>, <options>]` syntax.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
