### PR TITLE
chore(theme-docs): add tailwindcss purgeLayersByDefault future flag

### DIFF
--- a/packages/theme-docs/src/tailwind.config.js
+++ b/packages/theme-docs/src/tailwind.config.js
@@ -11,7 +11,8 @@ const selectorParser = require('postcss-selector-parser')
 
 module.exports = {
   future: {
-    removeDeprecatedGapUtilities: true
+    removeDeprecatedGapUtilities: true,
+    purgeLayersByDefault: true
   },
   theme: {
     extend: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->

Tailwind v1.8.0 introduced new layers purge mode which will be the default in v2.0, [as mentioned in the docs here](https://tailwindcss.com/docs/upcoming-changes#purge-layers-by-default). Quote from link:

> You should see an even smaller CSS file by default with the new layers mode enabled, and shouldn't see any negative consequences unless you were deliberately relying on the fact that Tailwind was previously not purging the base or components layers by default.

thus I didn't see anything breaking as mentioned by the quote, while reaping the benefit of lower filesize. Here is the comparison of before and after I manually added **purgeLayersByDefault** to the `tailwind.config.js` file:

_Note: both `original-docs` and `new-docs` are totally new projects created using `yarn create nuxt-content-docs`._

|| Original | With purgeLayersByDefault turned on |
|---|---|---|
| Terminal screenshot | ![WindowsTerminal_sZnCBeWky3](https://user-images.githubusercontent.com/42867097/93017831-47017e80-f5fe-11ea-8716-070df546c4aa.png) | ![WindowsTerminal_sBVHOXwFad](https://user-images.githubusercontent.com/42867097/93017911-d149e280-f5fe-11ea-9e71-2af767e5f016.png) |
| `yarn generate` resulting file size | 2.7 M | 2.1 M |



## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
