### PR TITLE
fix(query): handle array fields in `$in` operator

### DIFF
--- a/src/runtime/query/match/index.ts
+++ b/src/runtime/query/match/index.ts
@@ -69,7 +69,9 @@ function createOperators (match: (...args: any[]) => boolean, operators: Record<
     /**
      * Match if item is in condition array
      **/
-    $in: (item, condition) => ensureArray(condition).some(cond => match(item, cond)),
+    $in: (item, condition) => ensureArray(condition).some(
+      cond => Array.isArray(item) ? match(item, { $contains: cond }) : match(item, cond)
+    ),
 
     /**
      * Match if item contains every condition or math every rule in condition array

--- a/test/features/query/match.test.ts
+++ b/test/features/query/match.test.ts
@@ -74,17 +74,6 @@ describe('Match', () => {
     })
   })
 
-  test('$in', () => {
-    const item = { id: 1, name: 'a', to: 'a', category: 'c1', nested: { users: ['Mahatma', 'Steve', 'Woodrow'] } }
-
-    expect(match(item, { name: { $in: ['a', 'b'] } })).toBe(true)
-    expect(match(item, { category: { $in: 'c1' } })).toBe(true)
-    expect(match(item, { category: { $in: ['c1', 'c2'] } })).toBe(true)
-    expect(match(item, { category: { $in: ['c2', 'c3'] } })).toBe(false)
-
-    expect(match(item, { id: { $in: [1, 2] } })).toBe(true)
-  })
-
   test('$eq', () => {
     // string
     expect(match(item, { name: { $eq: 'a' } })).toBe(true)
@@ -185,6 +174,44 @@ describe('Match', () => {
     test('$lte', () => {
       expect(match(item, { id: { $lte: 1 } })).toBe(true)
       expect(match(item, { id: { $lte: 0 } })).toBe(false)
+    })
+  })
+
+  describe('$in ', () => {
+    test('string filed', () => {
+      const item = { id: 1, name: 'a', to: 'a', category: 'c1', nested: { users: ['Mahatma', 'Steve', 'Woodrow'] } }
+
+      expect(match(item, { name: { $in: ['a', 'b'] } })).toBe(true)
+      expect(match(item, { category: { $in: 'c1' } })).toBe(true)
+      expect(match(item, { category: { $in: ['c1', 'c2'] } })).toBe(true)
+      expect(match(item, { category: { $in: ['c2', 'c3'] } })).toBe(false)
+
+      expect(match(item, { id: { $in: [1, 2] } })).toBe(true)
+    })
+
+    test('array field', () => {
+      const data = [
+        {
+          name: 'post1',
+          tags: ['school', 'office']
+        },
+        {
+          name: 'post2',
+          tags: ['school', 'home']
+        },
+        {
+          item: 'Maps',
+          tags: ['office', 'storage']
+        }
+      ]
+
+      const condition = { tags: { $in: ['school', 'home'] } }
+      data.forEach((item) => {
+        expect(match(item, condition)).toBe(
+          item.tags.includes(condition.tags.$in[0]) ||
+          item.tags.includes(condition.tags.$in[1])
+        )
+      })
     })
   })
 })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue
resolves #1272

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
The current behavior of `$in` operator was wrong, because it tried to check equality between item and condition.
For example in this sample:
```
const item = { tags: ['foo', bar'] }
const cond = { tags: { $in: [ 'foo'] }

match(item, cond)
```

`$in` operator was checking if `'foo' === ['foo', 'bar']`. 

But the correct behavior for arrays is not equality check, it is `$contains` check.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
