### PR TITLE
fix incorrect github URL for navbar link

### DIFF
--- a/packages/theme-docs/src/store/index.js
+++ b/packages/theme-docs/src/store/index.js
@@ -32,7 +32,7 @@ export const getters = {
 
     // GitHub
     return {
-      repo: `https://github.com/repos/${github}`,
+      repo: `https://github.com/${github}`,
       api: {
         repo: `https://api.github.com/repos/${github}`,
         releases: `https://api.github.com/repos/${github}/releases`


### PR DESCRIPTION
Fixing issue that was causing the incorrect URL for a Github repository to be rendered in the navbar

## Types of changes
- [X ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
This pull request solves an issue that caused the incorrect Github repository URL to be applied in the navbar of a content docs layout. 


## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
