### PR TITLE
fix(query): surround and only cannot be used at the same time

### DIFF
--- a/src/runtime/query/match/utils.ts
+++ b/src/runtime/query/match/utils.ts
@@ -40,7 +40,7 @@ export const detectProperties = (keys: string[]) => {
 }
 
 export const withoutKeys = (keys: string[] = []) => (obj: any) => {
-  if (keys.length === 0) {
+  if (keys.length === 0 || !obj) {
     return obj
   }
   const { prefixes, properties } = detectProperties(keys)
@@ -48,7 +48,7 @@ export const withoutKeys = (keys: string[] = []) => (obj: any) => {
 }
 
 export const withKeys = (keys: string[] = []) => (obj: any) => {
-  if (keys.length === 0) {
+  if (keys.length === 0 || !obj) {
     return obj
   }
   const { prefixes, properties } = detectProperties(keys)

--- a/test/features/query/query.test.ts
+++ b/test/features/query/query.test.ts
@@ -205,6 +205,30 @@ describe('Database Provider', () => {
     assert(result[2] === null)
   })
 
+  test('Surround and using only method', async () => {
+    const fetcher = createPipelineFetcher(() => Promise.resolve([{ id: 1, _path: '/a' }, { id: 2, _path: '/b' }, { id: 3, _path: '/c' }] as any[]))
+    const result = await createQuery(fetcher)
+      .only(['_path'])
+      .findSurround({ id: 3 }, { before: 2, after: 1 })
+
+    assert((result as Array<any>).length === 3)
+    assert(result[0]._path === '/a')
+    assert(result[1]._path === '/b')
+    assert(result[2] === null)
+  })
+
+  test('Surround and using without method', async () => {
+    const fetcher = createPipelineFetcher(() => Promise.resolve([{ id: 1, _path: '/a' }, { id: 2, _path: '/b' }, { id: 3, _path: '/c' }] as any[]))
+    const result = await createQuery(fetcher)
+      .without('id')
+      .findSurround({ id: 3 }, { before: 2, after: 1 })
+
+    assert((result as Array<any>).length === 3)
+    assert(result[0]._path === '/a')
+    assert(result[1]._path === '/b')
+    assert(result[2] === null)
+  })
+
   test('Chain multiple where conditions', async () => {
     const fetcher = createPipelineFetcher(() => Promise.resolve([{ id: 1, path: '/a' }, { id: 2, path: '/b' }, { id: 3, path: '/c' }] as any[]))
     const query = createQuery(fetcher).where({ id: { $in: [1, 2] } })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue
resolves #1235 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
https://github.com/nuxt/content/blob/ede65e8337ca3eb597af95c17cfc609e4015238c/src/runtime/query/match/pipeline.ts#L46

When using `findSurround`, it is necessary to take into account that `null` are mixed in the pipeline data.


<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
