### PR TITLE
fix(ContentNavigation): exception on `query` prop

### DIFF
--- a/src/runtime/composables/navigation.ts
+++ b/src/runtime/composables/navigation.ts
@@ -6,7 +6,7 @@ import { withContentBase } from './utils'
 
 export const fetchContentNavigation = (queryBuilder?: QueryBuilder | QueryBuilderParams) => {
   let params = queryBuilder
-  if (typeof params.params === 'function') {
+  if (typeof params?.params === 'function') {
     params = params.params()
   }
   const apiPath = withContentBase(params ? `/navigation/${hash(params)}` : '/navigation')

--- a/src/runtime/composables/navigation.ts
+++ b/src/runtime/composables/navigation.ts
@@ -1,11 +1,14 @@
 import { hash } from 'ohash'
 import { useHead, useCookie } from '#app'
-import type { NavItem, QueryBuilder } from '../types'
+import type { NavItem, QueryBuilder, QueryBuilderParams } from '../types'
 import { jsonStringify } from '../utils/json'
 import { withContentBase } from './utils'
 
-export const fetchContentNavigation = (queryBuilder?: QueryBuilder) => {
-  const params = queryBuilder?.params()
+export const fetchContentNavigation = (queryBuilder?: QueryBuilder | QueryBuilderParams) => {
+  let params = queryBuilder
+  if (typeof params.params === 'function') {
+    params = params.params()
+  }
   const apiPath = withContentBase(params ? `/navigation/${hash(params)}` : '/navigation')
 
   if (!process.dev && process.server) {

--- a/src/runtime/composables/navigation.ts
+++ b/src/runtime/composables/navigation.ts
@@ -6,6 +6,7 @@ import { withContentBase } from './utils'
 
 export const fetchContentNavigation = (queryBuilder?: QueryBuilder | QueryBuilderParams) => {
   let params = queryBuilder
+  // when params is an instance of QueryBuilder then we need to pick the params explicitly
   if (typeof params?.params === 'function') {
     params = params.params()
   }


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/content/discussions/1156

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The specified type of the `query` prop is `QueryBuilderParams`. When you provide the query with this type an exception is thrown.

The change fixes the `ContentNavigation` component using the prop type provided. This is the only component affected by this.

Example:

```vue
<script lang="ts" setup>
const contentQuery = {
  where: [
    { _path: /^\/content/ },
  ],
}
</script>

<template>
<ContentNavigation v-slot="{ navigation }" :query="contentQuery">
  <NuxtLink
    v-for="link of navigation"
    :key="link._path"
    :to="link._path"
  >
    {{ link.navTitle || link.title }}
  </NuxtLink>
</ContentNavigation>
</template>
```

This exception is thrown.

![image](https://user-images.githubusercontent.com/5326365/171791793-bb4a0124-b1a7-4947-87c2-97a010d30d7f.png)


### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
