### PR TITLE
refactor!: spell `extensions` correctly

### DIFF
--- a/playground/content/real-content/content.md
+++ b/playground/content/real-content/content.md
@@ -89,7 +89,7 @@ Parsers and Transformers can be defined using `defineContentPlugin`:
 ```ts
 export default defineContentPlugin({
   name: 'plugin-name',
-  extentions: ['.md'],
+  extensions: ['.md'],
   parse: async (id, content) => {},
   transform: async content => {}
 })

--- a/src/module.ts
+++ b/src/module.ts
@@ -279,8 +279,8 @@ export default defineNuxtModule<ModuleOptions>({
         // TODO: remove kit usage
         templateUtils.importSources(contentContext.transformers),
         `const transformers = [${contentContext.transformers.map(templateUtils.importName).join(', ')}]`,
-        'export const getParser = (ext) => transformers.find(p => ext.match(new RegExp(p.extentions.join("|"),  "i")) && p.parse)',
-        'export const getTransformers = (ext) => transformers.filter(p => ext.match(new RegExp(p.extentions.join("|"),  "i")) && p.transform)',
+        'export const getParser = (ext) => transformers.find(p => ext.match(new RegExp(p.extensions.join("|"),  "i")) && p.parse)',
+        'export const getTransformers = (ext) => transformers.filter(p => ext.match(new RegExp(p.extensions.join("|"),  "i")) && p.transform)',
         'export default () => {}'
       ].join('\n')
     })

--- a/src/runtime/server/transformers/csv.ts
+++ b/src/runtime/server/transformers/csv.ts
@@ -2,7 +2,7 @@ import { useRuntimeConfig } from '#imports'
 
 export default {
   name: 'csv',
-  extentions: ['.csv'],
+  extensions: ['.csv'],
   parse: async (_id, content) => {
     const config = { ...useRuntimeConfig().content?.csv || {} }
 

--- a/src/runtime/server/transformers/json.ts
+++ b/src/runtime/server/transformers/json.ts
@@ -2,7 +2,7 @@ import destr from 'destr'
 
 export default {
   name: 'Json',
-  extentions: ['.json', '.json5'],
+  extensions: ['.json', '.json5'],
   parse: async (_id, content) => {
     let parsed = content
 

--- a/src/runtime/server/transformers/markdown.ts
+++ b/src/runtime/server/transformers/markdown.ts
@@ -9,7 +9,7 @@ const importPlugin = async (p: [string, any]) => ([
 
 export default {
   name: 'markdown',
-  extentions: ['.md'],
+  extensions: ['.md'],
   parse: async (_id, content) => {
     const config: MarkdownOptions = { ...useRuntimeConfig().content?.markdown || {} }
     config.rehypePlugins = await Promise.all((config.rehypePlugins || []).map(importPlugin))

--- a/src/runtime/server/transformers/path-meta.ts
+++ b/src/runtime/server/transformers/path-meta.ts
@@ -22,7 +22,7 @@ const describeId = (_id: string) => {
 
 export default {
   name: 'path-meta',
-  extentions: ['.*'],
+  extensions: ['.*'],
   transform (content) {
     const { locales, defaultLocale } = useRuntimeConfig().content || {}
     const { _source, _file, _path, _extension } = describeId(content._id)

--- a/src/runtime/server/transformers/shiki.ts
+++ b/src/runtime/server/transformers/shiki.ts
@@ -8,7 +8,7 @@ const withContentBase = (url: string) => {
 
 export default {
   name: 'markdown',
-  extentions: ['.md'],
+  extensions: ['.md'],
   transform: async (content) => {
     const codeBlocks = []
     visit(

--- a/src/runtime/server/transformers/yaml.ts
+++ b/src/runtime/server/transformers/yaml.ts
@@ -2,7 +2,7 @@ import { parseFrontMatter } from '../../markdown-parser'
 
 export default {
   name: 'Yaml',
-  extentions: ['.yml', '.yaml'],
+  extensions: ['.yml', '.yaml'],
   parse: async (_id, content) => {
     const { data } = await parseFrontMatter(`---\n${content}\n---`)
 

--- a/src/runtime/types.d.ts
+++ b/src/runtime/types.d.ts
@@ -105,7 +105,7 @@ export interface Toc {
 
 export interface ContentTransformer {
   name: string
-  extentions: string[]
+  extensions: string[]
   parse?(id: string, content: string): Promise<ParsedContent> | ParsedContent
   transform?: ((content: ParsedContent) => Promise<ParsedContent>) | ((content: ParsedContent) => ParsedContent)
 }


### PR DESCRIPTION
### 🔗 Linked issue

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The key is spelled incorrectly, as someone who is adding a custom transformer I'd prefer not to have misspelled keys in my code. 

BREAKING CHANGE: custom transformers should rename key `extentions` to  `extensions`

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
