### PR TITLE
fix(content): codeblock parse lang should support other meta

### DIFF
--- a/packages/content/parsers/markdown/handlers/code.js
+++ b/packages/content/parsers/markdown/handlers/code.js
@@ -56,7 +56,7 @@ const toAst = (h, node) => (highlighted) => {
 }
 
 module.exports = highlighter => (h, node) => {
-  const lang = node.lang + (node.meta || '')
+  const lang = node.lang + ' ' + (node.meta || '')
   const { language, lineHighlights, fileName } = parseThematicBlock(lang)
   const code = node.value ? detab(node.value + '\n') : ''
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change) 


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->

I think #621 breaks lang parsing in codeblock when it contains other meta that is not filename. This causes highlightjs not to work as expected. When codeblock contains other meta that is not filename, it should not break lang parsing in utils.parseThematicBlock. Making it difficult to write and use remark plugins that contains meta.

||For Reference|
|-|-|
| Markdown | <img src="https://user-images.githubusercontent.com/4266087/102744656-50d11580-4395-11eb-8393-c25c6b16c682.png" width="60%"> |
| Currently  | <img src="https://user-images.githubusercontent.com/4266087/102745212-76125380-4396-11eb-879c-7fa7d0a6a30f.png" width="60%"> |
| **Expected** | <img src="https://user-images.githubusercontent.com/4266087/102745332-ae199680-4396-11eb-9d83-6306bccfe148.png" width="60%"> |


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
