### PR TITLE
feat(theme-docs): add `defaultDir` options

### DIFF
--- a/docs/content/en/themes/docs.md
+++ b/docs/content/en/themes/docs.md
@@ -364,6 +364,8 @@ You can create a `content/settings.json` file to configure the theme.
   - The Twitter username `@username` you want to link. Example: `@nuxt_js`
 - `defaultBranch` (`String`) <badge>v0.2.0+</badge>
   - The default branch for the GitHub repository of your project, used in the `Edit this page on GitHub link` on each page (defaults to `main` if it cannot be detected).
+- `defaultDir` (`String`) <badge>v0.6.0+</badge>
+  - The default dir of your project, used in the `Edit this page on GitHub link` on each page (defaults to `docs`).
 - `layout` (`String`) <badge>v0.4.0+</badge>
   - The layout of your documentation (defaults to `default`). Can be changed to `single` to have a one-page doc.
 

--- a/packages/theme-docs/src/components/app/AppGithubLink.vue
+++ b/packages/theme-docs/src/components/app/AppGithubLink.vue
@@ -32,7 +32,14 @@ export default {
         return
       }
 
-      return `https://github.com/${this.settings.github}/edit/${this.settings.defaultBranch}/docs/content${this.document.path}${this.document.extension}`
+      return [
+        'https://github.com',
+        this.settings.github,
+        'edit',
+        this.settings.defaultBranch,
+        this.settings.defaultDir,
+        `content${this.document.path}${this.document.extension}`
+      ].filter(path => !!path).join('/')
     }
   }
 }

--- a/packages/theme-docs/src/store/index.js
+++ b/packages/theme-docs/src/store/index.js
@@ -6,6 +6,7 @@ export const state = () => ({
   releases: [],
   settings: {
     title: 'Nuxt Content Docs',
+    defaultDir: 'docs',
     defaultBranch: '',
     filled: false
   }
@@ -35,7 +36,7 @@ export const mutations = {
     state.settings.defaultBranch = branch
   },
   SET_SETTINGS (state, settings) {
-    state.settings = Object.assign({}, settings, { filled: true })
+    state.settings = Object.assign({}, state.settings, settings, { filled: true })
   }
 }
 


### PR DESCRIPTION
This option can be used to override the default `docs` dir used in the "Edit this page on GitHub" link if your project lives in a different directory.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->
Resolves #455, resolves #430.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
