### PR TITLE
fix(theme-docs): remove redundant header

### DIFF
--- a/docs/content/en/themes/docs.md
+++ b/docs/content/en/themes/docs.md
@@ -329,7 +329,8 @@ To make it work properly, make sure to include these properties in the front-mat
 #### Optional fields
 
 - `category` (`String`)
-  - This will be used to group the documents in the navigation
+  - This will be used to group the documents in the navigation (defaults to `""`)
+  - If `category` is falsy or not a string, it is coerced to be an empty string, and isn't renderd in the sidebar.
 - `version` (`Float`)
   - Alert users that the page is new with a badge. Once the page is seen, the version is stored in the local storage until you increment it
 - `fullscreen` (`Boolean`)

--- a/packages/theme-docs/src/components/app/AppNav.vue
+++ b/packages/theme-docs/src/components/app/AppNav.vue
@@ -18,6 +18,7 @@
           }"
         >
           <p
+            v-if="category"
             class="mb-2 text-gray-500 uppercase tracking-wider font-bold text-sm lg:text-xs"
           >{{ category }}</p>
           <ul>

--- a/packages/theme-docs/src/index.js
+++ b/packages/theme-docs/src/index.js
@@ -41,10 +41,13 @@ function themeModule () {
   // Configure content after each hook
   hook('content:file:beforeInsert', (document) => {
     const regexp = new RegExp(`^/(${options.i18n.locales.map(locale => locale.code).join('|')})`, 'gi')
-    const dir = document.dir.replace(regexp, '')
-    const slug = document.slug.replace(/^index/, '')
+    const { dir, slug, category } = document
+    const _dir = dir.replace(regexp, '')
+    const _slug = slug.replace(/^index/, '')
+    const _category = category && typeof category === 'string' ? category : ''
 
-    document.to = `${dir}/${slug}`
+    document.to = `${_dir}/${_slug}`
+    document.category = _category
   })
   // Extend `/` route
   hook('build:extendRoutes', (routes) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->

It is explained in documentation that `category` in front-matter is optional. However, theme docs renders the category header in AppNav component regardless of existence of it.

- If `category` is completely not defined in front-matter, theme docs renders `undefined` as a uppercase text.
- If `category` is set as an empty string in front-matter, theme docs renders an empty _p_ element with margin-bottom.

[Reproduction Link (CodeSandbox)](https://codesandbox.io/s/gifted-torvalds-kghq0?file=/content/en/about.md)

With my PR, `category` in front-matter is validated in `content:file:beforeInsert` hook, and is set as an empty string if it's falsy or not a string. Coercion to an empty string is for its type to match [that described in documentation](https://content.nuxtjs.org/themes/docs#front-matter).

In addition, if `category` is an empty string (i.e. falsy), now AppNav component doesn't render the category header (the _p_ element).

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)

I tested my changes in local by `yarn link` the modified package.