### PR TITLE
Add RTL support

### DIFF
--- a/packages/theme-docs/package.json
+++ b/packages/theme-docs/package.json
@@ -28,7 +28,8 @@
     "vue-scrollactive": "^0.9.3"
   },
   "devDependencies": {
-    "nuxt": "^2.14.7"
+    "nuxt": "^2.14.7",
+    "tailwindcss-dir": "^4.0.0"
   },
   "types": "./src/index.d.ts"
 }

--- a/packages/theme-docs/src/assets/css/main.css
+++ b/packages/theme-docs/src/assets/css/main.css
@@ -85,5 +85,25 @@
   & pre[class*="language-"] {
     /* Make pre static so the relative goes to the parent (.nuxt-content-highlight) */
     @apply bg-gray-800 static;
+
+    direction: initial;
+  }
+}
+
+body[dir="rtl"] {
+  & .nuxt-content {
+    & h2, & h3 {
+      & > a {
+        @apply ml-0 mr-5;
+
+        &::before {
+          @apply ml-0 pr-0 -mr-5 pl-2;
+        }
+
+        @screen lg {
+          @apply mr-0;
+        }
+      }
+    }
   }
 }

--- a/packages/theme-docs/src/components/app/AppDropdown.vue
+++ b/packages/theme-docs/src/components/app/AppDropdown.vue
@@ -18,7 +18,7 @@
     >
       <div
         v-show="open"
-        class="mt-2 w-auto rounded-md shadow-lg z-50 origin-top-right absolute bottom-0 right-0"
+        class="mt-2 w-auto rounded-md shadow-lg z-50 origin-top-right absolute bottom-0 ltr:right-0 rtl:left-0"
       >
         <div class="rounded-md bg-white dark:bg-gray-800 shadow-xs">
           <slot />

--- a/packages/theme-docs/src/components/app/AppFooter.vue
+++ b/packages/theme-docs/src/components/app/AppFooter.vue
@@ -9,7 +9,7 @@
       </div>
       <div class="flex">
         <AppLangSwitcher />
-        <AppColorSwitcher class="ml-4" />
+        <AppColorSwitcher class="ltr:ml-4 rtl:mr-4" />
       </div>
     </div>
   </footer>

--- a/packages/theme-docs/src/components/app/AppGithubLink.vue
+++ b/packages/theme-docs/src/components/app/AppGithubLink.vue
@@ -6,8 +6,9 @@
       rel="noopener"
       class="text-gray-600 dark:text-gray-400 text-sm font-medium hover:underline flex items-center"
     >
+      <IconExternalLink class="ltr:hidden w-4 h-4 ml-1" />
       {{ $t('article.github') }}
-      <IconExternalLink class="w-4 h-4 ml-1" />
+      <IconExternalLink class="rtl:hidden w-4 h-4 ml-1" />
     </a>
   </div>
 </template>

--- a/packages/theme-docs/src/components/app/AppHeader.vue
+++ b/packages/theme-docs/src/components/app/AppHeader.vue
@@ -6,7 +6,7 @@
   >
     <div class="container mx-auto flex-1 px-4 lg:px-8">
       <div class="flex items-center justify-between h-16">
-        <div class="lg:w-1/5 flex items-center pr-4" @click.stop="noop">
+        <div class="lg:w-1/5 flex items-center ltr:pr-4 rtl:pl-4" @click.stop="noop">
           <NuxtLink
             :to="localePath('/')"
             class="flex-shrink-0 flex-1 font-bold text-xl"
@@ -28,13 +28,13 @@
           <AppSearch v-else class="hidden lg:block" />
         </div>
         <div
-          class="lg:w-1/5 flex items-center pl-4 lg:pl-8"
+          class="lg:w-1/5 flex items-center ltr:pl-4 rtl:pr-4 lg:ltr:pl-8 lg:rtl:pr-8"
           :class="{ 'justify-between': lastRelease && settings.layout !== 'single', 'justify-end': !lastRelease || settings.layout === 'single' }"
         >
           <NuxtLink
             v-if="lastRelease"
             to="/releases"
-            class="font-semibold leading-none text-gray-700 dark:text-gray-300 hover:text-primary-500 dark-hover:text-primary-500 text-base mr-4"
+            class="font-semibold leading-none text-gray-700 dark:text-gray-300 hover:text-primary-500 dark-hover:text-primary-500 text-base ltr:mr-4 rtl:ml-4"
             exact-active-class="text-primary-500"
           >{{ lastRelease.name }}</NuxtLink>
           <div class="flex items-center">
@@ -45,7 +45,7 @@
               rel="noopener noreferrer"
               title="Twitter"
               name="Twitter"
-              class="text-gray-700 dark:text-gray-300 hover:text-primary-500 dark-hover:text-primary-500 ml-4"
+              class="text-gray-700 dark:text-gray-300 hover:text-primary-500 dark-hover:text-primary-500 ltr:ml-4 rtl:mr-4"
               :class="{
                 'hidden lg:block': settings.layout !== 'single'
               }"
@@ -59,7 +59,7 @@
               rel="noopener noreferrer"
               title="Github"
               name="Github"
-              class="text-gray-700 dark:text-gray-300 hover:text-primary-500 dark-hover:text-primary-500 ml-4"
+              class="text-gray-700 dark:text-gray-300 hover:text-primary-500 dark-hover:text-primary-500 ltr:ml-4 rtl:mr-4"
               :class="{
                 'hidden lg:block': settings.layout !== 'single'
               }"
@@ -69,7 +69,7 @@
 
             <button
               v-if="settings.layout !== 'single'"
-              class="lg:hidden p-2 rounded-md text-gray-700 dark:text-gray-300 focus:outline-none -mr-2"
+              class="lg:hidden p-2 rounded-md text-gray-700 dark:text-gray-300 focus:outline-none ltr:-mr-2 rtl:-ml-2"
               aria-label="Menu"
               @click.stop="menu = !menu"
             >

--- a/packages/theme-docs/src/components/app/AppNav.vue
+++ b/packages/theme-docs/src/components/app/AppNav.vue
@@ -4,7 +4,7 @@
     :class="{ 'block': menu, 'hidden': !menu }"
   >
     <div class="lg:sticky lg:top-16 overflow-y-auto h-full lg:h-auto lg:max-h-(screen-16)">
-      <ul class="p-4 lg:py-8 lg:pl-0 lg:pr-8">
+      <ul class="p-4 lg:py-8 lg:pl-0 lg:ltr:pr-8 lg:rtl:pl-8">
         <li v-if="!settings.algolia" class="mb-4 lg:hidden">
           <AppSearch />
         </li>
@@ -40,7 +40,7 @@
         </li>
         <li class="lg:hidden">
           <p class="mb-2 text-gray-500 uppercase tracking-wider font-bold text-sm lg:text-xs">More</p>
-          <div class="flex items-center ml-2">
+          <div class="flex items-center ltr:ml-2 rtl:mr-2">
             <a
               v-if="settings.twitter"
               :href="`https://twitter.com/${settings.twitter}`"
@@ -48,7 +48,7 @@
               rel="noopener noreferrer"
               title="Twitter"
               name="Twitter"
-              class="inline-flex text-gray-700 dark:text-gray-300 hover:text-primary-500 mr-4"
+              class="inline-flex text-gray-700 dark:text-gray-300 hover:text-primary-500 ltr:mr-4 rtl:ml-4"
             >
               <IconTwitter class="w-5 h-5" />
             </a>
@@ -59,12 +59,12 @@
               rel="noopener noreferrer"
               title="Github"
               name="Github"
-              class="inline-flex text-gray-700 dark:text-gray-300 hover:text-primary-500 mr-4"
+              class="inline-flex text-gray-700 dark:text-gray-300 hover:text-primary-500 ltr:mr-4 rtl:ml-4"
             >
               <IconGithub class="w-5 h-5" />
             </a>
 
-            <AppLangSwitcher class="mr-4" />
+            <AppLangSwitcher class="ltr:mr-4 rtl:ml-4" />
             <AppColorSwitcher />
           </div>
         </li>

--- a/packages/theme-docs/src/components/app/AppPrevNext.vue
+++ b/packages/theme-docs/src/components/app/AppPrevNext.vue
@@ -11,7 +11,8 @@
       :to="localePath(prev.to)"
       class="text-primary-500 font-bold hover:underline flex items-center justify-start"
     >
-      <IconArrowLeft class="w-4 h-4 mr-1 flex-shrink-0" />
+      <IconArrowLeft class="rtl:hidden w-4 h-4 mr-1 flex-shrink-0" />
+      <IconArrowRight class="ltr:hidden w-4 h-4 ml-1 flex-shrink-0" />
       <span class="truncate">{{ prev.title }}</span>
     </NuxtLink>
     <span v-else>&nbsp;</span>
@@ -22,7 +23,8 @@
       class="text-primary-500 font-bold hover:underline flex items-center justify-end"
     >
       <span class="truncate">{{ next.title }}</span>
-      <IconArrowRight class="w-4 h-4 ml-1 flex-shrink-0" />
+      <IconArrowRight class="rtl:hidden w-4 h-4 ml-1 flex-shrink-0" />
+      <IconArrowLeft class="ltr:hidden w-4 h-4 mr-1 flex-shrink-0" />
     </NuxtLink>
     <span v-else>&nbsp;</span>
   </div>

--- a/packages/theme-docs/src/components/app/AppSearch.vue
+++ b/packages/theme-docs/src/components/app/AppSearch.vue
@@ -8,14 +8,14 @@
     >
       <label for="search" class="sr-only">Search</label>
       <div class="relative">
-        <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+        <div class="absolute inset-y-0 ltr:left-0 rtl:right-0 pl-3 flex items-center pointer-events-none">
           <IconSearch class="h-5 w-5 text-gray-500" />
         </div>
         <input
           id="search"
           ref="search"
           v-model="q"
-          class="block w-full pl-10 pr-3 py-2 truncate leading-5 placeholder-gray-500 border border-transparent text-gray-700 dark:text-white dark-focus:text-white focus:border-gray-300 dark-focus:border-gray-700 rounded-md focus:outline-none focus:bg-white dark-focus:bg-gray-900 bg-gray-200 dark:bg-gray-800"
+          class="block w-full ltr:pl-10 rtl:pr-10 ltr:pr-3 rtl:pl-3 py-2 truncate leading-5 placeholder-gray-500 border border-transparent text-gray-700 dark:text-white dark-focus:text-white focus:border-gray-300 dark-focus:border-gray-700 rounded-md focus:outline-none focus:bg-white dark-focus:bg-gray-900 bg-gray-200 dark:bg-gray-800"
           :class="{ 'rounded-b-none': focus && (searching || results.length) }"
           :placeholder="$t('search.placeholder')"
           type="search"

--- a/packages/theme-docs/src/components/app/AppSearchAlgolia.vue
+++ b/packages/theme-docs/src/components/app/AppSearchAlgolia.vue
@@ -152,6 +152,8 @@ export default {
   --docsearch-searchbox-focus-background: var(--color-gray-200);
   --docsearch-hit-color: var(--color-gray-700);
   --docsearch-muted-color: var(--color-gray-500);
+
+  direction: initial;
 }
 
 .DocSearch-Button {

--- a/packages/theme-docs/src/components/app/AppToc.vue
+++ b/packages/theme-docs/src/components/app/AppToc.vue
@@ -4,7 +4,7 @@
       <nav
         class="py-4 lg:py-8"
         :class="{
-          'lg:pl-8 lg:pr-2': settings.layout !== 'single',
+          'lg:ltr:pl-8 lg:ltr:pr-2 lg:rtl:pl-8 lg:rtl:pr-2': settings.layout !== 'single',
           'lg:px-8': settings.layout === 'single'
         }"
       >
@@ -22,10 +22,10 @@
           >
             <a
               :href="`#${link.id}`"
-              class="block text-sm scrollactive-item transition-padding ease-in-out duration-300 hover:pl-1"
+              class="block text-sm scrollactive-item transition-padding ease-in-out duration-300 hover:ltr:pl-1 hover:rtl:pr-1"
               :class="{
                 'py-2': link.depth === 2,
-                'ml-2 pb-2': link.depth === 3
+                'ltr:ml-2 rtl:mr-2 pb-2': link.depth === 3
               }"
             >{{ link.text }}</a>
           </li>

--- a/packages/theme-docs/src/components/global/base/Alert.vue
+++ b/packages/theme-docs/src/components/global/base/Alert.vue
@@ -1,10 +1,10 @@
 <template>
-  <div class="alert border-l-4 p-4 mb-4 mt-4" :class="`alert-${type}`">
+  <div class="alert ltr:border-l-4 rtl:border-r-4 p-4 mb-4 mt-4" :class="`alert-${type}`">
     <div class="flex items-start">
       <div class="flex-shrink-0">
         <component :is="icon" class="alert-icon mt-px w-6 h-6" />
       </div>
-      <div class="flex-grow ml-2 overflow-auto alert-content">
+      <div class="flex-grow ltr:ml-2 rtl:mr-2 overflow-auto alert-content">
         <slot />
       </div>
     </div>

--- a/packages/theme-docs/src/components/global/base/List.vue
+++ b/packages/theme-docs/src/components/global/base/List.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <div v-for="(item, i) in items" :key="i" class="mt-3 flex">
-      <span :class="`list-${type}`" class="mt-px mr-3 flex-shrink-0">
+      <span :class="`list-${type}`" class="mt-px ltr:mr-3 rtl:ml-3 flex-shrink-0">
         <component :is="iconName" class="h-6 w-6" />
       </span>
       {{ item }}

--- a/packages/theme-docs/src/tailwind.config.js
+++ b/packages/theme-docs/src/tailwind.config.js
@@ -146,12 +146,14 @@ module.exports = ({ docsOptions, nuxt }) => ({
   },
   variants: {
     margin: ['responsive', 'last', 'direction'],
-    padding: ['responsive', 'hover'],
+    padding: ['responsive', 'hover', 'direction'],
     backgroundColor: ['responsive', 'hover', 'focus', 'dark', 'dark-focus'],
     textColor: ['responsive', 'hover', 'focus', 'dark', 'dark-hover', 'dark-focus'],
     borderColor: ['responsive', 'hover', 'focus', 'dark', 'dark-focus'],
     borderWidth: ['responsive', 'first', 'last', 'direction'],
-    typography: ['responsive', 'dark']
+    typography: ['responsive', 'dark'],
+    inset: ['responsive', 'direction'],
+    display: ['responsive', 'direction']
   },
   plugins: [
     plugin(function ({ addVariant, prefix, e }) {

--- a/packages/theme-docs/src/tailwind.config.js
+++ b/packages/theme-docs/src/tailwind.config.js
@@ -145,12 +145,12 @@ module.exports = ({ docsOptions, nuxt }) => ({
     })
   },
   variants: {
-    margin: ['responsive', 'last'],
+    margin: ['responsive', 'last', 'direction'],
     padding: ['responsive', 'hover'],
     backgroundColor: ['responsive', 'hover', 'focus', 'dark', 'dark-focus'],
     textColor: ['responsive', 'hover', 'focus', 'dark', 'dark-hover', 'dark-focus'],
     borderColor: ['responsive', 'hover', 'focus', 'dark', 'dark-focus'],
-    borderWidth: ['responsive', 'first', 'last'],
+    borderWidth: ['responsive', 'first', 'last', 'direction'],
     typography: ['responsive', 'dark']
   },
   plugins: [
@@ -203,7 +203,8 @@ module.exports = ({ docsOptions, nuxt }) => ({
         zIndex: false,
         opacity: false
       }
-    )
+    ),
+    require('tailwindcss-dir')()
   ],
   purge: {
     // Learn more on https://tailwindcss.com/docs/controlling-file-size/#removing-unused-css

--- a/yarn.lock
+++ b/yarn.lock
@@ -14548,7 +14548,14 @@ tailwind-css-variables@^2.0.3:
   resolved "https://registry.yarnpkg.com/tailwind-css-variables/-/tailwind-css-variables-2.0.3.tgz#3648e5fbadd40bb3393843828336b62c6915d529"
   integrity sha512-GYf4fQgtahUao7JN87hrEaeJgRnuksbP/5GOtMxnWylDsCIZ02CQJ13/8MFTCH21LhLxRBD8BCDxkwEmXbqwlg==
 
-tailwindcss@^1.9.5:
+tailwindcss-dir@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/tailwindcss-dir/-/tailwindcss-dir-4.0.0.tgz#72ddc8792225426c22de70f6d82a18173d843400"
+  integrity sha512-G5orTODS8sDQOZqKa2Q4Ey/F4nlxK1mTZm02iKHLxZaNjpboPews/h2KUksC5KbgIVrpmOe1hqcNYZJy07ftwA==
+  dependencies:
+    tailwindcss "^1.0.1"
+
+tailwindcss@^1.0.1, tailwindcss@^1.9.5:
   version "1.9.6"
   resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-1.9.6.tgz#0c5089911d24e1e98e592a31bfdb3d8f34ecf1a0"
   integrity sha512-nY8WYM/RLPqGsPEGEV2z63riyQPcHYZUJpAwdyBzVpxQHOHqHE+F/fvbCeXhdF1+TA5l72vSkZrtYCB9hRcwkQ==


### PR DESCRIPTION
This PR make the theme RTL compatible by adding the following block of code:

```js
...
  head: {
    bodyAttrs: {
      dir: 'rtl'
    }
  },
...
```
to the `nuxt.config.js` file.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
**Describe your changes in detail**
This PR adds `tailwindcss-dir` package to detect `ltr` and `RTL` version. Required TailwindCSS classes have been added so it won't break the already working LTR version.

**Why is this change required? What problem does it solve?**
An RTL version is not necessary at the moment for the documentation(s), as I have not seen the RTL version of documentations (neither website nor translations). But if it's in your internal team checklist for future features, this PR can be helpful.

I was going to use this theme for a Persian (RTL) website, and I thought this PR might be welcome. But there are some parts of it that might need more work and adjustments, such as Algolia search and tailwindcss-typography. As tailwindcss typography has an open issue for RTL support (https://github.com/tailwindlabs/tailwindcss-typography/issues/78)


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
