### PR TITLE
fix(content): prevent editor extending on typing

### DIFF
--- a/packages/content/templates/editor.vue
+++ b/packages/content/templates/editor.vue
@@ -2,7 +2,6 @@
   <textarea
     ref="textarea"
     v-model="file"
-    @keyup.stop="onType"
     @keydown.tab.exact.prevent="onTabRight"
     @keydown.tab.shift.prevent="onTabLeft"
     @compositionstart.prevent="isInComposition = true"
@@ -32,13 +31,18 @@ export default {
       this.$refs.textarea.focus()
     },
     file () {
+      this.onType()
       this.$emit('input', this.file)
     }
   },
   methods: {
     onType () {
       const el = this.$refs.textarea
-      el.style.height = el.scrollHeight + 'px'
+
+      el.style.height = 'auto'
+      this.$nextTick(() => {
+        el.style.height = el.scrollHeight + 'px'
+      })
     },
     onTabRight(event) {
       if (this.isInComposition) {

--- a/packages/content/templates/nuxt-content.dev.vue
+++ b/packages/content/templates/nuxt-content.dev.vue
@@ -98,7 +98,11 @@ export default {
 }
 
 .nuxt-content-editor {
+  box-sizing: border-box;
+  display: block;
   width: 100%;
   padding: 8px;
+  overflow: hidden;
+  resize: none;
 }
 </style>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->

Resolves: #932

In addition, I adjusted some CSS styles of textarea element.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)

This is UI bug, so there is nothing to change in unit tests.
Instead, I tested it in Chrome (91.0.4472.164), Firefox (90.0.2), and Safari (14.1.1) on MacBookPro (Big Sur).
