### PR TITLE
feat(content): Optional search parameter

### DIFF
--- a/docs/content/en/fetching.md
+++ b/docs/content/en/fetching.md
@@ -139,7 +139,7 @@ const articles = await this.$content('articles').skip(5).limit(5).fetch()
 ### search(field, value)
 
 - `field`
-  - Type: `String` | `Boolean`
+  - Type: `String`
   - `required`
 - `value`
   - Type: `String`
@@ -148,15 +148,15 @@ Performs a full-text search on a field. `value` is optional, in this case `field
 
 The fields you want to search on must be defined in options in order to be indexed, see [configuration](/configuration#fulltextsearchfields).
 
-To search only if there is a valid `value` to search for, you can use `false` as search parameter.
+Using an empty string as parameter will skip the search.
 
 ```js
 // Search on field title
 const articles = await this.$content('articles').search('title', 'welcome').fetch()
 // Search on all pre-defined fields
 const articles = await this.$content('articles').search('welcome').fetch()
-// Search only if the search string is valid
-const articles = await this.$content('articles').search(this.searchString?.length ? this.searchString : false).fetch()
+// Search will be skipped if the search string is empty
+const articles = await this.$content('articles').search('').fetch()
 ```
 
 <alert type="info">

--- a/docs/content/en/fetching.md
+++ b/docs/content/en/fetching.md
@@ -139,7 +139,7 @@ const articles = await this.$content('articles').skip(5).limit(5).fetch()
 ### search(field, value)
 
 - `field`
-  - Type: `String`
+  - Type: `String` | `Boolean`
   - `required`
 - `value`
   - Type: `String`
@@ -148,11 +148,15 @@ Performs a full-text search on a field. `value` is optional, in this case `field
 
 The fields you want to search on must be defined in options in order to be indexed, see [configuration](/configuration#fulltextsearchfields).
 
+To search only if there is a valid `value` to search for, you can use `false` as search parameter.
+
 ```js
 // Search on field title
 const articles = await this.$content('articles').search('title', 'welcome').fetch()
 // Search on all pre-defined fields
 const articles = await this.$content('articles').search('welcome').fetch()
+// Search only if the search string is valid
+const articles = await this.$content('articles').search(this.searchString?.length ? this.searchString : false).fetch()
 ```
 
 <alert type="info">

--- a/docs/content/fr/fetching.md
+++ b/docs/content/fr/fetching.md
@@ -132,7 +132,7 @@ const articles = await this.$content('articles').skip(5).limit(5).fetch()
 ### search(field, value)
 
 - `field`
-  - Type: `String`
+  - Type: `String` | `Boolean`
   - `requis`
 - `value`
   - Type: `String`
@@ -141,11 +141,15 @@ Effectue une recherche plein texte sur un champ. Le paramètre `value` est optio
 
 Le champ sur lequel vous voulez effectuer la recherche doit être défini dans les options afin d'être indexé, voir [configuration](/fr/configuration#fulltextsearchfields).
 
+Pour effectuer une recherche conditionnellement, il est possible de passer `false` comme paramètre à la fonction search
+
 ```js
 // Search on field title
 const articles = await this.$content('articles').search('titre', 'bienvenue').fetch()
 // Search on all pre-defined fields
 const articles = await this.$content('articles').search('bievenue').fetch()
+// Search only if the search string is valid
+const articles = await this.$content('articles').search(this.searchString?.length ? this.searchString : false).fetch()
 ```
 
 ### surround(slug, options)

--- a/docs/content/fr/fetching.md
+++ b/docs/content/fr/fetching.md
@@ -132,7 +132,7 @@ const articles = await this.$content('articles').skip(5).limit(5).fetch()
 ### search(field, value)
 
 - `field`
-  - Type: `String` | `Boolean`
+  - Type: `String`
   - `requis`
 - `value`
   - Type: `String`
@@ -141,15 +141,15 @@ Effectue une recherche plein texte sur un champ. Le paramètre `value` est optio
 
 Le champ sur lequel vous voulez effectuer la recherche doit être défini dans les options afin d'être indexé, voir [configuration](/fr/configuration#fulltextsearchfields).
 
-Pour effectuer une recherche conditionnellement, il est possible de passer `false` comme paramètre à la fonction search
+Utiliser une chaîne de caractères vide comme paramètre `value` n'exécutera pas la recherche.
 
 ```js
 // Search on field title
 const articles = await this.$content('articles').search('titre', 'bienvenue').fetch()
 // Search on all pre-defined fields
 const articles = await this.$content('articles').search('bievenue').fetch()
-// Search only if the search string is valid
-const articles = await this.$content('articles').search(this.searchString?.length ? this.searchString : false).fetch()
+// Search will be skipped if the search string is empty
+const articles = await this.$content('articles').search('').fetch()
 ```
 
 ### surround(slug, options)

--- a/packages/content/lib/query-builder.js
+++ b/packages/content/lib/query-builder.js
@@ -81,6 +81,9 @@ class QueryBuilder {
    * @returns {QueryBuilder} Returns current instance to be chained
    */
   search (query, value) {
+    // Passing false as query will avoid triggering a search to allow optional chaining
+    if(query === false) return this
+
     let $fts
 
     if (typeof query === 'object') {

--- a/packages/content/lib/query-builder.js
+++ b/packages/content/lib/query-builder.js
@@ -82,7 +82,7 @@ class QueryBuilder {
    */
   search (query, value) {
     // Passing false as query will avoid triggering a search to allow optional chaining
-    if(query === false) return this
+    if (query === false) { return this }
 
     let $fts
 

--- a/packages/content/lib/query-builder.js
+++ b/packages/content/lib/query-builder.js
@@ -81,8 +81,8 @@ class QueryBuilder {
    * @returns {QueryBuilder} Returns current instance to be chained
    */
   search (query, value) {
-    // Passing false as query will avoid triggering a search to allow optional chaining
-    if (query === false) { return this }
+    // Passing an empty or falsey value as query will avoid triggering a search to allow optional chaining
+    if (!query?.length) { return this }
 
     let $fts
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [X] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description

Passing an empty string  as query value will avoid triggering a search to allow optional chaining such as this:

```js
      this.total = (await this.$content('people')
          .search('')
          .only([])
          .fetch()).length
```
Docs have been updated in FR & EN. JA & RU update necessary.

## Checklist:
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
