### PR TITLE
fix(theme-docs): twitter preview when trailing slash on url

### DIFF
--- a/packages/theme-docs/src/layouts/default.vue
+++ b/packages/theme-docs/src/layouts/default.vue
@@ -28,6 +28,7 @@ export default {
   },
   head () {
     const i18nSeo = this.$nuxtI18nSeo()
+    const previewUrl = this.settings.url.replace(/\/$/, '') + '/preview.png'
 
     return {
       titleTemplate: (chunk) => {
@@ -46,12 +47,12 @@ export default {
         { hid: 'og:site_name', property: 'og:site_name', content: this.settings.title },
         { hid: 'og:type', property: 'og:type', content: 'website' },
         { hid: 'og:url', property: 'og:url', content: this.settings.url },
-        { hid: 'og:image', property: 'og:image', content: `${this.settings.url}/preview.png` },
+        { hid: 'og:image', property: 'og:image', content: previewUrl },
         // Twitter Card
         { hid: 'twitter:card', name: 'twitter:card', content: 'summary_large_image' },
         { hid: 'twitter:site', name: 'twitter:site', content: this.settings.twitter },
         { hid: 'twitter:title', name: 'twitter:title', content: this.settings.title },
-        { hid: 'twitter:image', name: 'twitter:image', content: `${this.settings.url}/preview.png` },
+        { hid: 'twitter:image', name: 'twitter:image', content: previewUrl },
         { hid: 'twitter:image:alt', name: 'twitter:image:alt', content: this.settings.title }
       ])
     }

--- a/packages/theme-docs/src/layouts/single.vue
+++ b/packages/theme-docs/src/layouts/single.vue
@@ -24,6 +24,7 @@ export default {
   },
   head () {
     const i18nSeo = this.$nuxtI18nSeo()
+    const previewUrl = this.settings.url.replace(/\/$/, '') + '/preview.png'
 
     return {
       titleTemplate: (chunk) => {
@@ -42,12 +43,12 @@ export default {
         { hid: 'og:site_name', property: 'og:site_name', content: this.settings.title },
         { hid: 'og:type', property: 'og:type', content: 'website' },
         { hid: 'og:url', property: 'og:url', content: this.settings.url },
-        { hid: 'og:image', property: 'og:image', content: `${this.settings.url}/preview.png` },
+        { hid: 'og:image', property: 'og:image', content: previewUrl },
         // Twitter Card
         { hid: 'twitter:card', name: 'twitter:card', content: 'summary_large_image' },
         { hid: 'twitter:site', name: 'twitter:site', content: this.settings.twitter },
         { hid: 'twitter:title', name: 'twitter:title', content: this.settings.title },
-        { hid: 'twitter:image', name: 'twitter:image', content: `${this.settings.url}/preview.png` },
+        { hid: 'twitter:image', name: 'twitter:image', content: previewUrl },
         { hid: 'twitter:image:alt', name: 'twitter:image:alt', content: this.settings.title }
       ])
     }

--- a/packages/theme-docs/src/store/index.js
+++ b/packages/theme-docs/src/store/index.js
@@ -6,6 +6,7 @@ export const state = () => ({
   releases: [],
   settings: {
     title: 'Nuxt Content Docs',
+    url: '',
     defaultDir: 'docs',
     defaultBranch: '',
     filled: false
@@ -60,6 +61,9 @@ export const mutations = {
   },
   SET_SETTINGS (state, settings) {
     state.settings = Object.assign({}, state.settings, settings, { filled: true })
+    if (!state.settings.url) {
+      console.warn('Please provide the `url` property in `content/setting.json`')
+    }
   }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->
When adding a trailing slash to `url`  in `content/setting.json`, the preview on Twitter was broken, this avoid this situation.

I also added a warning if the user forget to fill the url in `content/setting.json`.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
