### PR TITLE
docs: change from epoch-based to 'yyyy-mm-dd'-based date

### DIFF
--- a/docs/content/en/fetching.md
+++ b/docs/content/en/fetching.md
@@ -229,7 +229,7 @@ const articles = await this.$content('articles')
   .where({
     tags: 'testing',
     isArchived: false,
-    date: { $gt: new Date(2020) },
+    date: { $gt: new Date('2020-03-31') },
     rating: { $gte: 3 }
   })
   .search('welcome')


### PR DESCRIPTION
## Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

The current `new Date(2020)` example seems to suggest something about the year 2020, which is confusing, especially to newcomers using the documentation.

Therefore I propose to show a more meaningful example date (date of this repo's first commit), in a more common format (passed to Date constructor as string), instead of 2020 ms since Unix Epoch (passed to Date constructor as int).

## Checklist:

- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
