### PR TITLE
chore: allow directories name to contain a dot

### DIFF
--- a/packages/content/lib/database.js
+++ b/packages/content/lib/database.js
@@ -252,7 +252,16 @@ class Database extends Hookable {
    * @returns {string} Normalized path
    */
   normalizePath (path) {
-    return path.replace(this.dir, '').replace(/\.[^/.]+$/, '').replace(/\\/g, '/')
+    let extractPath = path.replace(this.dir, '')
+    const extensionPath = extractPath.substr(extractPath.lastIndexOf('.'))
+    const additionalsExt = EXTENSIONS.concat(this.extendParserExtensions)
+
+    // Remove the extension from the path if contained at the end or starts with a dot
+    if (additionalsExt.includes(extensionPath) || extractPath.startsWith('.')) {
+      extractPath = extractPath.replace(/(?:\.([^.]+))?$/, '')
+    }
+
+    return extractPath.replace(/\\/g, '/')
   }
 
   /**

--- a/packages/content/test/fixture/content/1.0/index.md
+++ b/packages/content/test/fixture/content/1.0/index.md
@@ -1,0 +1,5 @@
+---
+title: Title with dot
+---
+
+This is a page which contains dot !

--- a/packages/content/test/server.test.js
+++ b/packages/content/test/server.test.js
@@ -53,6 +53,19 @@ describe('module', () => {
     ]))
   })
 
+  test('$content() on directory with dot', async () => {
+    const items = await $content('1.0').fetch()
+
+    expect(items).toEqual([
+      expect.objectContaining({
+        title: 'Title with dot',
+        dir: '/1.0',
+        path: '/1.0/index',
+        slug: 'index'
+      })
+    ])
+  })
+
   test('$content() on file', async () => {
     const item = await $content('home').fetch()
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->
Currently, it's impossible to create a directory into `content` which contains dot due to replace extension of normalize path function.
Resolves: #640 

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes (if not applicable, please state why)
