### PR TITLE
fix(theme-docs): fix code block's filename style

### DIFF
--- a/packages/theme-docs/src/assets/css/main.css
+++ b/packages/theme-docs/src/assets/css/main.css
@@ -54,7 +54,12 @@
 
     /* Style filename span added by @nuxt/content */
     & > .filename {
-      @apply absolute right-0 top-0 text-gray-100 z-10 italic leading-none mr-3 mt-3;
+      @apply absolute right-0 top-0 text-gray-100 z-10 italic leading-none mr-4 mt-3;
+    }
+
+    /* Add top padding to code blocks with filename */
+    & > .filename + pre[class*="language-"] {
+      @apply pt-8;
     }
 
     /* Style copy button added in `pages/_.vue` */

--- a/packages/theme-docs/src/assets/css/main.css
+++ b/packages/theme-docs/src/assets/css/main.css
@@ -54,7 +54,7 @@
 
     /* Style filename span added by @nuxt/content */
     & > .filename {
-      @apply absolute right-0 top-0 text-gray-100 z-10 italic leading-none mr-4 mt-3;
+      @apply absolute right-0 top-0 text-gray-100 z-10 font-mono text-sm tracking-tight leading-none mr-4 mt-3;
     }
 
     /* Add top padding to code blocks with filename */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->

Fixes #463.

### Before Fix

As the issue highlighted, the filename will intersect with the first line of a code block. Below is a sample screenshot, one with no filename and the one with filename exhibits this issue:

_Note: They may not look super intersecting like the one show in the issue, but it's because only characters with long tail like "q", "p" or "g" are the worst offender._

![chrome_7QSL6WFJ9V](https://user-images.githubusercontent.com/42867097/92998268-5f649100-f54b-11ea-93f7-b822b3729a71.png)

### After Fix

The obvious fix is to add a top padding to code blocks, but this will make code blocks without filename look awkward with top gap. This is the reason why I used the `+` operator in `.filename + pre[class*="language-"]` which **will only target the `pre` tag if there is a div with `.filename` class above it.** The resulting fix is shown in the screenshot below:

![chrome_AOAuNRLwqp](https://user-images.githubusercontent.com/42867097/92998465-7a83d080-f54c-11ea-95b6-cc9b7dcfc142.png)

Notice how the top code block has equal top and bottom padding like usual, but only the bottom code block with file name has a larger top padding to compensate.

### Slight out-of-topic fix

Just in case you guys are wondering why I changed the styling for `.filename` itself, currently the filename is styled with equal top and right margin to space it away from the top right corner, as indicated by the `mt-3` and `mr-3` here:

https://github.com/nuxt/content/blob/a72d92e324a104f8763a67bd7953976358da7b5e/packages/theme-docs/src/assets/css/main.css#L57

However from my experience, typically we need more padding on the X axis (left & right) compared to the Y axis (top & bottom) when it comes to words. Here are my reasoning for my change on that line:

|Before ( mr-3 ) | After ( mr-4 } |
|---|---|
| ![chrome_aKc5Q5CUMO](https://user-images.githubusercontent.com/42867097/92998678-cd11bc80-f54d-11ea-83e3-cfce0690ff32.png) | ![chrome_2BZ67UkrjV](https://user-images.githubusercontent.com/42867097/92998684-d26f0700-f54d-11ea-83ca-f7b81ca89d4b.png) |

In the example above, we can see that even though originally the top and right margin is the same, it still seems like the right margin is visually less than the top margin. This is why we need to compensate more for the right margin.

Just to add on another example from the Nuxt official website's subscribe button for newsletter:

| Normal Visual | Padding shown via DevTools |
|---|---|
| ![chrome_JvH7DpRaP2](https://user-images.githubusercontent.com/42867097/92998739-4b6e5e80-f54e-11ea-8454-6c346857c58f.png) | ![ShareX_JDE5foyeTh](https://user-images.githubusercontent.com/42867097/92998748-62ad4c00-f54e-11ea-93f0-3a3d084e2947.png) |

This once again shows that even when the word `SUBSCRIBE` visually has same padding from all sides, but actually the left and right padding is more than top and bottom padding. Sorry if I'm rambling on too much for this little thing haha.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
