### PR TITLE
fix(theme-docs): fixed incorrect Github URL for navbar

### DIFF
--- a/packages/theme-docs/src/store/index.js
+++ b/packages/theme-docs/src/store/index.js
@@ -32,7 +32,7 @@ export const getters = {
 
     // GitHub
     return {
-      repo: `https://github.com/repos/${github}`,
+      repo: `https://github.com/${github}`,
       api: {
         repo: `https://api.github.com/repos/${github}`,
         releases: `https://api.github.com/repos/${github}/releases`


### PR DESCRIPTION
Fixing an issue in the store that was providing the incorrect URL for the Github repository to render in the navbar
## Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
This issue solves a problem that was causing a Github repository URL to include a /repos/ portion in the URL, which lead to a Github 404 page. The links in the navbar will not be correct. 


## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
