### PR TITLE
docs: correctly link to catch-all documentation

### DIFF
--- a/docs/content/3.guide/2.displaying/1.rendering.md
+++ b/docs/content/3.guide/2.displaying/1.rendering.md
@@ -20,7 +20,7 @@ The `<ContentDoc>` component fetches a document and renders it in a rich-text fo
 
 The fetching endpoint defaults to the current route (`$route.path`). An explicit path can be passed to the component with the `path` props.
 
-Create a [catch all route](/guide/directory-structure/pages#catch-all-route) named `pages/[...slug].vue` and the component:
+Create a [catch all route](https://v3.nuxtjs.org/guide/directory-structure/pages/#catch-all-route) named `pages/[...slug].vue` and the component:
 
 ```vue [pages/[...slug].vue]
 <template>


### PR DESCRIPTION
### 🔗 Linked issue

None, as this is a trivial typo-ish problem. 🙂 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The link to Nuxt 3's catch-all route documentation points to an internal path, but the correct path is naturally located under the v3.nuxtjs.org.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
