### PR TITLE
docs(content): add Vue components prop casing caveat

### DIFF
--- a/docs/content/en/writing.md
+++ b/docs/content/en/writing.md
@@ -280,12 +280,12 @@ An issue exists with locally registered components and live edit in development,
 
 </alert>
 
-Since `@nuxt/content` operates under the assumption all Markdown is provided by the author (and not via third-party user submission), sources are processed in full (tags included), with a couple of caveats from [rehype-raw](https://github.com/rehypejs/rehype-raw):
+Since `@nuxt/content` operates under the assumption that all Markdown is provided by the author (and not via third-party user submission), sources are processed in full (tags included), with a couple of caveats from [rehype-raw](https://github.com/rehypejs/rehype-raw):
 
-1. You need to refer to your components by kebab case naming:
+1. You need to refer to your components and their props by kebab case naming:
 
 ```html
-Use <my-component> instead of <MyComponent>
+Use <my-component :my-prop="myValue"> instead of <MyComponent :myProp="myValue">
 ```
 
 2. You cannot use self-closing tags, i.e., **this won't work**:


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

docs content tweak

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->

Props of Vue component  in Markdown content need to use kebab name casing. This PR adds this caveat to the the documentation.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
