### PR TITLE
docs: fix markdown syntax

### DIFF
--- a/docs/content/en/snippets.md
+++ b/docs/content/en/snippets.md
@@ -184,6 +184,7 @@ export default {
     }
   }
 }
+```
 
 > Check out the [`sortBy` documentation](/fetching#sortbykey-direction)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->

Fixes #756, where triple back ticks to close code block are missed.
Now _Snippet_ page is broken.

It's just my bad. 🙏 

| Current Production | This PR |
| :---: | :---: |
|<img width="100%" alt="Screen Shot 2021-02-10 at 22 19 38" src="https://user-images.githubusercontent.com/16436160/107515302-30337800-6bee-11eb-9600-ba8f7fc84021.png">|<img width="100%" alt="Screen Shot 2021-02-10 at 22 20 17" src="https://user-images.githubusercontent.com/16436160/107515315-33c6ff00-6bee-11eb-8742-466ac981b5d9.png">|


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)

As shown above, I checked UI in my local.