### PR TITLE
Allow "as" prop to change the root div

### DIFF
--- a/docs/content/en/displaying.md
+++ b/docs/content/en/displaying.md
@@ -39,6 +39,8 @@ export default {
 - document:
   - Type: `Object`
   - `required`
+- as:
+  - Type: `String`
 
 Learn more about what you can write in your markdown file in the [writing content](/writing#markdown) section.
 
@@ -65,6 +67,14 @@ export default {
   }
 }
 </script>
+```
+
+## Root Element
+
+`<nuxt-content>` component will add a `div` element as the root of the content. You can change this by setting the `as` prop. Below example will use `article` as the root element.
+
+```vue
+<nuxt-content :document="doc" as="article">
 ```
 
 ## Style

--- a/packages/content/templates/nuxt-content.js
+++ b/packages/content/templates/nuxt-content.js
@@ -132,10 +132,14 @@ export default {
   props: {
     document: {
       required: true
+    },
+    as: {
+      type: String,
+      default: 'div'
     }
   },
   render (h, { data, props }) {
-    const { document } = props
+    const { document, as } = props
     const { body } = document || {}
     if (!body || !body.children || !Array.isArray(body.children)) {
       return
@@ -151,6 +155,6 @@ export default {
     }
     data.class = classes.concat('nuxt-content')
     data.props = Object.assign({ ...body.props }, data.props)
-    return h('div', data, body.children.map(child => processNode(child, h, document)))
+    return h(as, data, body.children.map(child => processNode(child, h, document)))
   }
 }


### PR DESCRIPTION
This allows developers to change the root `div` element of nuxt-context to something that might be semantically preferable like an `article` tag. This would avoid having to wrap nuxt-content with an element, saving some HTML.