### PR TITLE
fix(sort): use `-1` for descending same as mongo syntax

### DIFF
--- a/src/runtime/query/match/utils.ts
+++ b/src/runtime/query/match/utils.ts
@@ -70,7 +70,7 @@ export const sortList = (data: any[], params: SortOptions) => {
         // `null` values are treated as `"null"` strings and ordered alphabetically
         // Turn `null` values into `undefined` so they place at the end of the list
         .map(value => value === null ? undefined : value)
-      if (params[key] === 0) {
+      if (params[key] === -1) {
         values.reverse()
       }
       return comperable.compare(values[0], values[1])

--- a/src/runtime/types.d.ts
+++ b/src/runtime/types.d.ts
@@ -148,7 +148,7 @@ export interface SortParams {
 }
 
 export interface SortFields {
-  [field: string]: 0 | 1
+  [field: string]: -1 | 1
 }
 
 export type SortOptions = SortParams | SortFields

--- a/test/features/query/query.test.ts
+++ b/test/features/query/query.test.ts
@@ -43,7 +43,7 @@ describe('Database Provider', () => {
     const nameAsc = await createQuery(pipelineFetcher).sort({ name: 1 }).find()
     assert(nameAsc[0].name === database[0].name)
 
-    const nameDesc = await createQuery(pipelineFetcher).sort({ name: 0 }).find()
+    const nameDesc = await createQuery(pipelineFetcher).sort({ name: -1 }).find()
     assert(nameDesc[0].name === database[database.length - 1].name)
   })
 

--- a/test/features/query/utils.test.ts
+++ b/test/features/query/utils.test.ts
@@ -74,7 +74,7 @@ describe('query utils', () => {
       { a: 2, b: 1 }
     ])
 
-    expect(sortList(data, { a: 0 })).toEqual([
+    expect(sortList(data, { a: -1 })).toEqual([
       { a: 2, b: 1 },
       { a: 1, b: 2 },
       { a: 1, b: 1 }
@@ -86,7 +86,7 @@ describe('query utils', () => {
       { a: 1, b: 2 }
     ])
 
-    expect(sortList(data, { b: 0 })).toEqual([
+    expect(sortList(data, { b: -1 })).toEqual([
       { a: 1, b: 2 },
       { a: 2, b: 1 },
       { a: 1, b: 1 }
@@ -97,8 +97,8 @@ describe('query utils', () => {
     const data = [{ data: { a: 1, b: 2 } }, { data: { a: 2, b: 1 } }, { data: { a: 1, b: 1 } }]
 
     // sort by a descending
-    const aDesc = sortList(data, { 'data.a': 0 })
-    expect(sortList(aDesc, { 'data.b': 0 })).toEqual([
+    const aDesc = sortList(data, { 'data.a': -1 })
+    expect(sortList(aDesc, { 'data.b': -1 })).toEqual([
       { data: { a: 1, b: 2 } },
       { data: { a: 2, b: 1 } },
       { data: { a: 1, b: 1 } }
@@ -112,6 +112,6 @@ describe('query utils', () => {
     ])
 
     // Sort again by a desc.
-    expect(sortList(aDesc, { 'data.a': 0 })).toEqual(aDesc)
+    expect(sortList(aDesc, { 'data.a': -1 })).toEqual(aDesc)
   })
 })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The idea is to match sort syntax with mongo db syntax. Mongodb uses `1` for ascending and `-1` for descending sorts. 
This PR will introduce a breaking change in sorting behavior. Former this content modules used `0` for  descending sort.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
