### PR TITLE
fix(navigation): allow navigation opt-out with `navigation: false`

### DIFF
--- a/src/runtime/server/api/navigation.ts
+++ b/src/runtime/server/api/navigation.ts
@@ -10,6 +10,14 @@ export default defineEventHandler(async (event) => {
   const contents = await serverQueryContent(event, query)
     .where({
       /**
+       * Exclude any pages which have opted out of navigation via frontmatter.
+       */
+      navigation: {
+        $ne: false
+      }
+    })
+    .where({
+      /**
        * Partial contents are not included in the navigation
        * A partial content is a content that has `_` prefix in its path
        */

--- a/src/runtime/server/api/navigation.ts
+++ b/src/runtime/server/api/navigation.ts
@@ -10,18 +10,16 @@ export default defineEventHandler(async (event) => {
   const contents = await serverQueryContent(event, query)
     .where({
       /**
+       * Partial contents are not included in the navigation
+       * A partial content is a content that has `_` prefix in its path
+       */
+      _partial: false,
+      /**
        * Exclude any pages which have opted out of navigation via frontmatter.
        */
       navigation: {
         $ne: false
       }
-    })
-    .where({
-      /**
-       * Partial contents are not included in the navigation
-       * A partial content is a content that has `_` prefix in its path
-       */
-      _partial: false
     })
     .find()
 

--- a/test/features/navigation.ts
+++ b/test/features/navigation.ts
@@ -53,5 +53,11 @@ export const testNavigation = () => {
         expect(item.title).toEqual(String(fibo[index]))
       })
     })
+
+    test('Should remove `navigation-disabled.md` content', async () => {
+      const list = await $fetch('/api/_content/navigation/')
+      const hidden = list.find(i => i._path === '/navigation-disabled')
+      expect(hidden).toBeUndefined()
+    })
   })
 }

--- a/test/fixtures/basic/content/navigation-disabled.md
+++ b/test/fixtures/basic/content/navigation-disabled.md
@@ -1,0 +1,7 @@
+---
+navigation: false
+---
+
+# Hidden from navigation
+
+Basic description


### PR DESCRIPTION
### 🔗 Linked issue

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The [documentation](https://content.nuxtjs.org/guide/displaying/navigation) says 

> Set navigation: false in the [front-matter](https://content.nuxtjs.org/guide/writing/markdown) of a page to exclude it in fetchContentNavigation() return value.

However, it doesn't work. I couldn't find any logic for excluding this. The Example on the page is even showing the wrong data.

This change properly filters out the pages with this setting from the navigation query.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
