### PR TITLE
fix(query): handle nullable fields in sort

### DIFF
--- a/src/runtime/query/match/utils.ts
+++ b/src/runtime/query/match/utils.ts
@@ -67,6 +67,9 @@ export const sortList = (data: any[], params: SortOptions) => {
   for (const key of keys) {
     data = data.sort((a, b) => {
       const values = [get(a, key), get(b, key)]
+        // `null` values are treated as `"null"` strings and ordered alphabetically
+        // Turn `null` values into `undefined` so they place at the end of the list
+        .map(value => value === null ? undefined : value)
       if (params[key] === 0) {
         values.reverse()
       }

--- a/test/features/query/query.test.ts
+++ b/test/features/query/query.test.ts
@@ -91,6 +91,18 @@ describe('Database Provider', () => {
     })
   })
 
+  test('Sort Nullable fields', async () => {
+    const fetcher = createPipelineFetcher(() => Promise.resolve([{ id: 1, name: 'Saman' }, { id: 2, name: 'Ebi' }, { id: 3, name: 'Narges' }, { id: 4, name: null }] as any[]))
+    const result = await createQuery(fetcher)
+      .sort({ name: 1 })
+      .find()
+
+    assert(result[0].name === 'Ebi')
+    assert(result[1].name === 'Narges')
+    assert(result[2].name === 'Saman')
+    assert(result[3].name === null)
+  })
+
   test('Apply $in', async () => {
     const result = await createQuery(pipelineFetcher)
       .where({


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue
#1006

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
