### PR TITLE
docs: add version badges for features of #458 

### DIFF
--- a/docs/content/en/themes/docs.md
+++ b/docs/content/en/themes/docs.md
@@ -360,8 +360,8 @@ You can create a `content/settings.json` file to configure the theme.
   - The logo of your project, can be an `Object` to set a logo per [color mode](https://github.com/nuxt-community/color-mode-module)
 - `github` (`String`)
   - The GitHub repository of your project `owner/name` to display the last version, the releases page, the link at the top and the `Edit this page on GitHub link` on each page Example: `nuxt/content`.
-  - For GitHub Enterprise, you have to assign a full url of your project without a trailing slash. Example: `https://hostname/repos/owner/name`.
-- `githubApi` (`String`)
+  - For GitHub Enterprise, you have to assign a full url of your project without a trailing slash. Example: `https://hostname/repos/owner/name`. <badge>v0.6.0+</badge>
+- `githubApi` (`String`) <badge>v0.6.0+</badge>
   - For GitHub Enterprise, in addition to `github`, you have to assign a API full url of your project without a trailing slash. Example: `https://hostname/api/v3/repos/owner/name`.
   - Releases are fetched from `${githubApi}/releases`.
 - `twitter` (`String`)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->

I found that my PR (#458) was [released as a part of `v0.6.0`](https://github.com/nuxt/content/releases/tag/%40nuxt%2Fcontent-theme-docs%400.6.0), so it would be kinder to add version badge to the according parts of doc.

By the way, I also found that my PR included a typo, which was reported by @antho1404 as #492, and fixed by @DavidTParks as #489. The bug-fix was released as a part of `v0.6.1`. Thank you folks. I will be more careful when submitting PRs. 🙏 🙇

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
