### PR TITLE
docs: upgrade highlightjs to 11.x

### DIFF
--- a/docs/content/en/configuration.md
+++ b/docs/content/en/configuration.md
@@ -315,7 +315,7 @@ export default {
   content: {
     markdown: {
       highlighter(rawCode, lang) {
-        const highlightedCode = highlightjs.highlight(lang, rawCode).value
+        const highlightedCode = highlightjs.highlight(rawCode, { language: lang }).value
 
         // We need to create a wrapper, because
         // the returned code from highlight.js
@@ -348,7 +348,7 @@ export default {
   content: {
     markdown: {
       highlighter(rawCode, lang, _, { h, node, u }) {
-        const highlightedCode = highlightjs.highlight(lang, rawCode).value
+        const highlightedCode = highlightjs.highlight(rawCode, { language: lang }).value
 
         // We can use ast helper to create the wrapper
         const childs = []
@@ -393,7 +393,7 @@ export default {
   content: {
     markdown: {
       highlighter(rawCode, lang, { lineHighlights, fileName }, { h, node, u }) {
-        const highlightedCode = highlightjs.highlight(lang, rawCode).value
+        const highlightedCode = highlightjs.highlight(rawCode, { language: lang }).value
 
         const childs = []
         const props = {
@@ -447,7 +447,7 @@ export default {
         const highlighter = await getHighlighter()
 
         return (rawCode, lang) => {
-          return highlighter.highlight(rawCode, lang)
+          return highlighter.highlight(rawCode, { language: lang })
         }
       }
     }

--- a/docs/content/en/snippets.md
+++ b/docs/content/en/snippets.md
@@ -280,7 +280,7 @@ export default {
         if (!lang) {
           return wrap(highlightjs.highlightAuto(rawCode).value, lang)
         }
-        return wrap(highlightjs.highlight(lang, rawCode).value, lang)
+        return wrap(highlightjs.highlight(rawCode, { language: lang }).value, lang)
       }
     }
   }
@@ -377,7 +377,7 @@ module.exports = function () {
         'https://api.github.com/repos/nuxt/content/contributors'
       ).then(res => res.json())
       .then(res => res.map(({ login }) => login))
-      
+
       data.$contributors = [...new Set(contributors)]
     }
     return tree

--- a/docs/content/fr/snippets.md
+++ b/docs/content/fr/snippets.md
@@ -230,7 +230,7 @@ export default {
         if (!lang) {
           return wrap(highlightjs.highlightAuto(rawCode).value, lang)
         }
-        return wrap(highlightjs.highlight(lang, rawCode).value, lang)
+        return wrap(highlightjs.highlight(rawCode, { language: lang }).value, lang)
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "babel-jest": "^27.3.1",
     "codecov": "^3.8.1",
     "eslint": "^7.21.0",
-    "highlight.js": "^10.6.0",
+    "highlight.js": "^11.3.1",
     "jest": "^27.3.1",
     "lerna": "^4.0.0",
     "nuxt-edge": "latest",

--- a/packages/content/test/highlighter.spec.js
+++ b/packages/content/test/highlighter.spec.js
@@ -67,7 +67,7 @@ describe("highlighter", () => {
                 )
               }
               return wrapHighlightjs(
-                highlightjs.highlight(lang, rawCode).value,
+                highlightjs.highlight(rawCode, { language: lang }).value,
                 lang
               )
             }
@@ -95,10 +95,10 @@ describe("highlighter", () => {
 
     test("renders correctly", () => {
       expect(nuxtContent).toMatchInlineSnapshot(`
-        "<div class=\\"nuxt-content-highlight\\"><pre><code class=\\"hljs js\\"><span class=\\"hljs-built_in\\">console</span>.log(<span class=\\"hljs-string\\">'Highlighter'</span>)
+        "<div class=\\"nuxt-content-highlight\\"><pre><code class=\\"hljs js\\"><span class=\\"hljs-variable language_\\">console</span>.<span class=\\"hljs-title function_\\">log</span>(<span class=\\"hljs-string\\">'Highlighter'</span>)
         </code></pre></div>
         <div class=\\"nuxt-content-highlight\\"><pre><code class=\\"hljs typescript\\"><span class=\\"hljs-comment\\">// @errors: 2322</span>
-        <span class=\\"hljs-function\\"><span class=\\"hljs-keyword\\">function</span> <span class=\\"hljs-title\\">sum</span>(<span class=\\"hljs-params\\">a: <span class=\\"hljs-built_in\\">number</span>, b: <span class=\\"hljs-built_in\\">number</span></span>): <span class=\\"hljs-title\\">string</span> </span>{
+        <span class=\\"hljs-keyword\\">function</span> <span class=\\"hljs-title function_\\">sum</span>(<span class=\\"hljs-params\\">a: <span class=\\"hljs-built_in\\">number</span>, b: <span class=\\"hljs-built_in\\">number</span></span>): <span class=\\"hljs-built_in\\">string</span> {
           <span class=\\"hljs-keyword\\">return</span> <span class=\\"hljs-literal\\">true</span>
         }
         </code></pre></div>"
@@ -246,7 +246,7 @@ describe("highlighter", () => {
               if (!lang || lang === "null") {
                 code = highlightjs.highlightAuto(rawCode).value
               } else {
-                code = highlightjs.highlight(lang, rawCode).value
+                code = highlightjs.highlight(rawCode, { language: lang }).value
               }
               return h(
                 node,
@@ -282,10 +282,10 @@ describe("highlighter", () => {
 
     test("renders correctly", () => {
       expect(nuxtContent).toMatchInlineSnapshot(`
-        "<div class=\\"highlighted-using-highlightjs\\"><pre><code class=\\"hljs undefined\\"><span class=\\"hljs-built_in\\">console</span>.log(<span class=\\"hljs-string\\">'Highlighter'</span>)
+        "<div class=\\"highlighted-using-highlightjs\\"><pre><code class=\\"hljs undefined\\"><span class=\\"hljs-variable language_\\">console</span>.<span class=\\"hljs-title function_\\">log</span>(<span class=\\"hljs-string\\">'Highlighter'</span>)
         </code></pre></div>
         <div data-line=\\"1\\" class=\\"highlighted-using-highlightjs index.ts\\"><pre><code class=\\"hljs undefined\\"><span class=\\"hljs-comment\\">// @errors: 2322</span>
-        <span class=\\"hljs-function\\"><span class=\\"hljs-keyword\\">function</span> <span class=\\"hljs-title\\">sum</span>(<span class=\\"hljs-params\\">a: <span class=\\"hljs-built_in\\">number</span>, b: <span class=\\"hljs-built_in\\">number</span></span>): <span class=\\"hljs-title\\">string</span> </span>{
+        <span class=\\"hljs-keyword\\">function</span> <span class=\\"hljs-title function_\\">sum</span>(<span class=\\"hljs-params\\">a: <span class=\\"hljs-built_in\\">number</span>, b: <span class=\\"hljs-built_in\\">number</span></span>): <span class=\\"hljs-built_in\\">string</span> {
           <span class=\\"hljs-keyword\\">return</span> <span class=\\"hljs-literal\\">true</span>
         }
         </code></pre></div>"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8342,10 +8342,10 @@ hex-color-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
   integrity sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==
 
-highlight.js@^10.6.0:
-  version "10.7.3"
-  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.7.3.tgz#697272e3991356e40c3cac566a74eef681756531"
-  integrity sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==
+highlight.js@^11.3.1:
+  version "11.3.1"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-11.3.1.tgz#813078ef3aa519c61700f84fe9047231c5dc3291"
+  integrity sha512-PUhCRnPjLtiLHZAQ5A/Dt5F8cWZeMyj9KRsACsWT+OD6OP0x6dp5OmT5jdx0JgEyPxPZZIPQpRN2TciUT7occw==
 
 hmac-drbg@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->
In documentation, we are mentioning highlight.js usage while internally still depending on 10.x with deprecated API. This PR upgrades docs, internal tests to latest API

Release notes: https://github.com/highlightjs/highlight.js/blob/main/VERSION_11_UPGRADE.md

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
