### PR TITLE
fix(types): more accurately represent `ParsedContentMeta`

### DIFF
--- a/src/runtime/server/transformers/path-meta.ts
+++ b/src/runtime/server/transformers/path-meta.ts
@@ -6,14 +6,14 @@ import { useRuntimeConfig } from '#imports'
 
 const SEMVER_REGEX = /^(\d+)(\.\d+)*(\.x)?$/
 
-const describeId = (_id: string): Partial<ParsedContentMeta> => {
+const describeId = (_id: string) => {
   const [_source, ...parts] = _id.split(':')
 
   const [, filename, _extension] = parts[parts.length - 1].match(/(.*)\.([^.]+)$/)
   parts[parts.length - 1] = filename
   const _path = parts.join('/')
 
-  return {
+  return <Pick<ParsedContentMeta, '_source' | '_path' | '_extension' | '_file'>> {
     _source,
     _path,
     _extension,

--- a/src/runtime/server/transformers/path-meta.ts
+++ b/src/runtime/server/transformers/path-meta.ts
@@ -1,11 +1,12 @@
 import { pascalCase } from 'scule'
 import slugify from 'slugify'
 import { withoutTrailingSlash, withLeadingSlash } from 'ufo'
+import { ParsedContentMeta } from '../../types'
 import { useRuntimeConfig } from '#imports'
 
 const SEMVER_REGEX = /^(\d+)(\.\d+)*(\.x)?$/
 
-const describeId = (_id: string) => {
+const describeId = (_id: string): Partial<ParsedContentMeta> => {
   const [_source, ...parts] = _id.split(':')
 
   const [, filename, _extension] = parts[parts.length - 1].match(/(.*)\.([^.]+)$/)
@@ -33,7 +34,7 @@ export default {
 
     const filePath = parts.join('/')
 
-    return {
+    return <ParsedContentMeta> {
       _path: generatePath(filePath),
       _draft: isDraft(filePath),
       _partial: isPartial(filePath),

--- a/src/runtime/types.d.ts
+++ b/src/runtime/types.d.ts
@@ -30,10 +30,6 @@ export interface ParsedContentMeta {
    */
   _locale?: boolean
   /**
-   * Content is empty
-   */
-  _empty?: boolean
-  /**
    * File type of the content, i.e `markdown`
    */
   _type?: boolean

--- a/src/runtime/types.d.ts
+++ b/src/runtime/types.d.ts
@@ -14,10 +14,6 @@ export interface ParsedContentMeta {
    */
   _path?: string
   /**
-   * Content slug
-   */
-  _slug?: string
-  /**
    * Content title
    */
   title?: string
@@ -33,6 +29,22 @@ export interface ParsedContentMeta {
    * Content locale
    */
   _locale?: boolean
+  /**
+   * Content is empty
+   */
+  _empty?: boolean
+  /**
+   * File type of the content, i.e `markdown`
+   */
+  _type?: boolean
+  /**
+   * Path to the file relative to the content directory.
+   */
+  _file?: string
+  /**
+   * Extension of the file
+   */
+  _extension?: string
 
   [key: string]: any
 }

--- a/src/runtime/types.d.ts
+++ b/src/runtime/types.d.ts
@@ -32,7 +32,7 @@ export interface ParsedContentMeta {
   /**
    * File type of the content, i.e `markdown`
    */
-  _type?: boolean
+  _type?: string
   /**
    * Path to the file relative to the content directory
    */

--- a/src/runtime/types.d.ts
+++ b/src/runtime/types.d.ts
@@ -34,7 +34,7 @@ export interface ParsedContentMeta {
    */
   _type?: boolean
   /**
-   * Path to the file relative to the content directory.
+   * Path to the file relative to the content directory
    */
   _file?: string
   /**
@@ -45,7 +45,7 @@ export interface ParsedContentMeta {
   [key: string]: any
 }
 
-export interface ParsedContent extends ParsedContentMeta{
+export interface ParsedContent extends ParsedContentMeta {
   /**
    * Excerpt
    */


### PR DESCRIPTION
### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

- `_slug` is not used but is in the types, which is misleading
- full list of id types (`_type`, `_file`, `_extension`) are missing
- added types to the path-meta file to ensure stricter type adherence

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
