### PR TITLE
docs: fix displaying style link

### DIFF
--- a/docs/content/en/displaying.md
+++ b/docs/content/en/displaying.md
@@ -52,7 +52,7 @@ Depending on what you're using to design your app, you may need to write some st
 }
 ```
 
-You can find an example in the [docs directory](https://github.com/nuxt/content/blob/master/docs/pages/_slug.vue).
+You can find an example in the [docs directory](https://github.com/nuxt/content/blob/master/docs/).
 
 ## Live Editing
 


### PR DESCRIPTION
This link is broken: https://github.com/nuxt/content/blob/master/docs/pages/_slug.vue
Leads to 404 page

<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
