### PR TITLE
fix(content): robustify filter regex for $content( path, { deep: true } ) 

### DIFF
--- a/packages/content/lib/database.js
+++ b/packages/content/lib/database.js
@@ -46,7 +46,7 @@ class Database extends Hookable {
   query (path, { deep = false, text = false } = {}) {
     const isDir = !path || !!this.dirs.find(dir => dir === path)
     // Look for dir or path
-    const query = isDir ? { dir: deep ? { $regex: new RegExp(`^${path}`) } : path } : { path }
+    const query = isDir ? { dir: deep ? { $regex: new RegExp(`^${path.replace( /[.*+?^${}()|[\]\\]/g, '\\$&') }`) } : path } : { path }
     // Postprocess to get only first result (findOne)
     const postprocess = isDir ? [] : [data => data[0]]
 

--- a/packages/content/lib/database.js
+++ b/packages/content/lib/database.js
@@ -46,7 +46,7 @@ class Database extends Hookable {
   query (path, { deep = false, text = false } = {}) {
     const isDir = !path || !!this.dirs.find(dir => dir === path)
     // Look for dir or path
-    const query = isDir ? { dir: deep ? { $regex: new RegExp(`^${path.replace( /[.*+?^${}()|[\]\\]/g, '\\$&') }`) } : path } : { path }
+    const query = isDir ? { dir: deep ? { $regex: new RegExp(`^${path.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') }`) } : path } : { path }
     // Postprocess to get only first result (findOne)
     const postprocess = isDir ? [] : [data => data[0]]
 

--- a/packages/content/lib/database.js
+++ b/packages/content/lib/database.js
@@ -46,7 +46,7 @@ class Database extends Hookable {
   query (path, { deep = false, text = false } = {}) {
     const isDir = !path || !!this.dirs.find(dir => dir === path)
     // Look for dir or path
-    const query = isDir ? { dir: deep ? { $regex: new RegExp(`^${path.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') }`) } : path } : { path }
+    const query = isDir ? { dir: deep ? { $regex: new RegExp(`^${path.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`) } : path } : { path }
     // Postprocess to get only first result (findOne)
     const postprocess = isDir ? [] : [data => data[0]]
 


### PR DESCRIPTION
The path in $content(path) is now regex-escaped befor being fed to LokiJs.
This Change escapes those characters with .https://stackoverflow.com/questions/3561493/is-there-a-regexp-escape-function-in-javascript/3561711

<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
