### PR TITLE
fix(websocket): disconnect clients on close

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -103,7 +103,12 @@ export function createWebSocket () {
   return {
     serve,
     broadcast,
-    close: () => new Promise(resolve => wss.close(resolve))
+    close: () => {
+      // disconnect all clients
+      wss.clients.forEach(client => client.close())
+      // close the server
+      return new Promise(resolve => wss.close(resolve))
+    }
   }
 }
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Disconnect all client before closing WebSocket server. This will in-force reconnecting to new websocket server without reloading the page.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
