### PR TITLE
Fixed a bug in named slot rendering

### DIFF
--- a/packages/content/templates/nuxt-content.js
+++ b/packages/content/templates/nuxt-content.js
@@ -94,7 +94,7 @@ function isTemplate (node) {
 function getSlotName (node) {
   let name = ''
   for (const propName of Object.keys(node.props)) {
-    if (!propName.startsWith('#') && !propName.startsWith('v-slot:')) { return }
+    if (!propName.startsWith('#') && !propName.startsWith('v-slot:')) { continue }
     name = propName.split(/[:#]/, 2)[1]
     break
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->
There was a bug in named slot rendering: if there was more than one prop in the slot and name was not the first one, it would be considered nameless.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
