### PR TITLE
fix(`<Markdown>`): prevent vDOM manipulation

### DIFF
--- a/src/runtime/components/Markdown.ts
+++ b/src/runtime/components/Markdown.ts
@@ -52,15 +52,24 @@ export default defineComponent({
 
       const unwrapped = flatUnwrap(slot(), tags)
 
-      return between
-        ? unwrapped.flatMap((vnode, index) => index === 0 ? [vnode] : [between(), vnode])
-        : unwrapped.reduce((acc, item) => {
-        // Concat raw texts to prevent hydration mismatches
-          (typeof item.children === 'string' && acc.length && typeof acc[acc.length - 1].children === 'string')
-            ? acc[acc.length - 1].children += item.children
-            : acc.push(item)
-          return acc
-        }, [])
+      if (between) {
+        return unwrapped.flatMap(
+          (vnode, index) => index === 0 ? [vnode] : [between(), vnode]
+        )
+      }
+
+      return unwrapped.reduce((acc, item) => {
+        if (typeof item.children === 'string') {
+          if (typeof acc[acc.length - 1] === 'string') {
+            acc[acc.length - 1] += item.children
+          } else {
+            acc.push(item.children)
+          }
+        } else {
+          acc.push(item)
+        }
+        return acc
+      }, [])
     } catch (e) {
       // Catching errors to allow content reactivity
       return h('div')


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Changing vDOM nodes directly will lead to unexpected behaviors in future renders. Instead of manipulating existed nodes we need to create new nodes. 

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
