### PR TITLE
Make raw data available to parsers

### DIFF
--- a/packages/content/lib/database.js
+++ b/packages/content/lib/database.js
@@ -227,10 +227,11 @@ class Database extends Hookable {
     }
 
     const stats = await fs.stat(path)
+    const raw = await fs.readFile(path)
     const file = {
       path,
       extension,
-      data: await fs.readFile(path, 'utf-8')
+      data: raw.toString('utf-8')
     }
 
     await this.callHook('file:beforeParse', file)
@@ -250,7 +251,7 @@ class Database extends Hookable {
     // Collect data from file
     let data = []
     try {
-      data = await parser(file.data, { path: file.path })
+      data = await parser(file.data, { path: file.path, raw })
       // Force data to be an array
       data = Array.isArray(data) ? data : [data]
     } catch (err) {


### PR DESCRIPTION
The current implementation hardcodes a UTF8 translation.  The patch makes the raw binary data available to parsers.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

Word .doc and .docx, Excel .xls and .xlsx, and a huge number of interesting file types are binary.

`@nuxt/content` provides means for writing custom parsers but the parsers receive UTF8 strings.  This is a problem for the binary formats, which makes Word and Excel compatibility impossible.

The proposed non-breaking change would enable custom binary parsers without changing the API.

Resolves #1007 and makes #1002 possible without having to change the library.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)

Ideally the API would be different (always passing raw buffers).  The docs can be written once the final code shape is determined and best practices are established.