### PR TITLE
 fix: content query not showing child files #1141

### DIFF
--- a/src/runtime/components/ContentQuery.ts
+++ b/src/runtime/components/ContentQuery.ts
@@ -105,7 +105,7 @@ export default defineComponent({
 
         if (path.value) {
           const _path = withLeadingSlash(withoutTrailingSlash(path.value))
-          queryBuilder = queryBuilder.where({ _path: { $regex: _path } })
+          queryBuilder = queryBuilder.where({ _path: { $regex: `^${_path}` } })
         }
 
         if (only.value) { queryBuilder = queryBuilder.only(only.value) }

--- a/src/runtime/components/ContentQuery.ts
+++ b/src/runtime/components/ContentQuery.ts
@@ -105,7 +105,7 @@ export default defineComponent({
 
         if (path.value) {
           const _path = withLeadingSlash(withoutTrailingSlash(path.value))
-          queryBuilder = queryBuilder.where({ _path })
+          queryBuilder = queryBuilder.where({ _path: { $regex: _path } })
         }
 
         if (only.value) { queryBuilder = queryBuilder.only(only.value) }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

#1141 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Content queries didn't seem to be working quite right when querying folders. If there was a matching exact file then it seemed to work ok but `ContentList` and `ContentQuery` that were pointing at folders seemed to be broken.

Looks like the intention was for the path was to match the start allowing a list of all child content pages to be returned.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
