### PR TITLE
fix(theme-docs): Add  vi-VN.js for Vietnamese

### DIFF
--- a/packages/theme-docs/src/i18n/vi-VN.js
+++ b/packages/theme-docs/src/i18n/vi-VN.js
@@ -1,0 +1,12 @@
+export default {
+  search: {
+    placeholder: 'Tìm nội dung (Ấn "/" để tìm)'
+  },
+  toc: {
+    title: 'Nội dung gồm'
+  },
+  article: {
+    github: 'Chỉnh sửa nội dung',
+    updatedAt: 'Cập nhật lần cuối'
+  }
+}


### PR DESCRIPTION
Adding i18n/vi-VN.js for Vietnamese locale
- [x] New feature (a non-breaking change which adds functionality)
