### PR TITLE
fix: encode regex in query params

### DIFF
--- a/src/runtime/composables/navigation.ts
+++ b/src/runtime/composables/navigation.ts
@@ -1,6 +1,7 @@
 import { hash } from 'ohash'
 import { useHead } from '#app'
 import type { NavItem, QueryBuilder } from '../types'
+import { jsonStringify } from '../utils/json'
 import { withContentBase } from './utils'
 
 export const fetchContentNavigation = (queryBuilder?: QueryBuilder) => {
@@ -18,7 +19,7 @@ export const fetchContentNavigation = (queryBuilder?: QueryBuilder) => {
     method: 'GET',
     responseType: 'json',
     params: {
-      params: JSON.stringify(params)
+      params: jsonStringify(params)
     }
   })
 }

--- a/src/runtime/composables/query.ts
+++ b/src/runtime/composables/query.ts
@@ -3,6 +3,7 @@ import { hash } from 'ohash'
 import { useHead } from '#app'
 import { createQuery } from '../query/query'
 import type { ParsedContent, QueryBuilder, QueryBuilderParams } from '../types'
+import { jsonStringify } from '../utils/json'
 import { withContentBase } from './utils'
 
 /**
@@ -22,7 +23,7 @@ const queryFetch = (params: Partial<QueryBuilderParams>) => {
     method: 'GET',
     responseType: 'json',
     params: {
-      params: JSON.stringify(params)
+      params: jsonStringify(params)
     }
   })
 }

--- a/src/runtime/server/api/navigation.ts
+++ b/src/runtime/server/api/navigation.ts
@@ -1,11 +1,11 @@
-import { defineEventHandler, useQuery } from 'h3'
-import { queryContent, useApiQuery } from '../storage'
+import { defineEventHandler } from 'h3'
+import { queryContent } from '../storage'
 import { createNav } from '../navigation'
 import { ParsedContentMeta, QueryBuilderParams } from '../../types'
+import { useApiParams } from '../params'
 
 export default defineEventHandler(async (event) => {
-  const { query: qid } = event.context.params
-  const query: Partial<QueryBuilderParams> = useApiQuery(qid, useQuery(event)?.params || undefined)
+  const query: Partial<QueryBuilderParams> = useApiParams(event)
 
   const contents = await queryContent(query)
     .where({

--- a/src/runtime/server/api/query.ts
+++ b/src/runtime/server/api/query.ts
@@ -1,10 +1,10 @@
-import { createError, defineEventHandler, useQuery } from 'h3'
+import { createError, defineEventHandler } from 'h3'
 import type { QueryBuilderParams } from '../../types'
-import { queryContent, useApiQuery } from '../storage'
+import { queryContent } from '../storage'
+import { useApiParams } from '../params'
 
 export default defineEventHandler(async (event) => {
-  const { query: qid } = event.context.params
-  const query: Partial<QueryBuilderParams> = useApiQuery(qid, useQuery(event)?.params || undefined)
+  const query: Partial<QueryBuilderParams> = useApiParams(event)
 
   const contents = await queryContent(query).find()
 

--- a/src/runtime/server/params.ts
+++ b/src/runtime/server/params.ts
@@ -1,0 +1,14 @@
+import { useQuery, CompatibilityEvent } from 'h3'
+import { jsonParse } from '../utils/json'
+
+const memory = {}
+export const useApiParams = (event: CompatibilityEvent) => {
+  const { query: qid } = event.context.params
+  const params = useQuery(event)?.params || undefined
+
+  if (params) {
+    memory[qid] = typeof params === 'string' ? jsonParse(params) : params
+  }
+
+  return memory[qid] || {}
+}

--- a/src/runtime/server/storage.ts
+++ b/src/runtime/server/storage.ts
@@ -1,6 +1,5 @@
 import { prefixStorage } from 'unstorage'
 import { hash as ohash } from 'ohash'
-import destr from 'destr'
 import type { QueryBuilderParams, ParsedContent } from '../types'
 import { createQuery } from '../query/query'
 import { createPipelineFetcher } from '../query/match/pipeline'
@@ -100,13 +99,4 @@ export const queryContent = (
   const pipelineFetcher = createPipelineFetcher(getContentsList)
 
   return createQuery(pipelineFetcher, body)
-}
-
-const _queries = {}
-export const useApiQuery = (qid?: string, query?: any) => {
-  if (query) {
-    _queries[qid] = typeof query === 'string' ? destr(query) : query
-  }
-
-  return _queries[qid] || {}
 }

--- a/src/runtime/utils/json.ts
+++ b/src/runtime/utils/json.ts
@@ -1,0 +1,40 @@
+/**
+ * Converts a JavaScript value to a JavaScript Object Notation (JSON) string.
+ * This function is equivalent to `JSON.stringify`, but it also handles RegExp objects.
+ */
+export function jsonStringify (value: any) {
+  return JSON.stringify(value, regExpReplacer)
+}
+
+/**
+ * Converts a JavaScript Object Notation (JSON) string into an object.
+ * This function is equivalent to `JSON.parse`, but it also handles RegExp objects.
+ */
+export function jsonParse (value: string) {
+  return JSON.parse(value, regExpReviver)
+}
+
+/**
+ * A function that transforms RegExp objects to their string representation.
+ */
+function regExpReplacer (_key: string, value: any) {
+  if (value instanceof RegExp) {
+    return `--REGEX ${value.toString()}`
+  }
+  return value
+}
+
+/**
+ * A function that transforms RegExp string representation back to RegExp objects.
+ */
+function regExpReviver (_key, value) {
+  const withOperator = (typeof value === 'string' && value.match(/^--([A-Z]+) (.+)$/)) || []
+
+  if (withOperator[1] === 'REGEX') {
+    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#advanced_searching_with_flags
+    const regex = withOperator[2].match(/\/(.*)\/([dgimsuy]*)$/)
+    return regex ? new RegExp(regex[1], regex[2] || '') : value
+  }
+
+  return value
+}

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -9,6 +9,7 @@ import { testNavigation } from './features/navigation'
 import { testMDCComponent } from './features/mdc-component'
 import { testJSONParser } from './features/parser-json'
 import { testCSVParser } from './features/parser-csv'
+import { testRegex } from './features/regex'
 
 describe('fixtures:basic', async () => {
   await setup({
@@ -97,4 +98,6 @@ describe('fixtures:basic', async () => {
   testPathMetaTransformer()
 
   testMDCComponent()
+
+  testRegex()
 })

--- a/test/features/regex.ts
+++ b/test/features/regex.ts
@@ -1,0 +1,38 @@
+import { describe, test, expect } from 'vitest'
+import { $fetch } from '@nuxt/test-utils'
+import { hash } from 'ohash'
+import { jsonStringify } from '../../src/runtime/utils/json'
+
+export const testRegex = () => {
+  describe('regex', () => {
+    test('Get cats with regex', async () => {
+      const params = { where: { slug: /^\/cats/ } }
+      const list = await $fetch(`/api/_content/query/${hash(params)}`, {
+        params: {
+          params: jsonStringify(params)
+        }
+      })
+
+      expect(list.length).greaterThan(0)
+      for (const item of list) {
+        expect(item.slug).toMatch(/^\/cats/)
+      }
+    })
+
+    test('Get cats navigation with regex', async () => {
+      const params = { where: { slug: /^\/cats/ } }
+      const list = await $fetch(`/api/_content/navigation/${hash(params)}`, {
+        params: {
+          params: jsonStringify(params)
+        }
+      })
+
+      expect(list.length).greaterThan(0)
+      expect(list[0].slug).toEqual('/cats')
+
+      for (const item of list[0].children) {
+        expect(item.slug).toMatch(/^\/cats/)
+      }
+    })
+  })
+}


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Usage:

```ts
queryContent().where({ slug: /^\/cats/ }).find()
```

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
