### PR TITLE
docs: added information on sitemap generation

### DIFF
--- a/docs/content/3.guide/2.displaying/5.sitemaps.md
+++ b/docs/content/3.guide/2.displaying/5.sitemaps.md
@@ -1,0 +1,36 @@
+---
+title: Sitemaps
+---
+
+A sitemap file is useful for helping Google to better index your website, ensuring that the content you write can be visible on search results.
+
+This can be created utilising the `sitemap` library, so you'll need to install that which can be done like so:
+  ```bash
+  yarn add sitemap
+  ```
+
+## Server Route
+We will be utilising the server routes available within Nuxt 3, and to do so you'll need to create the `server/` folder within your websites root directly.
+
+Once this is done, create a `routes/` folder inside this, and add a `sitemap.xml.ts` file, this corresponds to `https://example.com/sitemap.xml`.
+
+You'll need to add the following:
+
+```yaml [server/routes/sitemap.xml.ts]
+import {serverQueryContent} from '#content/server';
+import {SitemapStream, streamToPromise} from 'sitemap';
+
+export default defineEventHandler(async (event) => {
+    const articles = await serverQueryContent(event).find();
+
+    const sitemap = new SitemapStream({ hostname: 'https://example.com' });
+    articles.forEach((article) => sitemap.write({ url: article._path, changefreq: 'monthly' }));
+    sitemap.end();
+
+    let data = await streamToPromise(sitemap);
+    return data;
+});
+
+```
+
+Now, once users go to `https://example.com/sitemap.xml`, you'll find the generated XML file with all your blog posts.


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue
https://github.com/Atinux/content-wind/issues/5

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
Sometimes users may want to generate a sitemap file, to make it easier for Google to index the content within your website. I personally had this issue, and after a discussion with @Atinux within https://github.com/Atinux/content-wind/issues/5, he felt this could be good addition to the docs.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
