### PR TITLE
feat(config): allow ws config

### DIFF
--- a/docs/content/4.api/3.configuration.md
+++ b/docs/content/4.api/3.configuration.md
@@ -16,7 +16,6 @@ export default defineNuxtConfig({
 })
 ```
 
-
 ## `base`
 
 - Type: `String`{lang=ts}
@@ -179,7 +178,7 @@ Nuxt Content uses [Shiki](https://github.com/shikijs/shiki) to provide syntax hi
 
 ### `highlight` options
 
-| Option | Default | Description |
+| Option | Type | Description |
 | ----------------- | :--------: | :-------- |
 | `theme`     | `ShikiTheme` | The [color theme](https://github.com/shikijs/shiki/blob/main/docs/themes.md) to use |
 | `preload`     | `ShikiLang[]` | The [preloaded languages](https://github.com/shikijs/shiki/blob/main/docs/languages.md) available for highlighting. |
@@ -211,3 +210,14 @@ List of locale codes. This codes will be used to detect contents locale.
 - Default: `undefined`{lang=ts}
 
 Default locale for top level contents. Module will use first locale code from `locales` array if this option is not defined.
+
+## `ws`
+
+Nuxt Content uses a WebSocket server in development to allow hot reloading of your content files.
+
+### `ws` options
+
+| Option | Default | Description |
+| ----------------- | :--------: | :-------- |
+| `port`     | `4000` | Select the port used for the WebSocket server. |
+| `showUrl`     | `false` | Toggle URL display in dev server boot message. |

--- a/src/module.ts
+++ b/src/module.ts
@@ -158,6 +158,19 @@ export interface ModuleOptions {
    * @default undefined
    */
   defaultLocale: string
+  /**
+   * WebSocket server configuration.
+   */
+  ws: {
+    /**
+     * @default 4000
+     */
+    port: number
+    /**
+     * @default false
+     */
+    showUrl: boolean
+  }
 }
 
 interface ContentContext extends ModuleOptions {
@@ -181,6 +194,10 @@ export default defineNuxtModule<ModuleOptions>({
   defaults: {
     base: '_content',
     watch: true,
+    ws: {
+      port: 4000,
+      showUrl: false
+    },
     sources: ['content'],
     ignores: ['\\.', '-'],
     locales: [],
@@ -416,7 +433,7 @@ export default defineNuxtModule<ModuleOptions>({
       })
 
       // Listen dev server
-      const { server, url } = await listen(() => 'Nuxt Content', { port: 4000, showURL: false })
+      const { server, url } = await listen(() => 'Nuxt Content', options.ws)
       server.on('upgrade', ws.serve)
 
       // Register ws url


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/content/issues/1244

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [X] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Resolves #1244

Allow user to change WebSocket port used, improving compatibility with Docker environments.

`ws` key is used for config, might be subject to changes based on @farnabaz review.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have linked an issue or discussion.
- [X] I have updated the documentation accordingly.
