### PR TITLE
fix(ContentQuery): generate cache key based on props

### DIFF
--- a/src/runtime/components/ContentQuery.ts
+++ b/src/runtime/components/ContentQuery.ts
@@ -1,3 +1,4 @@
+import { hash } from 'ohash'
 import { PropType, toRefs, defineComponent, h, useSlots } from 'vue'
 import type { ParsedContent, QueryBuilder, SortParams } from '../types'
 import { computed, useAsyncData, queryContent } from '#imports'
@@ -98,7 +99,7 @@ export default defineComponent({
     const isPartial = computed(() => path.value.includes('/_'))
 
     const { data, refresh } = await useAsyncData<ParsedContent | ParsedContent[]>(
-      `content-doc-${path.value}`,
+      `content-query-${hash(props)}`,
       () => {
         let queryBuilder: QueryBuilder
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Generate cache key based on component props to prevent conflict between different usages. (For example using `ContentDoc` and `ContentList` with same path)

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
