### PR TITLE
feat(theme-docs): filter releases by `releases` setting

### DIFF
--- a/docs/content/en/themes/docs.md
+++ b/docs/content/en/themes/docs.md
@@ -394,6 +394,18 @@ You can create a `content/settings.json` file to configure the theme.
     ```
   - If you use `i18n`, make sure the `<langAttribute>` is the same as the html lang selector in the config (defaults to `language`).
   - Take a look at the [@nuxt/content](https://github.com/algolia/docsearch-configs/blob/master/configs/nuxtjs_content.json) docsearch config for an example.
+- `releases` (`Object`) <badge>v0.9.0+</badge>
+  - This option can be used to filter the releases. These options are optional and can be used separately.
+    ```json
+    "releases": {
+        "preRelease": true,
+        "channel": "alpha",
+        "tag": "v2.*.*-alpha"
+    }
+    ```
+  - The `preRelease` option filter based on `prerelease` flag. It's useful when you want to make different docs for stable and pre releases.
+  - The `channel` option filter based on `target_commitish` value. It's really useful when CI make releases based on branch like `alpha`, `beta`, `next`. Making it easy to make docs for specific branches. Can be either a string, or an array of strings.
+  - The `tag` option filter based on `tag_name`. For example, `v2.*.*-alpha` will return alpha releases of v2. Can be either a string, or an array of strings.
 
 ### Example
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->

This PR add `releases` setting which can be used to filter the GitHub Releases by: `preRelease`, `channel` and `tag`.
These options are optional and can be used separately.

- `preRelease`: filter based on `prerelease` flag.
- `channel`: filter based on `target_commitish` value
- `tag`: filter based on `tag_name`.

The `preRelease` option is useful when you want to make different docs for stable and pre releases.

The `channel` option is really useful when CI make releases based on branch like `alpha`, `beta`, `next`. Making it easy to make docs for specific branches. Can be either a string, or an array of strings.

The `tag` option make it easy to filter by the tag name. For example, `v2.*.*-alpha` will return alpha releases of v2. Can be either a string, or an array of strings.

### Example for [Auth Module](https://github.com/nuxt-community/auth-module)

These changes would make it possible to have two separate docs for v4 and v5.

#### v5.x
In v5 only pre releases with tags that are major version `5` and ends with `dev` would be shown in [releases page](https://auth.nuxtjs.org/releases) and header.

```json
{
  "releases": {
    "tag": "5.*.*-dev",
    "preRelease": true
  }
}
```

#### v4.x
In v4 only stable releases with tags that are major version `4` would be shown in [releases page](https://auth.nuxtjs.org/releases) and header.

```json
{
  "releases": {
    "tag": "4.*.*",
    "preRelease": false
  }
}
```

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
