### PR TITLE
fix(theme-docs): correct releases link

### DIFF
--- a/packages/theme-docs/src/components/app/AppHeader.vue
+++ b/packages/theme-docs/src/components/app/AppHeader.vue
@@ -33,7 +33,7 @@
         >
           <NuxtLink
             v-if="lastRelease"
-            to="/releases"
+            :to="localePath('/releases')"
             class="font-semibold leading-none text-gray-700 dark:text-gray-300 hover:text-primary-500 dark-hover:text-primary-500 text-base mr-4"
             exact-active-class="text-primary-500"
           >{{ lastRelease.name }}</NuxtLink>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->
Take care of trailing slashes enabled in the nuxt configuration. Currently, it gives 404 not found page.

Basically, when trailing slashes enabled in nuxt configuration releases page doesn't load:

 ```js
router: {
 trailingSlash: true,
},
```

You can check it here http://haraka.github.io/ click on version and it gives `This page could not be found`, however complete refresh of a page works fine.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
