### PR TITLE
docs: fix querying example route is not defined

### DIFF
--- a/docs/content/3.guide/2.displaying/2.querying.md
+++ b/docs/content/3.guide/2.displaying/2.querying.md
@@ -129,7 +129,7 @@ This example uses the `where()`{lang="ts"} and `only()`{lang="ts"} methods to fe
 <script setup>
 const { path } = useRoute()
 
-const { data } = await useAsyncData(`content-${route.path}`, () => {
+const { data } = await useAsyncData(`content-${path}`, () => {
   return queryContent().where({ _path: path }).only(['title']).findOne()
 })
 </script>


### PR DESCRIPTION
### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

In the current example, route is being destructured to only use the path property, so I've replaced `route.path` with just `path` to not get a `route is not defined` error


### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
