### PR TITLE
feat(types): provide augmentations for `only` and `without`

### DIFF
--- a/src/runtime/query/query.ts
+++ b/src/runtime/query/query.ts
@@ -29,7 +29,7 @@ export const createQuery = <T>(
 
   const query: QueryBuilder<T> = {
     params: () => Object.freeze(params),
-    only: $set('only', ensureArray),
+    only: $set('only', ensureArray) as () => ReturnType<QueryBuilder<T>['only']>,
     without: $set('without', ensureArray),
     where: $set('where', (q: any) => [...ensureArray(params.where), q]),
     sort: $set('sort', (sort: SortOptions) => [...ensureArray(params.sort), ...ensureArray(sort)]),

--- a/src/runtime/query/query.ts
+++ b/src/runtime/query/query.ts
@@ -1,10 +1,10 @@
 import type { DatabaseFetcher, QueryBuilder, QueryBuilderParams, SortOptions } from '../types'
-import { ParsedContentMeta } from '../types'
+import { ParsedContent } from '../types'
 import { ensureArray } from './match/utils'
 
 const arrayParams = ['sort', 'where', 'only', 'without']
 
-export const createQuery = <T = ParsedContentMeta>(
+export const createQuery = <T = ParsedContent>(
   fetcher: DatabaseFetcher<T>,
   queryParams?: Partial<QueryBuilderParams>
 ): QueryBuilder<T> => {

--- a/src/runtime/query/query.ts
+++ b/src/runtime/query/query.ts
@@ -1,9 +1,10 @@
 import type { DatabaseFetcher, QueryBuilder, QueryBuilderParams, SortOptions } from '../types'
+import { ParsedContentMeta } from '../types'
 import { ensureArray } from './match/utils'
 
 const arrayParams = ['sort', 'where', 'only', 'without']
 
-export const createQuery = <T>(
+export const createQuery = <T = ParsedContentMeta>(
   fetcher: DatabaseFetcher<T>,
   queryParams?: Partial<QueryBuilderParams>
 ): QueryBuilder<T> => {

--- a/src/runtime/types.d.ts
+++ b/src/runtime/types.d.ts
@@ -174,12 +174,14 @@ export interface QueryBuilder<T = ParsedContentMeta> {
   /**
    * Select a subset of fields
    */
-  only(keys: string | string[]): QueryBuilder<T>
+  only<K extends keyof T | string>(keys: K): QueryBuilder<Pick<T, K>>
+  only<K extends (keyof T | string)[]>(keys: K): QueryBuilder<Pick<T, K[number]>>
 
   /**
    * Remove a subset of fields
    */
-  without(keys: string | string[]): QueryBuilder<T>
+  without<K extends keyof T | string>(keys: K): QueryBuilder<Omit<T, K>>
+  without<K extends (keyof T | string)[]>(keys: K): QueryBuilder<Omit<T, K[number]>>
 
   /**
    * Sort results


### PR DESCRIPTION
### 🔗 Linked issue

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Allows type hinting on the keys for `only` and `without` as well as augmenting the result which will either include or exclude the provided keys from the IntelliSense respectively.

![image](https://user-images.githubusercontent.com/5326365/171581964-1218f469-467d-4ad8-9f64-1305311bed2d.png)

![image](https://user-images.githubusercontent.com/5326365/171582064-88da8d23-b32c-4d2f-9b90-ebcf9fefb060.png)

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
