### PR TITLE
feat: internal cache version

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -18,6 +18,7 @@ import { listen } from 'listhen'
 import type { WatchEvent } from 'unstorage'
 import { name, version } from '../package.json'
 import {
+  CACHE_VERSION,
   createWebSocket,
   MOUNT_PREFIX,
   processMarkdownOptions,
@@ -386,7 +387,7 @@ export default defineNuxtModule<ModuleOptions>({
     })
     // Context will use in server
     nuxt.options.runtimeConfig.content = {
-      version,
+      cacheVersion: CACHE_VERSION,
       ...contentContext as any
     }
 
@@ -437,7 +438,11 @@ interface ModulePublicRuntimeConfig {
 }
 
 interface ModulePrivateRuntimeConfig {
-  version: string;
+  /**
+   * Internal version that represents cache format.
+   * This is used to invalidate cache when the format changes.
+   */
+  cacheVersion: string;
 }
 
 declare module '@nuxt/schema' {

--- a/src/runtime/server/storage.ts
+++ b/src/runtime/server/storage.ts
@@ -98,7 +98,7 @@ export const getContent = async (event: CompatibilityEvent, id: string): Promise
   const hash = ohash({
     meta,
     // Add Content version to the hash, to revalidate the cache on content update
-    version: contentConfig.version
+    version: contentConfig.cacheVersion
   })
   if (cached?.hash === hash) {
     return cached.parsed as ParsedContent

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -7,6 +7,12 @@ import { WebSocketServer } from 'ws'
 import { useLogger } from '@nuxt/kit'
 import type { ModuleOptions, MountOptions } from './module'
 
+/**
+ * Internal version that represents cache format.
+ * This is used to invalidate cache when the format changes.
+ */
+export const CACHE_VERSION = 2
+
 export const MOUNT_PREFIX = 'content:source:'
 
 export const PROSE_TAGS = [


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

> You could preserve an internal version that represents cache format independent from module versioning
https://github.com/nuxt/content/pull/1099#issuecomment-1132829442

Introduce `cacheVersion` config to invalidate content caches instead of using module version.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
