### PR TITLE
Revert "feat!: update json & yml transformers"

### DIFF
--- a/src/runtime/server/transformers/json.ts
+++ b/src/runtime/server/transformers/json.ts
@@ -15,17 +15,10 @@ export default {
       }
     }
 
-    // Keep array contents under `body` key
-    if (Array.isArray(parsed)) {
-      parsed = {
-        body: parsed
-      }
-    }
-
     return {
-      ...parsed,
       id,
-      type: 'json'
+      type: 'json',
+      body: parsed
     }
   }
 }

--- a/src/runtime/server/transformers/yaml.ts
+++ b/src/runtime/server/transformers/yaml.ts
@@ -4,15 +4,12 @@ export default {
   name: 'Yaml',
   extentions: ['.yml', '.yaml'],
   parse: async (id, content) => {
-    const { data } = await parseFrontMatter(`---\n${content}\n---`)
-
-    // Keep array contents under `body` key
-    const parsed = Array.isArray(data) ? { body: data } : data
+    const parsed = await parseFrontMatter(`---\n${content}\n---`)
 
     return {
-      ...parsed,
       id,
-      type: 'yaml'
+      type: 'yaml',
+      body: parsed.data
     }
   }
 }

--- a/test/features/parser-json.ts
+++ b/test/features/parser-json.ts
@@ -4,10 +4,6 @@ import { $fetch } from '@nuxt/test-utils'
 const json = `{
   "key": "value"
 }`
-const jsonArray = JSON.stringify([
-  'item 1',
-  'item 2'
-])
 const json5 = `{
   key: 'value',
   // comments
@@ -35,7 +31,9 @@ export const testJSONParser = () => {
 
       expect(parsed).toHaveProperty('id')
       assert(parsed.id === 'content:index.json')
-      assert(parsed.key === 'value')
+
+      expect(parsed).toHaveProperty('body')
+      expect(parsed.body).toHaveProperty('key', 'value')
     })
   })
 
@@ -52,29 +50,12 @@ export const testJSONParser = () => {
       expect(parsed).toHaveProperty('id')
       assert(parsed.id === 'content:index.json5')
 
-      assert(parsed.key === 'value')
+      expect(parsed).toHaveProperty('body')
+      expect(parsed.body).toHaveProperty('key', 'value')
 
-      expect(parsed.leadingDecimalPoint).toEqual(0.8675309)
-      expect(parsed.andTrailing).toEqual(8675309)
-      expect(parsed.lineBreaks).toEqual("Look, Mom! No \n's!")
+      expect(parsed.body.leadingDecimalPoint).toEqual(0.8675309)
+      expect(parsed.body.andTrailing).toEqual(8675309)
+      expect(parsed.body.lineBreaks).toEqual("Look, Mom! No \n's!")
     })
-  })
-
-  test('array', async () => {
-    const parsed = await $fetch('/api/parse', {
-      method: 'POST',
-      body: {
-        id: 'content:index.json',
-        content: jsonArray
-      }
-    })
-
-    expect(parsed).toHaveProperty('id')
-    assert(parsed.id === 'content:index.json')
-
-    expect(parsed).haveOwnProperty('body')
-    expect(Array.isArray(parsed.body)).toBeTruthy()
-    expect(parsed.body).toHaveLength(2)
-    expect(parsed.body).toMatchObject(['item 1', 'item 2'])
   })
 }

--- a/test/features/parser-yaml.ts
+++ b/test/features/parser-yaml.ts
@@ -15,25 +15,8 @@ export const testYamlParser = () => {
       expect(parsed).toHaveProperty('id')
       assert(parsed.id === 'content:index.yml')
 
-      expect(parsed).toHaveProperty('key', 'value')
-    })
-
-    test('array', async () => {
-      const parsed = await $fetch('/api/parse', {
-        method: 'POST',
-        body: {
-          id: 'content:index.yml',
-          content: '- item 1 \n- item 2'
-        }
-      })
-
-      expect(parsed).toHaveProperty('id')
-      assert(parsed.id === 'content:index.yml')
-
-      expect(parsed).haveOwnProperty('body')
-      expect(Array.isArray(parsed.body)).toBeTruthy()
-      expect(parsed.body).toHaveLength(2)
-      expect(parsed.body).toMatchObject(['item 1', 'item 2'])
+      expect(parsed).toHaveProperty('body')
+      expect(parsed.body).toHaveProperty('key', 'value')
     })
   })
 }


### PR DESCRIPTION
Reverts nuxt/content#1095

After discussions we stated that merging data objects would not be the pattern supported in v2.

This is a breaking change from v1 and will stay as is for consistency concerns over parsed content objects.