### PR TITLE
docs(typescript): fix repo url

### DIFF
--- a/docs/content/1.guide/2.displaying/4.typescript.md
+++ b/docs/content/1.guide/2.displaying/4.typescript.md
@@ -48,5 +48,5 @@ We want to provide fully generated type for each content in your project, that w
 This is not yet implemented but will be part of the roadmap in upcoming months.
 
 ::alert{type="warning"}
-You can track #1057 if you want to know more about roadmap for TypeScript support of front-matter keys.
+You can track [#1057](https://github.com/nuxt/content/issues/1057) if you want to know more about roadmap for TypeScript support of front-matter keys.
 ::


### PR DESCRIPTION
### 🔗 Linked issue

#1101

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

It seems like `#1057` in `alert` component is parsed incorrectly, it linked to https://github.com/content/nuxt/issues/1057, not nuxt/content.
I tried to fix it in alert compoennt, but I failed, the doc will be public in 19 May, I think it better to fix it immediately.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
