### PR TITLE
fix: use top 2 level of nodes to generate toc

### DIFF
--- a/packages/content/parsers/markdown/index.js
+++ b/packages/content/parsers/markdown/index.js
@@ -29,8 +29,8 @@ class Markdown {
     }
   }
 
-  flattenNode (node, maxDepth = 2, depth = 1) {
-    if (!node.children || depth === maxDepth) {
+  flattenNode (node, maxDepth = 2, depth = 0) {
+    if (!Array.isArray(node.children) || depth === maxDepth) {
       return [node]
     }
     return [

--- a/packages/content/parsers/markdown/index.js
+++ b/packages/content/parsers/markdown/index.js
@@ -29,6 +29,16 @@ class Markdown {
     }
   }
 
+  flattenNode (node, maxDepth = 2, depth = 1) {
+    if (!node.children || depth === maxDepth) {
+      return [node]
+    }
+    return [
+      node,
+      ...node.children.flatMap(child => this.flattenNode(child, maxDepth, depth + 1))
+    ]
+  }
+
   /**
    * Generate table of contents
    * @param {object} body - JSON AST generated from markdown.
@@ -37,7 +47,9 @@ class Markdown {
   generateToc (body) {
     const { tocTags } = this.options
 
-    return body.children.filter(node => tocTags.includes(node.tag)).map((node) => {
+    const children = this.flattenNode(body, 2)
+
+    return children.filter(node => tocTags.includes(node.tag)).map((node) => {
       const id = node.props.id
 
       const depth = ({

--- a/packages/content/test/fixture/content/toc-dom-depth-2.md
+++ b/packages/content/test/fixture/content/toc-dom-depth-2.md
@@ -1,0 +1,57 @@
+---
+title: Table of Contents Tests
+---
+
+## Heading A-2
+
+<div>
+
+# Heading B-1
+
+Pragraph.
+
+## Heading B-2
+
+Pragraph.
+
+### Heading B-3
+
+Pragraph.
+
+#### Heading B-4
+
+Pragraph.
+
+##### Heading B-5
+
+Pragraph.
+
+###### Heading B-6
+
+Pragraph.
+
+# Heading C-1
+
+Pragraph.
+
+## Heading C-2
+
+Pragraph.
+
+### Heading C-3
+
+Pragraph.
+
+#### Heading C-4
+
+Pragraph.
+
+##### Heading C-5
+
+Pragraph.
+
+###### Heading C-6
+
+Pragraph.
+
+</div>

--- a/packages/content/test/options.test.js
+++ b/packages/content/test/options.test.js
@@ -237,6 +237,37 @@ describe('options', () => {
       })
     })
 
+    describe('generated table of contents for document with wrapper div', () => {
+      let nuxt
+      let $content
+
+      beforeAll(async () => {
+        ({ nuxt } = (await setup(loadConfig(__dirname))))
+        const module = require('@nuxt/content')
+        $content = module.$content
+      }, 60000)
+
+      afterAll(async () => {
+        await nuxt.close()
+      })
+
+      test('', async () => {
+        const item = await $content('toc-dom-depth-2').fetch()
+
+        expect(item).toEqual(
+          expect.objectContaining({
+            toc: expect.arrayContaining([
+              expect.objectContaining({ depth: 2, id: 'heading-a-2', text: 'Heading A-2' }),
+              expect.objectContaining({ depth: 2, id: 'heading-b-2', text: 'Heading B-2' }),
+              expect.objectContaining({ depth: 3, id: 'heading-b-3', text: 'Heading B-3' }),
+              expect.objectContaining({ depth: 2, id: 'heading-c-2', text: 'Heading C-2' }),
+              expect.objectContaining({ depth: 3, id: 'heading-c-3', text: 'Heading C-3' })
+            ])
+          })
+        )
+      })
+    })
+
     describe('generated table of contents with depth 1', () => {
       let nuxt
       let $content


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->
Currently Nuxt Content uses only top level elements to generate table of content therefore TOC will not generate for documents which wrapped inside a tag.  

Originally issued here: https://www.github.com/nuxtlabs/docus/issues/21#issuecomment-776078940

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
