### PR TITLE
fix(content): add missing types

### DIFF
--- a/packages/content/types/index.d.ts
+++ b/packages/content/types/index.d.ts
@@ -28,6 +28,8 @@ interface IContentOptions {
   fullTextSearchFields?: extendOrOverwrite<Array<string>>;
   nestedProperties?: extendOrOverwrite<Array<string>>;
   markdown?: {
+    tocDepth?: number;
+    tocTags?: extendOrOverwrite<Array<string>>;
     remarkPlugins?: extendOrOverwrite<Array<string | [string, Record<string, unknown>]>>;
     rehypePlugins?: extendOrOverwrite<Array<string | [string, Record<string, unknown>]>>;
     prism?: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->

Fix #600.
I forgot to add types of `options.markdown.tocDepth` and `options.markdown.tocTags` ([link](https://github.com/nuxt/content/blob/b2f45db0b16ecdf21981f6eff0afdc851829ccbe/packages/content/lib/utils.js#L36-L54), [link](https://github.com/nuxt/content/blob/b2f45db0b16ecdf21981f6eff0afdc851829ccbe/packages/content/lib/utils.js#L87)).

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)

There is no tests for types, as far as I see.
By the way, the tests fails in highlighter in the latest commit of `dev` branch of `nuxt/content` (b2f45db).
Since this branch is created from `dev`, PR CI will fail too.