### PR TITLE
fix(server): rename `queryContent` to `serverQueryContent`

### DIFF
--- a/src/runtime/server/api/cache.ts
+++ b/src/runtime/server/api/cache.ts
@@ -1,11 +1,11 @@
 import { defineEventHandler } from 'h3'
-import { queryContent } from '../storage'
+import { serverQueryContent } from '../storage'
 
 // This route is used to cache all the parsed content
-export default defineEventHandler(async () => {
+export default defineEventHandler(async (event) => {
   const now = Date.now()
   // Fetch all content
-  await queryContent().find()
+  await serverQueryContent(event).find()
 
   return {
     generatedAt: now,

--- a/src/runtime/server/api/navigation.ts
+++ b/src/runtime/server/api/navigation.ts
@@ -1,5 +1,5 @@
 import { defineEventHandler } from 'h3'
-import { queryContent } from '../storage'
+import { serverQueryContent } from '../storage'
 import { createNav } from '../navigation'
 import { ParsedContentMeta, QueryBuilderParams } from '../../types'
 import { useApiParams } from '../params'
@@ -7,7 +7,7 @@ import { useApiParams } from '../params'
 export default defineEventHandler(async (event) => {
   const query: Partial<QueryBuilderParams> = useApiParams(event)
 
-  const contents = await queryContent(query)
+  const contents = await serverQueryContent(event, query)
     .where({
       /**
        * Partial contents are not included in the navigation
@@ -17,7 +17,7 @@ export default defineEventHandler(async (event) => {
     })
     .find()
 
-  const dirConfigs = await queryContent().where({ path: /\/_dir$/i, partial: true }).find()
+  const dirConfigs = await serverQueryContent(event).where({ path: /\/_dir$/i, partial: true }).find()
   const configs = dirConfigs.reduce((configs, conf) => {
     if (conf.title.toLowerCase() === 'dir') {
       conf.title = undefined

--- a/src/runtime/server/api/query.ts
+++ b/src/runtime/server/api/query.ts
@@ -1,12 +1,12 @@
 import { createError, defineEventHandler } from 'h3'
 import type { QueryBuilderParams } from '../../types'
-import { queryContent } from '../storage'
+import { serverQueryContent } from '../storage'
 import { useApiParams } from '../params'
 
 export default defineEventHandler(async (event) => {
   const query: Partial<QueryBuilderParams> = useApiParams(event)
 
-  const contents = await queryContent(query).find()
+  const contents = await serverQueryContent(event, query).find()
 
   // If no documents matchs and using findOne()
   if (query.first && Array.isArray(contents) && contents.length === 0) {

--- a/src/runtime/server/index.ts
+++ b/src/runtime/server/index.ts
@@ -1,0 +1,3 @@
+export { serverQueryContent } from './storage'
+export { parse as contentParse } from './transformers'
+export { transform as contentTransform } from './transformers'

--- a/src/runtime/server/storage.ts
+++ b/src/runtime/server/storage.ts
@@ -1,6 +1,7 @@
 import { joinURL, withLeadingSlash } from 'ufo'
 import { prefixStorage } from 'unstorage'
 import { hash as ohash } from 'ohash'
+import type { CompatibilityEvent } from 'h3'
 import type { QueryBuilderParams, ParsedContent, QueryBuilder } from '../types'
 import { createQuery } from '../query/query'
 import { createPipelineFetcher } from '../query/match/pipeline'
@@ -86,10 +87,10 @@ export const getContent = async (id: string): Promise<ParsedContent> => {
 /**
  * Query contents
  */
-export function queryContent<T = ParsedContent>(): QueryBuilder<T>;
-export function queryContent<T = ParsedContent>(params?: Partial<QueryBuilderParams>): QueryBuilder<T>;
-export function queryContent<T = ParsedContent>(slug?: string, ...slugParts: string[]): QueryBuilder<T>;
-export function queryContent<T = ParsedContent> (slug?: string | Partial<QueryBuilderParams>, ...slugParts: string[]) {
+export function serverQueryContent<T = ParsedContent>(event: CompatibilityEvent): QueryBuilder<T>;
+export function serverQueryContent<T = ParsedContent>(event: CompatibilityEvent, params?: Partial<QueryBuilderParams>): QueryBuilder<T>;
+export function serverQueryContent<T = ParsedContent>(event: CompatibilityEvent, slug?: string, ...slugParts: string[]): QueryBuilder<T>;
+export function serverQueryContent<T = ParsedContent> (_event: CompatibilityEvent, slug?: string | Partial<QueryBuilderParams>, ...slugParts: string[]) {
   let body = slug as Partial<QueryBuilderParams>
   if (typeof slug === 'string') {
     slug = withLeadingSlash(joinURL(slug, ...slugParts))
@@ -98,10 +99,10 @@ export function queryContent<T = ParsedContent> (slug?: string | Partial<QueryBu
     }
   }
   const pipelineFetcher = createPipelineFetcher<T>(
-    getContentsList as unknown as () => Promise<T[]>
+      getContentsList as unknown as () => Promise<T[]>
   )
 
   return createQuery<T>(pipelineFetcher, body)
-    // Provide default sort order
+  // Provide default sort order
     .sortBy('path', 'asc')
 }

--- a/src/runtime/server/storage.ts
+++ b/src/runtime/server/storage.ts
@@ -91,7 +91,7 @@ export function serverQueryContent<T = ParsedContent>(event: CompatibilityEvent)
 export function serverQueryContent<T = ParsedContent>(event: CompatibilityEvent, params?: Partial<QueryBuilderParams>): QueryBuilder<T>;
 export function serverQueryContent<T = ParsedContent>(event: CompatibilityEvent, slug?: string, ...slugParts: string[]): QueryBuilder<T>;
 export function serverQueryContent<T = ParsedContent> (_event: CompatibilityEvent, slug?: string | Partial<QueryBuilderParams>, ...slugParts: string[]) {
-  let params = slug as Partial<QueryBuilderParams>
+  let params = (slug || {}) as Partial<QueryBuilderParams>
   if (typeof slug === 'string') {
     slug = withLeadingSlash(joinURL(slug, ...slugParts))
     params = {

--- a/src/runtime/server/storage.ts
+++ b/src/runtime/server/storage.ts
@@ -91,18 +91,21 @@ export function serverQueryContent<T = ParsedContent>(event: CompatibilityEvent)
 export function serverQueryContent<T = ParsedContent>(event: CompatibilityEvent, params?: Partial<QueryBuilderParams>): QueryBuilder<T>;
 export function serverQueryContent<T = ParsedContent>(event: CompatibilityEvent, slug?: string, ...slugParts: string[]): QueryBuilder<T>;
 export function serverQueryContent<T = ParsedContent> (_event: CompatibilityEvent, slug?: string | Partial<QueryBuilderParams>, ...slugParts: string[]) {
-  let body = slug as Partial<QueryBuilderParams>
+  let params = slug as Partial<QueryBuilderParams>
   if (typeof slug === 'string') {
     slug = withLeadingSlash(joinURL(slug, ...slugParts))
-    body = {
+    params = {
       where: [{ slug: new RegExp(`^${slug}`) }]
     }
   }
   const pipelineFetcher = createPipelineFetcher<T>(
-      getContentsList as unknown as () => Promise<T[]>
+    getContentsList as unknown as () => Promise<T[]>
   )
 
-  return createQuery<T>(pipelineFetcher, body)
   // Provide default sort order
-    .sortBy('path', 'asc')
+  if (!params.sortBy?.length) {
+    params.sortBy = [['path', 'asc']]
+  }
+
+  return createQuery<T>(pipelineFetcher, params)
 }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue
Change server query composable interface and rename it to `serverQueryContent` #1067 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
