### PR TITLE
fix(content): only use nuxt-link for absolute html links

### DIFF
--- a/packages/content/parsers/markdown/compilers/json.js
+++ b/packages/content/parsers/markdown/compilers/json.js
@@ -1,3 +1,5 @@
+const { extname } = require('path')
+
 /**
  * Parses nodes for JSON structure. Attempts to drop
  * unwanted properties.
@@ -13,10 +15,14 @@ function parseAsJSON (node, parent) {
     /**
      * Replace a tag with nuxt-link if relative
      */
-    if (node.tagName === 'a' && (node.properties.href || '').startsWith('/')) {
-      node.tagName = 'nuxt-link'
-      node.properties.to = node.properties.href
-      delete node.properties.href
+    if (node.tagName === 'a') {
+      const pathname = (node.properties.href || '')
+
+      if (pathname.startsWith('/') && extname(pathname) === '') {
+        node.tagName = 'nuxt-link'
+        node.properties.to = node.properties.href
+        delete node.properties.href
+      }
     }
 
     const filtered = {

--- a/packages/content/parsers/markdown/compilers/json.js
+++ b/packages/content/parsers/markdown/compilers/json.js
@@ -16,7 +16,7 @@ function parseAsJSON (node, parent) {
      * Replace a tag with nuxt-link if relative
      */
     if (node.tagName === 'a') {
-      const pathname = (node.properties.href || '')
+      const [pathname] = (node.properties.href || '').split('#')
 
       if (pathname.startsWith('/') && extname(pathname) === '') {
         node.tagName = 'nuxt-link'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->
This resolves #851 by only replacing links with `nuxt-link` if it's an absolute path without an extension. This was the most accurate way I could think of doing it, and should fix _most_ use cases.

No tests where added because I could not find anything related to the initial `a` to `nuxt-link` implementation. If you want tests, please direct me to where I should place those.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
