### PR TITLE
fix: properly treat falsy values in context

### DIFF
--- a/packages/content/templates/nuxt-content.js
+++ b/packages/content/templates/nuxt-content.js
@@ -10,18 +10,11 @@ function propsToData (props, doc) {
     const { attribute } = info.find(info.html, key)
 
     if (key === 'v-bind') {
-      let val = doc[value]
-      if (!val) {
-        val = eval(`(${value})`)
-      }
+      const val = value in doc ? doc[value] : eval(`(${value})`)
       obj = Object.assign(obj, val)
     } else if (key.indexOf(':') === 0 || key.indexOf('v-bind:') === 0) {
       key = key.replace('v-bind:', '').replace(':', '')
-      if (doc[value]) {
-        obj[key] = doc[value]
-      } else {
-        obj[key] = eval(`(${value})`)
-      }
+      obj[key] = value in doc ? doc[value] : eval(`(${value})`)
     } else if (Array.isArray(value)) {
       obj[attribute] = value.join(' ')
     } else {


### PR DESCRIPTION
Properly treat falsy values in context

## Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
Previously, if a component's attribute referenced a value in context and that value happened to be falsy, it was ignored, which lead to an error. See this [sandbox](https://codesandbox.io/s/nuxt-content-reactivity-issue-forked-lkjyy?file=/content/en/index.md) for reproduction.

This PR fixes this problem.

This was discovered while researching #519


## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
