### PR TITLE
fix(types): change `QueryBuilderParams` keys to partial

### DIFF
--- a/src/runtime/composables/query.ts
+++ b/src/runtime/composables/query.ts
@@ -9,7 +9,7 @@ import { withContentBase } from './utils'
 /**
  * Query fetcher
  */
-export const queryFetch = <T = ParsedContent>(params: Partial<QueryBuilderParams>) => {
+export const queryFetch = <T = ParsedContent>(params: QueryBuilderParams) => {
   const apiPath = withContentBase(process.dev ? '/query' : `/query/${hash(params)}`)
 
   // Prefetch the query

--- a/src/runtime/query/match/pipeline.ts
+++ b/src/runtime/query/match/pipeline.ts
@@ -1,4 +1,4 @@
-import type { QueryBuilderParams, QueryPipe } from '../../types'
+import type { QueryBuilderParams, QueryBuilderSchema, QueryPipe } from '../../types'
 import { apply, ensureArray, sortList, withoutKeys, withKeys } from './utils'
 import { createMatch } from '.'
 
@@ -9,7 +9,7 @@ export function createPipelineFetcher<T> (getContentsList: () => Promise<T[]>) {
   /**
    * Exctract surrounded items of specific condition
    */
-  const surround = (data: any[], { query, before, after }: QueryBuilderParams['surround']) => {
+  const surround = (data: any[], { query, before, after }: QueryBuilderSchema['surround']) => {
     const matchQuery = typeof query === 'string' ? { _path: query } : query
     // Find matched item index
     const index = data.findIndex(item => match(item, matchQuery))

--- a/src/runtime/query/match/pipeline.ts
+++ b/src/runtime/query/match/pipeline.ts
@@ -1,4 +1,4 @@
-import type { QueryBuilderParams, QueryBuilderSchema, QueryPipe } from '../../types'
+import type { QueryBuilderParams, QueryPipe } from '../../types'
 import { apply, ensureArray, sortList, withoutKeys, withKeys } from './utils'
 import { createMatch } from '.'
 
@@ -9,7 +9,7 @@ export function createPipelineFetcher<T> (getContentsList: () => Promise<T[]>) {
   /**
    * Exctract surrounded items of specific condition
    */
-  const surround = (data: any[], { query, before, after }: QueryBuilderSchema['surround']) => {
+  const surround = (data: any[], { query, before, after }: QueryBuilderParams['surround']) => {
     const matchQuery = typeof query === 'string' ? { _path: query } : query
     // Find matched item index
     const index = data.findIndex(item => match(item, matchQuery))

--- a/src/runtime/query/query.ts
+++ b/src/runtime/query/query.ts
@@ -5,7 +5,7 @@ const arrayParams = ['sort', 'where', 'only', 'without']
 
 export const createQuery = <T>(
   fetcher: DatabaseFetcher<T>,
-  queryParams?: Partial<QueryBuilderParams>
+  queryParams?: QueryBuilderParams
 ): QueryBuilder<T> => {
   const params = {
     ...queryParams

--- a/src/runtime/server/api/navigation.ts
+++ b/src/runtime/server/api/navigation.ts
@@ -1,11 +1,11 @@
 import { defineEventHandler } from 'h3'
 import { serverQueryContent } from '../storage'
 import { createNav } from '../navigation'
-import { ParsedContentMeta, QueryBuilderParams } from '../../types'
+import { ParsedContentMeta } from '../../types'
 import { getContentQuery } from '../../utils/query'
 
 export default defineEventHandler(async (event) => {
-  const query: Partial<QueryBuilderParams> = getContentQuery(event)
+  const query = getContentQuery(event)
 
   const contents = await serverQueryContent(event, query)
     .where({

--- a/src/runtime/server/api/query.ts
+++ b/src/runtime/server/api/query.ts
@@ -1,10 +1,9 @@
 import { createError, defineEventHandler } from 'h3'
-import type { QueryBuilderParams } from '../../types'
 import { serverQueryContent } from '../storage'
 import { getContentQuery } from '../../utils/query'
 
 export default defineEventHandler(async (event) => {
-  const query: Partial<QueryBuilderParams> = getContentQuery(event)
+  const query = getContentQuery(event)
   const contents = await serverQueryContent(event, query).find()
 
   // If no documents matchs and using findOne()

--- a/src/runtime/server/storage.ts
+++ b/src/runtime/server/storage.ts
@@ -122,10 +122,10 @@ export const getContent = async (event: CompatibilityEvent, id: string): Promise
  * Query contents
  */
 export function serverQueryContent<T = ParsedContent>(event: CompatibilityEvent): QueryBuilder<T>;
-export function serverQueryContent<T = ParsedContent>(event: CompatibilityEvent, params?: Partial<QueryBuilderParams>): QueryBuilder<T>;
+export function serverQueryContent<T = ParsedContent>(event: CompatibilityEvent, params?: QueryBuilderParams): QueryBuilder<T>;
 export function serverQueryContent<T = ParsedContent>(event: CompatibilityEvent, path?: string, ...pathParts: string[]): QueryBuilder<T>;
-export function serverQueryContent<T = ParsedContent> (event: CompatibilityEvent, path?: string | Partial<QueryBuilderParams>, ...pathParts: string[]) {
-  let params = (path || {}) as Partial<QueryBuilderParams>
+export function serverQueryContent<T = ParsedContent> (event: CompatibilityEvent, path?: string | QueryBuilderParams, ...pathParts: string[]) {
+  let params = (path || {}) as QueryBuilderParams
   if (typeof path === 'string') {
     path = withLeadingSlash(joinURL(path, ...pathParts))
     // escape regex special chars

--- a/src/runtime/types.d.ts
+++ b/src/runtime/types.d.ts
@@ -153,15 +153,15 @@ export interface SortFields {
 
 export type SortOptions = SortParams | SortFields
 
-export interface QueryBuilderSchema {
-  first: boolean
-  skip: number
-  limit: number
-  only: string[]
-  without: string[]
-  sort: SortOptions[]
-  where: object[]
-  surround: {
+export interface QueryBuilderParams {
+  first?: boolean
+  skip?: number
+  limit?: number
+  only?: string[]
+  without?: string[]
+  sort?: SortOptions[]
+  where?: object[]
+  surround?: {
     query: string | object
     before?: number
     after?: number
@@ -169,8 +169,6 @@ export interface QueryBuilderSchema {
 
   [key: string]: any
 }
-
-export type QueryBuilderParams = Partial<QueryBuilderSchema>
 
 export interface QueryBuilder<T = ParsedContentMeta> {
   /**

--- a/src/runtime/types.d.ts
+++ b/src/runtime/types.d.ts
@@ -153,7 +153,7 @@ export interface SortFields {
 
 export type SortOptions = SortParams | SortFields
 
-export interface QueryBuilderParams {
+export interface QueryBuilderSchema {
   first: boolean
   skip: number
   limit: number
@@ -169,6 +169,8 @@ export interface QueryBuilderParams {
 
   [key: string]: any
 }
+
+export type QueryBuilderParams = Partial<QueryBuilderSchema>
 
 export interface QueryBuilder<T = ParsedContentMeta> {
   /**

--- a/src/runtime/utils/query.ts
+++ b/src/runtime/utils/query.ts
@@ -1,4 +1,5 @@
 import { useQuery, CompatibilityEvent, createError } from 'h3'
+import { QueryBuilderParams } from '../types'
 import { jsonParse } from './json'
 
 const parseQueryParams = (body: string) => {
@@ -10,7 +11,7 @@ const parseQueryParams = (body: string) => {
 }
 
 const memory = {}
-export const getContentQuery = (event: CompatibilityEvent) => {
+export const getContentQuery = (event: CompatibilityEvent): QueryBuilderParams => {
   const { qid } = event.context.params
   const query: any = useQuery(event) || {}
 


### PR DESCRIPTION
### 🔗 Linked issue

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

I wanted to modify the query for a `<ContentNavigation>`, the docs specify you can provide a type of `QueryBuilderParams`. When typing a `QueryBuilderParams` though, it requires all fields to be provided. 

I could get around this using `Partial`, but better to accurately represent the params, it's not guaranteed that any specific key will be available.

![image](https://user-images.githubusercontent.com/5326365/171784874-e063a1e5-cd86-4073-97b6-5b2b18aa1d83.png)


### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
