### PR TITLE
fix: invalid default import from property-information

### DIFF
--- a/packages/content/templates/nuxt-content.js
+++ b/packages/content/templates/nuxt-content.js
@@ -1,4 +1,4 @@
-import info from 'property-information'
+import * as info from 'property-information'
 
 const rootKeys = ['class-name', 'class', 'className', 'style']
 


### PR DESCRIPTION
The `property-information` package does not export a default object and thus `import info from "property-information"` returns `undefined`, resulting in the content module failing to render markdown files.

<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
I was trying to use the `nuxt-content` component to display a fetched markdown file, but it failed with an error. I followed the code and discovered that the import statement used in `nuxt-content.js` is incorrect. It tries to import a default `info` object from the property-information package, but there is no default object exported. Instead, all members are exported individually.

The fix involves using `import * as info from...` instead `import info from...`

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)

I have run tests and they all passed.