### PR TITLE
feat(types): expose `MarkdownParsedContent` for improved type generics

### DIFF
--- a/docs/content/3.guide/2.displaying/4.typescript.md
+++ b/docs/content/3.guide/2.displaying/4.typescript.md
@@ -39,6 +39,27 @@ const { data } = await useAsyncData(
 </script>
 ```
 
+## Markdown Specific Types
+
+If you know the content being fetched will be Markdown, then you can extend the `MarkdownParsedContent`{lang="ts"} type for improved
+type-safety.
+
+```vue
+<script setup lang="ts">
+import type { MarkdownParsedContent } from '@nuxt/content/dist/runtime/types'
+
+interface Article extends MarkdownParsedContent {
+  author: string
+}
+const { data } = await useAsyncData(
+  'first-article',  
+  () => queryContent<Article>('articles').findOne()
+)
+// data.value.author will be typed as well as markdown specific entries
+</script>
+```
+
+
 ## The future
 
 TypeScript support is a strong focus for us.

--- a/src/runtime/markdown-parser/index.ts
+++ b/src/runtime/markdown-parser/index.ts
@@ -8,7 +8,7 @@ import remarkGfm from 'remark-gfm'
 import rehypeSortAttributeValues from 'rehype-sort-attribute-values'
 import rehypeSortAttributes from 'rehype-sort-attributes'
 import rehypeRaw from 'rehype-raw'
-import { MarkdownOptions, Toc } from '../types'
+import { MarkdownOptions, MarkdownParsedContent, Toc } from '../types'
 import { parseFrontMatter } from './remark-mdc/frontmatter'
 import { generateToc } from './toc'
 import { contentHeading, generateBody } from './content'
@@ -61,7 +61,7 @@ export async function parse (file: string, userOptions: Partial<MarkdownOptions>
    */
   const heading = contentHeading(body)
 
-  return {
+  return <{ meta: Partial<MarkdownParsedContent>, body: MarkdownParsedContent['body'] }> {
     body: {
       ...body,
       toc

--- a/src/runtime/server/transformers/markdown.ts
+++ b/src/runtime/server/transformers/markdown.ts
@@ -1,5 +1,6 @@
 import { parse } from '../../markdown-parser'
 import type { MarkdownOptions } from '../../types'
+import { MarkdownParsedContent } from '../../types'
 import { useRuntimeConfig } from '#imports'
 
 const importPlugin = async (p: [string, any]) => ([
@@ -17,7 +18,7 @@ export default {
 
     const parsed = await parse(content, config)
 
-    return {
+    return <MarkdownParsedContent> {
       ...parsed.meta,
       body: parsed.body,
       _type: 'markdown',

--- a/src/runtime/types.d.ts
+++ b/src/runtime/types.d.ts
@@ -103,6 +103,22 @@ export interface Toc {
   links: TocLink[]
 }
 
+export interface MarkdownParsedContent extends ParsedContent {
+  _type: 'markdown',
+  /**
+   * Content is empty
+   */
+  _empty?: boolean
+  /**
+   * Content description
+   */
+  description: string
+  excerpt?: MarkdownRoot
+  body: MarkdownRoot & {
+    toc?: Toc
+  }
+}
+
 export interface ContentTransformer {
   name: string
   extentions: string[]

--- a/src/runtime/types.d.ts
+++ b/src/runtime/types.d.ts
@@ -113,7 +113,13 @@ export interface MarkdownParsedContent extends ParsedContent {
    * Content description
    */
   description: string
+  /**
+   * Content excerpt, generated from content
+   */
   excerpt?: MarkdownRoot
+  /**
+   * Parsed Markdown body with included table of contents.
+   */
   body: MarkdownRoot & {
     toc?: Toc
   }

--- a/src/runtime/types.d.ts
+++ b/src/runtime/types.d.ts
@@ -108,7 +108,7 @@ export interface MarkdownParsedContent extends ParsedContent {
   /**
    * Content is empty
    */
-  _empty?: boolean
+  _empty: boolean
   /**
    * Content description
    */


### PR DESCRIPTION
### 🔗 Linked issue

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Add a Markdown specific parsed content schema, allowing end-users to build generics that have better type safety.

I did see https://github.com/nuxt/content/issues/1057, I'd presume we'd need a safer type for markdown files when that's built so this should help with that.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
