### PR TITLE
chore(theme-docs): improve list component

### DIFF
--- a/docs/content/en/themes/docs.md
+++ b/docs/content/en/themes/docs.md
@@ -448,8 +448,11 @@ Check out an info alert with a `codeblock` and a [link](/themes/docs)!
   - Default: `[]`
 - `type`
   - Type: `String`
-  - Default: `'success'`
-  - Values: `['info', 'success', 'warning', 'danger']`
+  - Default: `'primary'`
+  - Values: `['primary', 'info', 'success', 'warning', 'danger']`
+- `icon`
+  - Type: `String`
+  - *Can be used to override the default `type` icon, check out the [icons available](https://github.com/nuxt/content/tree/dev/packages/theme-docs/src/components/global/icons)*
 
 **Example**
 

--- a/packages/theme-docs/src/components/global/base/List.vue
+++ b/packages/theme-docs/src/components/global/base/List.vue
@@ -2,7 +2,7 @@
   <div>
     <div v-for="(item, i) in items" :key="i" class="mt-3 flex">
       <span :class="`list-${type}`" class="mt-px mr-3 flex-shrink-0">
-        <component :is="icon" class="h-6 w-6" />
+        <component :is="iconName" class="h-6 w-6" />
       </span>
       {{ item }}
     </div>
@@ -16,19 +16,24 @@ export default {
       type: Array,
       default: () => []
     },
+    icon: {
+      type: String,
+      default: null
+    },
     type: {
       type: String,
-      default: 'success',
+      default: 'primary',
       validator (value) {
-        return ['info', 'success', 'warning', 'danger'].includes(value)
+        return ['primary', 'info', 'success', 'warning', 'danger'].includes(value)
       }
     }
   },
   computed: {
-    icon () {
-      return ({
+    iconName () {
+      return this.icon || ({
+        primary: 'IconBadgeCheck',
         info: 'IconInformationCircle',
-        success: 'IconBadgeCheck',
+        success: 'IconCheckCircle',
         warning: 'IconExclamationCircle',
         danger: 'IconXCircle'
       })[this.type]
@@ -38,7 +43,10 @@ export default {
 </script>
 
 <style>
-
+/* Primary */
+.list-primary {
+  @apply text-primary-500;
+}
 /* Info */
 .list-info {
   @apply text-blue-500;


### PR DESCRIPTION
Improve `<list>` component to default to `primary` color (avoids breaking actual docs) and allows to override the icon.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.