### PR TITLE
fix: remove trailing slash to support nuxt generate

### DIFF
--- a/src/runtime/components/ContentQuery.ts
+++ b/src/runtime/components/ContentQuery.ts
@@ -1,4 +1,5 @@
 import { PropType, toRefs, defineComponent, h, useSlots } from 'vue'
+import { withLeadingSlash, withoutTrailingSlash } from 'ufo'
 import type { ParsedContent, QueryBuilder, SortParams } from '../types'
 import { computed, useAsyncData, queryContent } from '#imports'
 
@@ -102,7 +103,10 @@ export default defineComponent({
       () => {
         let queryBuilder: QueryBuilder = queryContent()
 
-        if (path.value) { queryBuilder = queryBuilder.where({ _path: path.value }) }
+        if (path.value) {
+          const _path = withLeadingSlash(withoutTrailingSlash(path.value))
+          queryBuilder = queryBuilder.where({ _path })
+        }
 
         if (only.value) { queryBuilder = queryBuilder.only(only.value) }
 

--- a/src/runtime/composables/query.ts
+++ b/src/runtime/composables/query.ts
@@ -1,4 +1,4 @@
-import { joinURL, withLeadingSlash } from 'ufo'
+import { joinURL, withLeadingSlash, withoutTrailingSlash } from 'ufo'
 import { hash } from 'ohash'
 import { useHead, useCookie } from '#app'
 import { createQuery } from '../query/query'
@@ -39,7 +39,7 @@ export function queryContent<T = ParsedContent>(query: string, ...pathParts: str
 export function queryContent<T = ParsedContent> (query: QueryBuilderParams): QueryBuilder<T>;
 export function queryContent<T = ParsedContent> (query?: string | QueryBuilderParams, ...pathParts: string[]) {
   if (typeof query === 'string') {
-    const path = withLeadingSlash(joinURL(query, ...pathParts))
+    const path = withLeadingSlash(withoutTrailingSlash(joinURL(query, ...pathParts)))
 
     return createQuery<T>(queryFetch).where({ _path: new RegExp(`^${path}`) })
   }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
When using `nuxt generate` and deployed on `surge.sh`, a trailing slash is added automatically, making a new request on client-side with a different query hash. Removing the trailing slash fixes it.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
