### PR TITLE
chore(theme-docs): unify term in official docs

### DIFF
--- a/docs/content/en/advanced.md
+++ b/docs/content/en/advanced.md
@@ -73,7 +73,7 @@ The module adds some hooks you can use:
 Allows you to modify the contents of a file before it is handled by the parsers.
 
 Arguments:
-- `data`
+- `file`
  - Type: `Object`
  - Properties:
    - path: `String`


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

None of above.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->

Argument of `content:file:beforeParse` hook is explained as `data`, but it is written as `file` in both the sample code and the internal code. So, I changed the term `data` to `file` for consistency.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)

Since this is just a change on text in doc, unit/e2e testing is not needed, is it?