### PR TITLE
docs: french translation

### DIFF
--- a/docs/content/fr/examples/basic.md
+++ b/docs/content/fr/examples/basic.md
@@ -1,0 +1,11 @@
+---
+title: Exemple d'utilisation de base
+menuTitle: Utilisation de base
+description: "Exemple en direct d'utilisation de base de Nuxt Content sur CodeSandbox."
+position: 9
+category: Exemples
+csb_link: https://codesandbox.io/embed/nuxt-content-playground-l164h?hidenavigation=1&theme=dark
+fullscreen: true
+---
+
+<code-sandbox :src="csb_link"></code-sandbox>

--- a/docs/content/fr/examples/docs-theme.md
+++ b/docs/content/fr/examples/docs-theme.md
@@ -1,0 +1,11 @@
+---
+title: Exemple de thèmes de documentation
+menuTitle: Thème de documentation
+description: 'Exemple en direct du thème de la documentation Nuxt Content sur CodeSandbox.'
+position: 11
+category: Exemples
+csb_link: https://codesandbox.io/embed/nuxt-content-docs-theme-playground-inwxb?hidenavigation=1&theme=dark
+fullscreen: true
+---
+
+<code-sandbox :src="csb_link"></code-sandbox>

--- a/docs/content/fr/examples/tailwindcss-typography.md
+++ b/docs/content/fr/examples/tailwindcss-typography.md
@@ -1,0 +1,11 @@
+---
+title: Exemple TailwindCSS Typography
+menuTitle: TailwindCSS Typography
+description: 'Exemple en direct de contenu Nuxt avec le plugin TailwindCSS Typography sur CodeSandbox.'
+position: 10
+category: Exemples
+csb_linkx: https://codesandbox.io/embed/nuxt-content-tailwindcss-typography-twhtf?hidenavigation=1&theme=dark
+fullscreen: true
+---
+
+<code-sandbox :src="csb_linkx"></code-sandbox>

--- a/docs/content/fr/integrations.md
+++ b/docs/content/fr/integrations.md
@@ -1,0 +1,287 @@
+---
+title: Intégrations
+description: "Apprenez comment utiliser @nuxt/content avec d'autres modules."
+position: 13
+category: Community
+---
+
+## @nuxtjs/feed
+
+Dans le cas d'articles, le contenu peut être utilisé pour générer des fils d'actualités 
+en utilisant le module [@nuxtjs/feed](https://github.com/nuxt-community/feed-module).
+
+<alert type="info">
+
+Pour utiliser `$content` à l'intérieur de l'option `feed`, vous devez ajouter `@nuxt/content` avant `@nuxtjs/feed` dans la propriété `modules`. 
+
+</alert>
+
+Vous pouvez accéder à votre flux via : `baseUrl + baseLinkFeedArticles + file`
+
+Pour RSS: ```https://mywebsite.com/feed/articles/rss.xml```
+
+Pour JSON: ```https://mywebsite.com/feed/articles/feed.json```
+
+**Exemple 1**
+
+```js
+export default {
+  modules: [
+    '@nuxt/content',
+    '@nuxtjs/feed'
+  ],
+
+  feed () {
+    const baseUrlArticles = 'https://mywebsite.com/articles'
+    const baseLinkFeedArticles = '/feed/articles'
+    const feedFormats = {
+      rss: { type: 'rss2', file: 'rss.xml' },
+      json: { type: 'json1', file: 'feed.json' },
+    }
+    const { $content } = require('@nuxt/content')
+
+    const createFeedArticles = async function (feed) {
+      feed.options = {
+        title: 'My Blog',
+        description: 'I write about technology',
+        link: baseUrlArticles,
+      }
+      const articles = await $content('articles').fetch()
+
+      articles.forEach((article) => {
+        const url = `${baseUrlArticles}/${article.slug}`
+
+        feed.addItem({
+          title: article.title,
+          id: url,
+          link: url,
+          date: article.published,
+          description: article.summary,
+          content: article.summary,
+          author: article.authors,
+        })
+      })
+    }
+
+    return Object.values(feedFormats).map(({ file, type }) => ({
+      path: `${baseLinkFeedArticles}/${file}`,
+      type: type,
+      create: createFeedArticles,
+    }))
+  }
+}
+```
+
+L'approche ci-dessus fonctionne bien pour certains cas d'utilisation. Cependant, si vous utilisez `npm run generate`, cette approche produira une erreur.
+
+Ou, si vous souhaitez inclure le corps de l'article en tant que contenu, y compris le contenu des composants si vous mélangez vos composants Vue et votre markdown, vous devrez aborder cela différemment.
+
+Une façon possible pour faire cela est d'utiliser l'approche documentée de [@nuxtjs/feed](https://github.com/nuxt-community/feed-module) qui fonctionnera avec `npm run generate` et utilisera le processus de Nuxt pour inclure le contenu. Voici comment procéder.
+
+Tout d'abord, utilisez l'approche basée sur les tableaux pour déclarer vos flux comme indiqué dans la documentation @nuxtjs/feed. Le tableau de flux se compose d'objets avec 5 valeurs possibles.
+
+1. Le `path` qui le chemin de votre nom de domaine vers le flux de votre document.
+2. Une fonction qui générera le contenu du flux.
+3. Le `cacheTime` qui comme son nom l'indique détermine quand le flux doit être actualisé.
+4. Le `type` qui détermine quel type de flux rss que vous souhaitez générer.
+5. Les `data` qui sont fournies comme argument à la fonction (la propriété args dans l'exemple ci-dessous)
+
+```js
+modules: [    
+    '@nuxt/content',
+    '@nuxtjs/feed'    
+  ],
+
+  feed: [
+    {
+      path: '/feed.xml',
+      async create(feed, args) => {  
+        // create the feed
+      },
+      cacheTime: 1000 * 60 * 15,
+      type: 'rss2',
+      data: [ 'some', 'info' ]
+    },
+    {
+      path: '/feed.json',
+      async create(feed, args) => {  
+        // create the feed
+      },
+      cacheTime: 1000 * 60 * 15,
+      type: 'json1',
+      data: [ 'other', 'info' ]
+    }
+  ],
+```
+
+Vous pouvez tirer le meilleur de l'API nuxt/content, mais en déclarant votre fonction `create` séparément, puis en la fournissant à l'objet de tableau de flux. La fonction `create` peut être déclarée en haut du fichier nuxt.config.js, ou séparément dans un autre répertoire et exportée. Cette fonction `create` s'exécute _après_ que le processus Nuxt a compilé les composants markdown et Vue en HTML. Cela nous permet d'extraire ce contenu et de le fournir au flux.
+
+**Exemple 2**
+
+```js
+// this Exemple declares the function at the top of the nuxt.config.js file
+const fs = require('fs').promises;
+const path = require('path');
+
+let posts = [];
+
+const constructFeedItem = async (post, dir, hostname) => {  
+  //note the path used here, we are using a dummy page with an empty layout in order to not send that data along with our other content
+  const filePath = path.join(__dirname, `dist/rss/${post.slug}/index.html`); 
+  const content = await fs.readFile(filePath, 'utf8');
+  const url = `${hostname}/${dir}/${post.slug}`;
+  return {
+    title: post.title,
+    id: url,
+    link: url,
+    description: post.description,
+    content: content
+  }
+} 
+
+const create = async (feed, args) => {
+  const [filePath, ext] = args;  
+  const hostname = process.NODE_ENV === 'production' ? 'https://my-production-domain.com' : 'http://localhost:3000';
+  feed.options = {
+    title: "My Blog",
+    description: "Blog Stuff!",
+    link: `${hostname}/feed.${ext}`
+  }
+  const { $content } = require('@nuxt/content')
+  if (posts === null || posts.length === 0)
+    posts = await $content(filePath).fetch();
+
+  for (const post of posts) {
+    const feedItem = await constructFeedItem(post, filePath, hostname);
+    feed.addItem(feedItem);
+  }
+  return feed;
+}
+
+export default {
+...
+  modules: [    
+    '@nuxt/content',
+    '@nuxtjs/feed'    
+  ],
+  feed: [
+    {
+      path: '/feed.xml',
+      create
+      cacheTime: 1000 * 60 * 15,
+      type: 'rss2',
+      data: [ 'blog', 'xml' ]
+    },
+  ],  
+...
+}
+```
+
+Il y a cependant deux inconvénients à cette approche :
+
+1. Puisque vous lisez la totalité de la page générée, vous pouvez récupérer du contenu indésirable tel que celui de l'en-tête et du pied de page. Une façon de résoudre ce problème consiste à créer une page factice en utilisant une mise en page vide afin que seul le contenu que vous souhaitez inclure dans le flux rss soit utilisé.
+2. rss2 et XML fonctionnent bien car le HTML est automatiquement encodé. Cependant, json1 et json peuvent nécessiter du travail supplémentaire pour que le contenu puisse être transmis.
+
+N'oubliez pas également que si vous n'utilisez pas de contenu mixte dans votre markdown (donc si vous n'utilisez que du markdown), il est beaucoup plus facile d'inclure uniquement celui-ci. Vous pouvez récupérer le markdown en utilisant ce hook dans votre nuxt.config.js :
+
+**Exemple 3**
+
+```js
+export default {
+...
+  hooks: {
+    'content:file:beforeInsert': (document) => {
+      if (document.extension === '.md') {      
+        document.bodyPlainText = document.text;
+      }
+    },
+  },
+...
+}
+```
+
+Et puis dans votre fonction `create` :
+
+```js
+
+const constructFeedItem = (post, dir, hostname) => {  
+  const url = `${hostname}/${dir}/${post.slug}`;
+  return {
+    title: post.title,
+    id: url,
+    link: url,
+    description: post.description,
+    content: post.bodyPlainText
+  }
+} 
+
+const create = async (feed, args) => {
+  const [filePath, ext] = args;  
+  const hostname = process.NODE_ENV === 'production' ? 'https://my-production-domain.com' : 'http://localhost:3000';
+  feed.options = {
+    title: "My Blog",
+    description: "Blog Stuff!",
+    link: `${hostname}/feed.${ext}`
+  }
+  const { $content } = require('@nuxt/content')
+  if (posts === null || posts.length === 0)
+    posts = await $content(filePath).fetch();
+
+  for (const post of posts) {
+    const feedItem = await constructFeedItem(post, filePath, hostname);
+    feed.addItem(feedItem);
+  }
+  return feed;
+}
+```
+
+Récupérer uniquement le markdown fonctionne très bien si vous utilisez le flux pour intégrer [dev.to](https://dev.to/) ou [medium](https://medium.com/) puisque ces deux sites utiliser markdown dans leurs éditeurs.
+
+
+## @nuxtjs/sitemap
+
+Vous souhaiterez peut-être générer un plan du site contenant des liens vers tous vos articles. Vous pouvez le faire de la même manière que vous avez généré votre flux.
+
+**Exemple 1**
+
+Le module du plan du site doit toujours être déclaré en dernier afin que les routes créées par d'autres modules puissent être incluses. Après avoir déclaré le module, vous devez configurer le plan du site en ajoutant l'objet de configuration du plan du site dans nuxt.config.js. Vous devez fournir le nom d'hôte et vous pouvez éventuellement inclure toutes les routes générées dynamiquement à partir de nuxt-content.
+La propriété routes accepte une fonction asynchrone qui renvoie un tableau d'URL.
+
+```js
+const createSitemapRoutes = async () => {
+  let routes = [];
+  const { $content } = require('@nuxt/content')
+  if (posts === null || posts.length === 0)
+    posts = await $content('blog').fetch();
+  for (const post of posts) {
+    routes.push(`blog/${post.slug}`);
+  }
+  return routes;
+}
+
+export default {
+...
+  modules: [
+    '@nuxt/content',
+    '@nuxtjs/sitemap'
+  ],
+  sitemap: {
+    hostname: 'https://my-domain-name.com',
+    gzip: true,
+    routes: createSitemapRoutes
+  },
+...
+}
+```
+
+## Forestry CMS
+
+Vous pouvez intégrer Nuxt Content avec [Forestry](https://forestry.io) en quelques étapes.
+
+<alert>
+
+Nous vous recommandons de jeter un œil à ce tutoriel réalisé par [Pascal Cauhépé](https://twitter.com/eQRoeil)
+
+👉 &nbsp;https://nuxt-content-and-forestry.netlify.app
+
+</alert>

--- a/docs/content/fr/snippets.md
+++ b/docs/content/fr/snippets.md
@@ -99,7 +99,7 @@ export default {
 </script>
 ```
 
-> Vérifier la [documentatio de recherche](/fetching#searchfield-value).
+> Consulter la [documentatio de recherche](/fetching#searchfield-value).
 
 ### Prev et Next
 
@@ -136,7 +136,7 @@ export default {
 </script>
 ```
 
-> Vérifier la [documentation de surround](/fetching#surroundslug-options).
+> Consulter la [documentation de surround](/fetching#surroundslug-options).
 
 ### Table des matières
 
@@ -169,7 +169,7 @@ export default {
 </script>
 ```
 
-> Vérifiez la [documentation de la table des matières](/writing#table-of-contents).
+> Consulter la [documentation de la table des matières](/writing#table-of-contents).
 
 ### Routes dynamiques
 

--- a/docs/content/fr/snippets.md
+++ b/docs/content/fr/snippets.md
@@ -1,0 +1,308 @@
+---
+title: Extraits
+description: 'Apprenez comment implémenter @nuxt/content dans votre application avec ces extraits de code.'
+position: 12
+category: Community
+subtitle: 'Découvrez ces extraits de code qui peuvent être copiés directement dans votre application.'
+version: 1.1
+---
+
+## Utilisation
+
+### asyncData
+
+```js
+export default {
+  async asyncData({ $content, params }) {
+    const article = await $content('articles', params.slug).fetch()
+
+    return {
+      article
+    }
+  }
+}
+```
+
+### head
+
+Ajouter des métadatas en fonction du titre et de la description définie dans [front-matter](https://content.nuxtjs.org/writing#front-matter) :
+
+```js
+export default {
+  async asyncData({ $content, params }) {
+    const article = await $content('articles', params.slug).fetch()
+
+    return {
+      article
+    }
+  },
+  head() {
+    return {
+      title: this.article.title,
+      meta: [
+        { hid: 'description', name: 'description', content: this.article.description },
+        // Open Graph
+        { hid: 'og:title', property: 'og:title', content: this.article.title },
+        { hid: 'og:description', property: 'og:description', content: this.article.description },
+        // Twitter Card
+        { hid: 'twitter:title', name: 'twitter:title', content: this.article.title },
+        { hid: 'twitter:description', name: 'twitter:description', content: this.article.description }
+      ]
+    }
+  }
+}
+```
+
+## Fonctionnalités
+
+### Recherche
+
+Ajoutez un composant de recherche à l'aide de watch :
+
+```vue
+<template>
+  <div>
+    <input v-model="query" type="search" autocomplete="off" />
+
+    <ul v-if="articles.length">
+      <li v-for="article of articles" :key="article.slug">
+        <NuxtLink :to="{ name: 'blog-slug', params: { slug: article.slug } }">{{ article.title }}</NuxtLink>
+      </li>
+    </ul>
+  </div>
+</template>
+
+<script>
+export default {
+  data () {
+    return {
+      query: '',
+      articles: []
+    }
+  },
+  watch: {
+    async query (query) {
+      if (!query) {
+        this.articles = []
+        return
+      }
+
+      this.articles = await this.$content('articles')
+        .only(['title', 'slug'])
+        .sortBy('createdAt', 'asc')
+        .limit(12)
+        .search(query)
+        .fetch()
+    }
+  }
+}
+</script>
+```
+
+> Vérifier la [documentatio de recherche](/fetching#searchfield-value).
+
+### Prev et Next
+
+Ajoutez les liens précédents et suivants en utilisant la méthode `surround` :
+
+```vue
+<template>
+  <div>
+    <NuxtLink v-if="prev" :to="{ name: 'blog-slug', params: { slug: prev.slug } }">
+      {{ prev.title }}
+    </NuxtLink>
+
+    <NuxtLink v-if="next" :to="{ name: 'blog-slug', params: { slug: next.slug } }">
+      {{ next.title }}
+    </NuxtLink>
+  </div>
+</template>
+
+<script>
+export default {
+  async asyncData({ $content, params }) {
+    const [prev, next] = await $content('articles')
+      .only(['title', 'slug'])
+      .sortBy('createdAt', 'asc')
+      .surround(params.slug)
+      .fetch()
+
+    return {
+      prev,
+      next
+    }
+  }
+}
+</script>
+```
+
+> Vérifier la [documentation de surround](/fetching#surroundslug-options).
+
+### Table des matières
+
+Ajoutez une table des matières en parcourant le tableau toc et utilisez l'`id` pour créer un lien vers celui-ci ainsi que le `text` pour afficher le titre. Nous pouvons utiliser la propriété `depth` pour styliser les titres différemment :
+
+```vue
+<template>
+  <ul>
+    <li
+      v-for="link of article.toc"
+      :key="link.id"
+      :class="{ 'toc2': link.depth === 2, 'toc3': link.depth === 3 }"
+    >
+      <NuxtLink :to="`#${link.id}`">{{ link.text }}</NuxtLink>
+    </li>
+  </ul>
+</template>
+
+<script>
+export default {
+  async asyncData({ $content, params }) {
+    const article = await $content('articles', params.slug)
+      .fetch()
+
+    return {
+      article
+    }
+  }
+}
+</script>
+```
+
+> Vérifiez la [documentation de la table des matières](/writing#table-of-contents).
+
+### Routes dynamiques
+
+Supposons que vous souhaitez créer une application avec des routes suivant la structure de fichier `content/`, vous pouvez le faire en créant un composant `pages/_.vue` :
+
+```vue[pages/_.vue]
+<script>
+export default {
+  async asyncData ({ $content, app, params, error }) {
+    const path = `/${params.pathMatch || 'index'}`
+    const [article] = await $content({ deep: true }).where({ path }).fetch()
+
+    if (!article) {
+      return error({ statusCode: 404, message: 'Article not found' })
+    }
+
+    return {
+      article
+    }
+  }
+}
+</script>
+```
+
+De cette façon, si vous suivez la route `/themes/docs`, il affichera le fichier `content/themes/docs.md`. Si vous avez besoin d'une page d'index pour vos répertoires, vous devez créer un fichier avec le même nom que le répertoire :
+
+```bash
+content/
+  themes/
+    docs.md
+  themes.md
+```
+
+<alert type="warning">
+
+N'oubliez pas de préfixer vos appels avec les paramètres de langues si vous utilisez `nuxt-i18n`.
+
+</alert>
+
+### Surligneurs personnalisés
+
+#### Highlight.js
+
+```js{}[nuxt.config.js]
+import highlightjs from 'highlight.js'
+
+const wrap = (code, lang) => `<pre><code class="hljs ${lang}">${code}</code></pre>`
+
+export default {
+  // Complete themes: https://github.com/highlightjs/highlight.js/tree/master/src/styles
+  css: ['highlight.js/styles/nord.css'],
+
+  modules: ['@nuxt/content'],
+
+  content: {
+    markdown: {
+      highlighter(rawCode, lang) {
+        if (!lang) {
+          return wrap(highlightjs.highlightAuto(rawCode).value, lang)
+        }
+        return wrap(highlightjs.highlight(lang, rawCode).value, lang)
+      }
+    }
+  }
+}
+```
+
+#### Shiki
+
+[Shiki](https://github.com/shikijs/shiki) est un surligneur de syntaxe qui utilise la grammaire TexMate et colore les éléments avec des thèmes VS Code. Il générera du HTML qui ressemble exactement à votre code dans VS Code.
+
+Vous n'avez pas besoin d'ajouter un style personnalisé, car Shiki l'intègrera dans le HTML.
+
+```js{}[nuxt.config.js]
+import shiki from 'shiki'
+
+export default {
+  modules: ['@nuxt/content'],
+
+  content: {
+    markdown: {
+      async highlighter() {
+        const highlighter = await shiki.getHighlighter({
+          // Complete themes: https://github.com/shikijs/shiki/tree/master/packages/themes
+          theme: 'nord'
+        })
+        return (rawCode, lang) => {
+          return highlighter.codeToHtml(rawCode, lang)
+        }
+      }
+    }
+  }
+}
+```
+
+#### Shiki Twoslash
+
+[Twoslash](https://github.com/microsoft/TypeScript-Website/tree/v2/packages/ts-twoslasher) est un format de balisage pour le code TypeScript. En interne, Twoslash utilise le compilateur TypeScript pour générer des informations riches en surlignage.
+
+Pour avoir une meilleure idée du fonctionnement de Twoslash, vous pouvez jeter un oeil à la [documentation officielle TypeScript](https://www.typescriptlang.org/docs/handbook/typescript-in-5-minutes-func.html#type-aliases) et survolez un exemple de code là-bas.
+
+Vous pouvez obtenir le même résultat en utilisant [Shiki Twoslash](https://github.com/microsoft/TypeScript-Website/tree/v2/packages/shiki-twoslash). Ce package est également celui qui alimente la documentation officielle de TypeScript.
+
+```js{}[nuxt.config.js]
+import {
+  createShikiHighlighter,
+  runTwoSlash,
+  renderCodeToHTML
+} from 'shiki-twoslash'
+
+export default {
+  modules: ['@nuxt/content'],
+
+  content: {
+    markdown: {
+      async highlighter() {
+        const highlighter = await createShikiHighlighter({
+          // Complete themes: https://github.com/shikijs/shiki/tree/master/packages/themes
+          theme: 'nord'
+        })
+        return (rawCode, lang) => {
+          const twoslashResults = runTwoSlash(rawCode, lang)
+          return renderCodeToHTML(
+            twoslashResults.code,
+            lang,
+            ['twoslash'],
+            {},
+            highlighter,
+            twoslashResults
+          )
+        }
+      }
+    }
+  }
+}
+```

--- a/docs/content/fr/themes.md
+++ b/docs/content/fr/themes.md
@@ -1,6 +1,0 @@
----
-title: Utiliser un thème (WIP)
-description: 'Ajoutez un thème et accélérez votre développement avec Nuxt et @nuxt/content'
-category: Thèmes
-position: 8
----

--- a/docs/content/fr/themes/docs.md
+++ b/docs/content/fr/themes/docs.md
@@ -1,0 +1,593 @@
+---
+title: Thèmes de documentation
+subtitle: 'Créez une belle documentation comme ce site Web en quelques secondes ✨'
+menuTitle: Docs
+description: 'Créez votre documentation avec le thème @ nuxt / content docs en quelques secondes!'
+category: Themes
+position: 8
+version: 1.2
+badge: 'v0.8.1'
+showcases:
+  - https://strapi.nuxtjs.org
+  - https://tailwindcss.nuxtjs.org
+  - https://storybook.nuxtjs.org
+  - https://firebase.nuxtjs.org
+  - https://pwa.nuxtjs.org
+  - https://image.nuxtjs.org
+  - https://http.nuxtjs.org
+  - https://cloudinary.nuxtjs.org
+  - https://i18n.nuxtjs.org
+  - https://snipcart.nuxtjs.org
+  - https://prismic.nuxtjs.org
+  - https://google-analytics.nuxtjs.org
+  - https://color-mode.nuxtjs.org
+  - https://mdx.nuxtjs.org
+  - https://sanity.nuxtjs.org
+  - https://speedcurve.nuxtjs.org
+---
+
+<alert type="info">
+
+Découvrez [l'exemple en direct](/Exemples/docs-theme)
+
+</alert>
+
+## Pour commencer
+
+Pour commencer rapidement, vous pouvez utiliser le package [create-nuxt-content-docs](https://github.com/nuxt/content/tree/dev/packages/create-nuxt-content-docs).
+
+<code-group>
+  <code-block label="Yarn" active>
+
+  ```bash
+  yarn create nuxt-content-docs <project-name>
+  ```
+
+  </code-block>
+  <code-block label="NPX">
+
+  ```bash
+  # Assurez-vous que npx est installé (npx est livré par défaut depuis NPM 5.2.0) ou npm v6.1 ou yarn.
+  npx create-nuxt-content-docs <project-name>
+  ```
+
+  </code-block>
+  <code-block label="NPM">
+
+  ```bash
+  # À partir de npm v6.1, vous pouvez faire :
+  npm init nuxt-content-docs <project-name>
+  ```
+
+  </code-block>
+</code-group>
+
+Il vous posera quelques questions (nom, titre, url, référentiel, etc.), une fois répondu, les dépendances seront installées. L'étape suivante consiste à accéder au dossier du projet et à le lancer:
+
+<code-group>
+  <code-block label="Yarn" active>
+
+  ```bash
+  cd <project-name>
+  yarn dev
+  ```
+
+  </code-block>
+  <code-block label="NPM">
+
+  ```bash
+  cd <project-name>
+  npm run dev
+  ```
+
+  </code-block>
+</code-group>
+
+L'application s'exécute maintenant sur [http://localhost:3000](http://localhost:3000). Bien joué !
+
+## Configuration manuelle
+
+Disons que nous créons la documentation d'un projet open-source dans le répertoire `docs/`.
+
+Le thème est une application NuxtJS classique, vous avez besoin de :
+
+### `package.json`
+
+> Ce fichier peut être créé avec `npm init`.
+
+Installez `nuxt` et `@nuxt/content-theme-docs`:
+
+<code-group>
+  <code-block label="Yarn" active>
+
+  ```bash
+  yarn add nuxt @nuxt/content-theme-docs
+  ```
+
+  </code-block>
+  <code-block label="NPM">
+
+  ```bash
+  npm install nuxt @nuxt/content-theme-docs
+  ```
+
+  </code-block>
+</code-group>
+
+**Exemple**
+
+```json[package.json]
+{
+  "name": "docs",
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "nuxt",
+    "build": "nuxt build",
+    "start": "nuxt start",
+    "generate": "nuxt generate"
+  },
+  "dependencies": {
+    "@nuxt/content-theme-docs": "^0.1.3",
+    "nuxt": "^2.14.0"
+  }
+}
+```
+
+### `nuxt.config.js`
+
+Importez la fonction de thème depuis `@nuxt/content-theme-docs`:
+
+```js[nuxt.config.js]
+import theme from '@nuxt/content-theme-docs'
+
+export default theme({
+  // [additional nuxt configuration]
+})
+```
+
+Le thème exporte une fonction pour configurer `nuxt.config.js` et vous permet d'ajouter / remplacer la configuration par défaut.
+
+> Consultez la documentation de [defu.arrayFn](https://github.com/nuxt-contrib/defu#array-function-merger) pour voir comment la configuration est fusionnée.
+
+**Exemple**
+
+```js[nuxt.config.js]
+import theme from '@nuxt/content-theme-docs'
+
+export default theme({
+  docs: {
+    primaryColor: '#E24F55'
+  },
+  loading: { color: '#00CD81' },
+  i18n: {
+    locales: () => [{
+      code: 'fr',
+      iso: 'fr-FR',
+      file: 'fr-FR.js',
+      name: 'Français'
+    }, {
+      code: 'en',
+      iso: 'en-US',
+      file: 'en-US.js',
+      name: 'English'
+    }],
+    defaultLocale: 'en'
+  },
+  buildModules: [
+    ['@nuxtjs/google-analytics', {
+      id: 'UA-12301-2'
+    }]
+  ]
+})
+```
+
+<alert type="warning">
+
+N'oubliez pas d'installer les dépendances des modules que vous ajoutez dans votre `nuxt.config.js`.
+
+</alert>
+
+### `tailwind.config.js`
+
+<badge>v0.4.0+</badge>
+
+Vous pouvez remplacer la [configuration du thème par défaut](https://github.com/nuxt/content/blob/dev/packages/theme-docs/src/tailwind.config.js) en créant le votre dans `tailwind.config.js`.
+
+La conception du thème est basé sur la couleur `primary` pour faciliter le remplacement.
+
+> Les couleurs par défaut sont générées en utilisant [theme-colors](https://github.com/nuxt-contrib/theme-colors) avec `docs.primaryColor` comme base. <badge>v0.7.0+</badge>
+
+**Exemple**
+
+```js[tailwind.config.js]
+module.exports = {
+  theme: {
+    extend: {
+      colors: {
+        primary: {
+          // ...
+        }
+      }
+    }
+  }
+}
+```
+
+### `content/`
+
+C'est ici que vous placez vos fichiers de contenu markdown. Vous pouvez en savoir plus dans la section suivante.
+
+### `static/`
+
+C'est ici que vous placez vos fichiers statiques comme le logo.
+
+<alert type="info">
+
+Vous pouvez ajouter un fichier `static/icon.png` pour activer [nuxt-pwa](https://pwa.nuxtjs.org/) et générer un favicon automatiquement.
+
+*L'icône doit être un carré d'au moins 512x512px*
+
+</alert>
+
+<alert type="info">
+
+Vous pouvez ajouter un fichier `static/preview.png` pour avoir une image de prévisualisation dans vos métas.
+
+*L'image doit être au moins 640×320px (1280×640px pour un meilleur affichage).*
+
+</alert>
+
+**Exemple**
+
+```bash
+content/
+  en/
+    index.md
+static/
+  icon.png
+nuxt.config.js
+package.json
+```
+
+## Contenu
+
+Une fois que vous avez configuré votre documentation, vous pouvez directement commencer à écrire votre contenu.
+
+> Consultez la documentation sur [l'écriture de contenu markdown](/writing#markdown)
+
+### Langues
+
+Le premier niveau de répertoires dans le dossier `content/` correspond aux paramètres de langues utilisés avec [nuxt-i18n](https://github.com/nuxt-community/i18n-module) défini dans votre `nuxt.config.js`. Par défaut, seuls les paramètres de langues par défaut `en` sont définis, vous devez créer un répertoire `content/en/` pour le faire fonctionner.
+
+Vous pouvez remplacer les paramètres de langues dans votre `nuxt.config.js`:
+
+```js[nuxt.config.js]
+import theme from '@nuxt/content-theme-docs'
+
+export default theme({
+  i18n: {
+    locales: () => [{
+      code: 'fr',
+      iso: 'fr-FR',
+      file: 'fr-FR.js',
+      name: 'Français'
+    }, {
+      code: 'en',
+      iso: 'en-US',
+      file: 'en-US.js',
+      name: 'English'
+    }],
+    defaultLocale: 'en'
+  }
+})
+```
+
+<alert type="warning">
+
+Comme expliqué dans la section [nuxt.config.js](/themes/docs#nuxtconfigjs), nous utilisons `defu.arrayFn` pour fusionner votre configuration. Vous pouvez remplacer le tableau `i18n.locales` en utilisant une fonction, ou vous pouvez passer un tableau à concaténer avec celui par défaut (qui n'a que le paramètre de langue `en`).
+
+</alert>
+
+### Routes
+
+Chaque page markdown dans le répertoire `content/{locale}/` deviendra une page et sera répertoriée dans la navigation de gauche.
+
+> Vous pouvez également placer vos fichiers markdown dans des sous-répertoires pour générer des sous-routes. <badge>v0.4.+</badge>
+
+**Exemple**
+
+```
+content/
+  en/
+    Exemples/
+      basic-usage.md
+    setup.md
+```
+
+**Result**
+
+```
+/Exemples/basic-usage
+/setup
+```
+
+> Vous pouvez jeter un oeil à notre [dossier de contenu docs](https://github.com/nuxt/content/tree/dev/docs/content/en) pour avoir un exemple
+
+### Front-matter
+
+Pour le faire fonctionner correctement, assurez-vous d'inclure ces propriétés dans la section front-matter de vos fichiers markdown.
+
+#### Champs obligatoires
+
+- `title` (`String`)
+  - Le titre de la page sera injecté dans les métas
+- `description` (`String`)
+  - La description de la page sera injecté dans les métas
+- `position` (`Number`)
+  - Ceci sera utilisé pour définir l'ordre des pages dans la navigation
+
+#### Champs facultatifs
+
+- `category` (`String`)
+  - Ceci sera utilisé pour regrouper les pages dans la navigation
+- `version` (`Float`)
+  - Alertez les utilisateurs que la page est nouvelle avec un badge. Une fois la page vue, la version est stockée dans le stockage local jusqu'à ce que vous l'incrémentiez
+- `fullscreen` (`Boolean`)
+  - Agrandit la page et masque la table des matières
+- `menuTitle` (`String`) <badge>v0.4.0+</badge>
+  - Remplace le titre de la page qui sera affiché dans le menu de gauche (par défaut `titre`)
+- `subtitle` (`String`) <badge>v0.5.0+</badge>
+  - Ajoute un sous-titre sous le titre de la page
+- `badge` (`String`) <badge>v0.5.0+</badge>
+  - Ajoute un badge à côté du titre de la page
+
+### Exemple
+
+```bash[content/en/index.md]
+---
+title: 'Introduction'
+description: 'Empower your NuxtJS application with this awesome module.'
+position: 1
+category: 'Getting started'
+version: 1.4
+fullscreen: false
+menuTitle: 'Intro'
+---
+
+Introducing my awesome Nuxt module!
+```
+
+## Réglages
+
+Vous pouvez créer un fichier `content/settings.json` pour configurer le thème.
+
+### Propriétés
+
+- `title` (`String`)
+  - Le titre de votre documentation
+- `url` (`String`)
+  - L'url où votre documentation sera déployée
+- `logo` (`String` | `Object`)
+  - Le logo de votre projet, peut-être un `Objet` pour définir un logo par [color mode](https://github.com/nuxt-community/color-mode-module)
+- `github` (`String`)
+  - Le repository GitHub de votre projet `owner/name` pour afficher la dernière version, la page des versions, le lien en haut et le `Editer cette page sur GitHub` sur chaque page. Exemple: `nuxt/content`.
+  - Pour GitHub Enterprise, vous devez attribuer une URL complète de votre projet sans barre oblique finale. Exemple: `https://hostname/repos/owner/name`. <badge>v0.6.0+</badge>
+- `githubApi` (`String`) <badge>v0.6.0+</badge>
+  - Pour GitHub Enterprise, en plus de `github`, vous devez attribuer une URL complète d'API de votre projet sans barre oblique finale. Exemple: `https://hostname/api/v3/repos/owner/name`.
+  - Les versions sont extraites de `${githubApi}/releases`.
+- `twitter` (`String`)
+  - Le nom d'utilisateur Twitter `@username` que vous souhaitez lier. Exemple: `@nuxt_js`
+- `defaultBranch` (`String`) <badge>v0.2.0+</badge>
+  - La branche par défaut du repository GitHub de votre projet, utilisée dans le lien `Editer cette page sur GitHub` sur chaque page (par défaut `main` s'il ne peut pas être détecté).
+- `defaultDir` (`String`) <badge>v0.6.0+</badge>
+  - The default dir of your project, used in the `Editer cette page sur GitHub` on each page (defaults to `docs`. Can be an empty string eg. `""`).
+  - Le répertoire par défaut de votre projet, utilisé dans `Editer cette page sur GitHub` sur chaque page (par défaut `docs`. Peut être une chaîne vide, par exemple. `""`).
+- `layout` (`String`) <badge>v0.4.0+</badge>
+  - La mise en page de votre documentation (par défaut, `default`). Peut être changé en `single` pour avoir un document d'une seule page.
+- `algolia` (`Object`) <badge>v0.7.0+</badge>
+  - Cette option vous permet d'utiliser [Algolia DocSearch](https://docsearch.algolia.com) pour remplacer la recherche intégrée simple. Pour l'activer, vous devez fournir au moins le `apiKey` et le `indexName` : 
+    ```json
+    "algolia": {
+        "apiKey": "<API_KEY>",
+        "indexName": "<INDEX_NAME>",
+        "langAttribute": "language"
+    }
+    ```
+  - Si vous utilisez `i18n`, assurez-vous que `<langAttribute>` est le même que le sélecteur de langue html dans la configuration (par défaut, `language`).
+  - Jetez un oeil sur [@nuxt/content](https://github.com/algolia/docsearch-configs/blob/master/configs/nuxtjs_content.json) pour la configuration de docsearch comme exemple.
+
+### Exemple
+
+```json[content/settings.json]
+{
+  "title": "Nuxt Content",
+  "url": "https://content.nuxtjs.org",
+  "logo": {
+    "light": "/logo-light.svg",
+    "dark": "/logo-dark.svg"
+  },
+  "github": "nuxt/content",
+  "twitter": "@nuxt_js"
+}
+```
+
+## Images
+
+Vous pouvez appliquer les classes `dark-img` et `light-img` à vos images lorsque vous avez deux versions à permuter automatiquement en fonction du mode couleur.
+
+**Exemple**
+
+```md
+<img src="/logo-light.svg" class="light-img" alt="Logo light" />
+<img src="/logo-dark.svg" class="dark-img" alt="Logo dark" />
+```
+
+**Result**
+
+<img src="/logo-light.svg" class="light-img" alt="Logo light" />
+<img src="/logo-dark.svg" class="dark-img" alt="Logo dark" />
+
+<p class="flex items-center">Essayez de basculer entre le mode clair et sombre :&nbsp;<app-color-switcher class="inline-flex ml-2"></app-color-switcher></p>
+
+## Composants
+
+Le thème est livré avec des composants Vue.js par défaut que vous pouvez utiliser directement dans votre contenu markdown.
+
+> Vous pouvez créer vos propres composants dans le dossier `components/global/`, consultez [cette section](/writing#vue-components). <badge>v0.3.0+</badge>
+
+### `<alert>`
+
+**Props**
+
+- `type`
+  - Type: `String`
+  - Défaut: `'info'`
+  - Valeurs: `['info', 'success', 'warning', 'danger']`
+
+**Exemple**
+
+```md
+<alert>
+
+Check out an info alert with a `codeblock` and a [link](/themes/docs)!
+
+</alert>
+```
+
+**Result**
+
+<alert>
+
+Check out an info alert with a `codeblock` and a [link](/themes/docs)!
+
+</alert>
+
+### `<list>`
+
+**Props**
+
+- `items`
+  - Type: `Array`
+  - Défaut: `[]`
+- `type` <badge>v0.7.0+</badge>
+  - Type: `String`
+  - Défaut: `'primary'`
+  - Valeurs: `['primary', 'info', 'success', 'warning', 'danger']`
+- `icon` <badge>v0.7.0+</badge>
+  - Type: `String`
+  - *Peut être utilisé pour remplacer l'icône par défaut `type`, consultez les [icônes disponibles](https://github.com/nuxt/content/tree/dev/packages/theme-docs/src/components/global/icons)*
+
+**Exemple**
+
+```md
+---
+items:
+  - Item1
+  - Item2
+  - Item3
+---
+
+<list :items="items"></list>
+```
+
+**Result**
+
+<list :items="['Item1', 'Item2', 'Item3']"></list>
+
+
+### `<badge>`
+
+<badge>v0.5.0+</badge>
+
+**Exemple**
+
+```md
+<badge>v1.2+</badge>
+```
+
+**Result**
+
+<badge>v1.2+</badge>
+
+### `<code-group>`
+
+Ce composant utilise des `slots`, reportez-vous au `code-block` ci-dessous.
+
+### `<code-block>`
+
+**Props**
+
+- `label`
+  - Type: `String`
+  - `required`
+- `active`
+  - Type: `Boolean`
+  - Défaut: `false`
+
+**Exemple**
+
+```html
+# Backslashes are for demonstration
+
+<code-group>
+  <code-block label="Yarn" active>
+
+  ```bash
+  yarn add @nuxt/content-theme-docs
+  \```
+
+  </code-block>
+  <code-block label="NPM">
+
+  ```bash
+  npm install @nuxt/content-theme-docs
+  \```
+
+  </code-block>
+</code-group>
+```
+
+**Result**
+
+<code-group>
+  <code-block label="Yarn" active>
+
+  ```bash
+  yarn add @nuxt/content-theme-docs
+  ```
+
+  </code-block>
+  <code-block label="NPM">
+
+  ```bash
+  npm install @nuxt/content-theme-docs
+  ```
+
+  </code-block>
+</code-group>
+
+### `<code-sandbox>`
+
+**Props**
+
+- `src`
+  - Type: `String`
+  - `required`
+
+**Exemple**
+
+```md
+---
+link: https://codesandbox.io/embed/nuxt-content-l164h?hidenavigation=1&theme=dark
+---
+
+<code-sandbox :src="link"></code-sandbox>
+```
+
+**Result**
+
+<code-sandbox src="https://codesandbox.io/embed/nuxt-content-l164h?hidenavigation=1&theme=dark"></code-sandbox>
+
+## Showcases
+
+<showcases :showcases="showcases"></showcases>


### PR DESCRIPTION
Hi 👋 
There is several missing pages about the french documentation particularly for creation of docs themes 😀

## Types of changes
- [x] Documentation 
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->
I added the missing pages and examples like : 
- integrations.md
- snippets.md
- theme/docs.md
- examples/tailwindcss-typography.md
- examples/docs-theme.md
- examples/basic.md

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)

