### PR TITLE
feat(theme-docs): adding styles to scrollbar

### DIFF
--- a/packages/theme-docs/src/assets/css/main.css
+++ b/packages/theme-docs/src/assets/css/main.css
@@ -11,6 +11,29 @@
   display: block;
 }
 
+/* Style Scrollbar: Works on Firefox */
+* {
+  scrollbar-width: thin;
+  scrollbar-color: var(--color-primary-500) transparent;
+}
+
+/* Style Scrollbar: Works on Chrome, Edge, and Safari */
+*::-webkit-scrollbar {
+  width: 4px;
+}
+
+*::-webkit-scrollbar-track {
+    background: none;
+}
+  
+*::-webkit-scrollbar-thumb {
+    background-color: var(--color-primary-500);
+    border-radius: 100px;
+    margin-top: 5px;
+    border: 3px solid var(--color-primary-500);
+}
+
+
 .nuxt-content {
   @apply break-words;
 


### PR DESCRIPTION
The scrollbars of nuxt-content docs-theme currently looks like this:

<img width="1296" alt="Screenshot 2021-01-15 at 12 08 59" src="https://user-images.githubusercontent.com/4020037/104718052-9087e480-572a-11eb-8372-090cddde8932.png">

This is not really nice, especially when the side navigations get higher than the screen size.

This PR is an idea of how to nicely style the sidebars, so the overall experience of the docs-theme looks more professional. 

⚠️ I'm not the best styler, so I'm sure this could be further improved, maybe the primary color is not the best pick for the scrollbar? Feel free to change it to something even nicer looking.

## Types of changes
- [X] New feature (a non-breaking change which adds functionality)

## Description

This PR makes the scrollbar look like this on Safari, Chrome and Firefox: 
<img width="1470" alt="Screenshot 2021-01-15 at 12 00 29" src="https://user-images.githubusercontent.com/4020037/104717775-1a837d80-572a-11eb-8a2a-75f5b320296e.png">
<img width="1456" alt="Screenshot 2021-01-15 at 12 01 22" src="https://user-images.githubusercontent.com/4020037/104717777-1c4d4100-572a-11eb-8953-50401b5338e8.png">
## Checklist:
- [NOT NEEDED] My change requires a change to the documentation.
- [NOT NEEDED] I have updated the documentation accordingly.
- [NOT NEEDED] I have added tests to cover my changes (if not applicable, please state why)
