### PR TITLE
fix(types): change types

### DIFF
--- a/packages/content/types/index.d.ts
+++ b/packages/content/types/index.d.ts
@@ -1,5 +1,4 @@
 import type { contentFunc, extendOrOverwrite, contentFileBeforeInstert, contentFileBeforeParse } from './content'
-import type { QueryBuilder } from './query-builder';
 
 import '@nuxt/types';
 import type { DumpOptions as YamlOptions } from 'js-yaml';
@@ -16,7 +15,7 @@ export const getOptions: (userOptions: IContentOptions) => IContentOptions
 // Modifyed types
 declare module "vuex/types/index" {
   interface Store<S> {
-    $content: QueryBuilder;
+    $content: contentFunc;
   }
 }
 


### PR DESCRIPTION
in vuex with typescript `this.$content` will not work

example code:
```ts
export const actions: ActionTree<AppState, {}> = {
  // ....
  async loadData({ commit }) {
    const data: IData[] = (await this.$content(this.$i18n.locale, "data").fetch().catch(console.error)) as any;
    if (data) {
      commit("UPDATE_DATA", data);
    }
  }
};
```

it should be typed as 'contentFunc'

<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
