### PR TITLE
Allow "as" prop to change the root div

### DIFF
--- a/packages/content/templates/nuxt-content.js
+++ b/packages/content/templates/nuxt-content.js
@@ -132,10 +132,14 @@ export default {
   props: {
     document: {
       required: true
+    },
+    as: {
+      type: String,
+      default: 'div'
     }
   },
   render (h, { data, props }) {
-    const { document } = props
+    const { document, as } = props
     const { body } = document || {}
     if (!body || !body.children || !Array.isArray(body.children)) {
       return
@@ -151,6 +155,6 @@ export default {
     }
     data.class = classes.concat('nuxt-content')
     data.props = Object.assign({ ...body.props }, data.props)
-    return h('div', data, body.children.map(child => processNode(child, h, document)))
+    return h(as, data, body.children.map(child => processNode(child, h, document)))
   }
 }


### PR DESCRIPTION
This allows a developer to have a different root element than "div", avoiding for example the need to wrap an "article" element around an article