### PR TITLE
fix(content): fix tab key handling of editor component with IME

### DIFF
--- a/packages/content/templates/editor.vue
+++ b/packages/content/templates/editor.vue
@@ -5,6 +5,8 @@
     @keyup.stop="onType"
     @keydown.tab.exact.prevent="onTabRight"
     @keydown.tab.shift.prevent="onTabLeft"
+    @compositionstart.prevent="isInComposition = true"
+    @compositionend.prevent="isInComposition = false"
     @blur="$emit('endEdit')"
   />
 </template>
@@ -17,7 +19,8 @@ export default {
   },
   data () {
     return {
-      file: ''
+      file: '',
+      isInComposition: false
     }
   },
   watch: {
@@ -37,7 +40,10 @@ export default {
       const el = this.$refs.textarea
       el.style.height = el.scrollHeight + 'px'
     },
-    onTabRight (event) {
+    onTabRight(event) {
+      if (this.isInComposition) {
+        return
+      }
       const text = this.file
       const originalSelectionStart = event.target.selectionStart
       const textStart = text.slice(0, originalSelectionStart)
@@ -47,7 +53,10 @@ export default {
       event.target.selectionEnd = event.target.selectionStart =
         originalSelectionStart + 1
     },
-    onTabLeft (event) {
+    onTabLeft(event) {
+      if (this.isInComposition) {
+        return
+      }
       const text = this.file
       const originalSelectionStart = event.target.selectionStart
       const textStart = text.slice(0, originalSelectionStart)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->
I often use tab key to composition string from the suggested clauses with IME, but using on editor.vue occurs unexpected behavior.
This PR is to avoid tab key handling on the editor.vue during text composition session.

|  Before  |  After  |
| ---- | ---- |
|  ![before](https://user-images.githubusercontent.com/2783737/94357627-838caa00-00d5-11eb-89ed-b5e96942731d.gif) |  ![after](https://user-images.githubusercontent.com/2783737/94357631-88e9f480-00d5-11eb-9dde-00f1a0d14b51.gif)  |

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)

Testing event handling is a bit hard..., but l can try to add it so please let me know if it's needed.