### PR TITLE
feat(content): add path for custom parsers

### DIFF
--- a/packages/content/lib/database.js
+++ b/packages/content/lib/database.js
@@ -200,7 +200,7 @@ class Database extends Hookable {
     // Collect data from file
     let data = []
     try {
-      data = await parser(file.data)
+      data = await parser(file.data, { path: file.path })
       // Force data to be an array
       data = Array.isArray(data) ? data : [data]
     } catch (err) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
This PR adds a second param for custom parsers that is an object (for future extend-ability) with the file path.

Here is my use case:

I'm building a photography portfolio website where I want to drop images in the content folder. I have a custom parser that extracts metadata from the jpg. Sadly I can't get the utf-8 read file content to parse correctly on any of the packages I have found on npm. Most of them just take the file path and handle the reading themselves.


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
