### PR TITLE
fix: Included types folder in files

### DIFF
--- a/packages/content/package.json
+++ b/packages/content/package.json
@@ -8,7 +8,7 @@
     "lib",
     "parsers",
     "templates",
-    "types/*.d.ts"
+    "types"
   ],
   "main": "lib/",
   "dependencies": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
Include all typescript files on build. This will solve the problem that parsers are not included in the build.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->
In #444 I created a PR for extra types. By mistake I didn't add these files to the package.json for build process. This means in test environment it works but after a build the parser types are not included. I believe including all `*.d.ts` files in the package.json will resolve this problem. 

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
