### PR TITLE
feat(theme-docs): support contents hidden in menu

### DIFF
--- a/docs/content/en/themes/docs.md
+++ b/docs/content/en/themes/docs.md
@@ -340,6 +340,8 @@ To make it work properly, make sure to include these properties in the front-mat
   - Adds a subtitle under the page title
 - `badge` (`String`) <badge>v0.5.0+</badge>
   - Adds a badge next to the page title
+- `hiddenInMenu` (`Boolean`) <!-- set badge later -->
+  - Hides the page in the left menu (defaults to `false`)
 
 ### Example
 

--- a/packages/theme-docs/src/index.js
+++ b/packages/theme-docs/src/index.js
@@ -135,6 +135,7 @@ export default (userConfig) => {
     const slug = document.slug.replace(/^index/, '')
 
     document.to = `${dir}/${slug}`
+    document.hiddenInMenu = document.hiddenInMenu || false
   }
 
   return config

--- a/packages/theme-docs/src/pages/_.vue
+++ b/packages/theme-docs/src/pages/_.vue
@@ -52,11 +52,17 @@ export default {
       return error({ statusCode: 404, message: 'Page not found' })
     }
 
-    const [prev, next] = await $content(app.i18n.locale, { deep: true })
-      .only(['title', 'slug', 'to'])
-      .sortBy('position', 'asc')
-      .surround(document.slug, { before: 1, after: 1 })
-      .fetch()
+    let prev
+    let next
+
+    if (!document.hiddenInMenu) {
+      [prev, next] = await $content(app.i18n.locale, { deep: true })
+        .where({ hiddenInMenu: false })
+        .only(['title', 'slug', 'to'])
+        .sortBy('position', 'asc')
+        .surround(document.slug, { before: 1, after: 1 })
+        .fetch()
+    }
 
     return {
       document,

--- a/packages/theme-docs/src/store/index.js
+++ b/packages/theme-docs/src/store/index.js
@@ -73,7 +73,7 @@ export const actions = {
     if (process.dev === false && state.categories[this.$i18n.locale]) {
       return
     }
-    const docs = await this.$content(this.$i18n.locale, { deep: true }).only(['title', 'menuTitle', 'category', 'slug', 'version', 'to']).sortBy('position', 'asc').fetch()
+    const docs = await this.$content(this.$i18n.locale, { deep: true }).where({ hiddenInMenu: false }).only(['title', 'menuTitle', 'category', 'slug', 'version', 'to']).sortBy('position', 'asc').fetch()
     if (state.releases.length > 0) {
       docs.push({ slug: 'releases', title: 'Releases', category: 'Community', to: '/releases' })
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->

Resolves #626.
Implementation is inspired by https://github.com/nuxt/content/commit/f67ec7de49db6d49692d836e1d09f944e33da52f.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)

Currently, there is no unit tests for theme-docs.
Instead, I tested in the following way:

~- Run `yarn create nuxt-content-docs test-hidden-in-menu`~
~- Link `yarn link @nuxt/content-theme-docs` in my local~
~- Run `yarn run dev`~
~- See Setup page is shown in the menu~
~- Set `hiddenInMenu: false` to `setup.md`~
~- See Setup page is hidden in the menu~
~- See Setup page is searchable in the search box (I didn't test with Algolia search)~

_Updated Test:_

- Run `yarn create nuxt-content-docs test-hidden-in-menu`
- Run `yarn link @nuxt/content-theme-docs` in my local
- Create markdown files:
  - `index.md` (`position`: 1)
  - `2.md` (`position`: 2)
  - `3.md` (`position`: 3, `hiddenInMenu`: true)
  - `4.md` (`position`: 4)
  - `5.md` (`position`: 5)
- Run `yarn run dev`
- Check that `3.md` is hidden in the sidebar
- Check that `3.md` is accessible via the search box in the header
- Check that both links (prev, next) are not shown in `3.md`
- Check that `4.md` is shown as next link in `2.md`, instead of `3.md` (being consistent with what the sidebar shows)
- Check that `2.md` is shown as prev link in `4.md`, instead of `3.md` (being consistent with what the sidebar shows)
- Check that only next link is shown in `index.md` (existing behavior is not influenced)
- Check that only prev link is shown in `5.md` (existing behavior is not influenced)