### PR TITLE
feat: Unwanted <p> tag Over <img> improved.

### DIFF
--- a/src/runtime/markdown-parser/compiler.ts
+++ b/src/runtime/markdown-parser/compiler.ts
@@ -20,6 +20,17 @@ export default function (this: any, _options: MarkdownOptions) {
     if (Array.isArray(node)) {
       return node.map(parseAsJSON).filter(Boolean)
     }
+
+
+    /**
+     * If Current Element is p and Its Only Child is img then
+     * unwrapping img from it to avoid unwated p tags around img tag.
+     */
+    if(node.type === 'element' && node.tagName === 'p' && node.children.length === 1 && node.children[0].tagName === 'img') {
+      node = parseAsJSON(node.children[0])
+      return node as MarkdownNode;
+    }
+
     /**
      * Element node creates an isolated children array to
      * allow nested elements

--- a/src/runtime/markdown-parser/compiler.ts
+++ b/src/runtime/markdown-parser/compiler.ts
@@ -24,9 +24,9 @@ export default function (this: any, _options: MarkdownOptions) {
 
     /**
      * If Current Element is p and Its Only Child is img then
-     * unwrapping img from it to avoid unwated p tags around img tag.
+     * unwrapping img from it to avoid unwated p tags around img
      */
-    if(node.type === 'element' && node.tagName === 'p' && node.children.length === 1 && node.children[0].tagName === 'img') {
+    if(node.type === 'element' && node.tagName === 'p' && node.children?.length === 1 && node.children[0].tagName === 'img') {
       node = parseAsJSON(node.children[0])
       return node as MarkdownNode;
     }


### PR DESCRIPTION
<!---
feat: Unwanted <img> tag under <p> improved.
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
![image](https://user-images.githubusercontent.com/46915613/176329973-bd470c5f-e8c7-41bf-ac23-92baa987d79e.png)
For the Markdown of Above Type Where Image Exists, As Per the Current Implementation the parsed Syntax Tree Would Be:
![image](https://user-images.githubusercontent.com/46915613/176330413-c716a936-9d28-41d3-a730-3bac1ac1d676.png)
It Means an unwanted p tag was introduced over each **img** tag.
![image](https://user-images.githubusercontent.com/46915613/176331041-edc932d7-7dbf-42d4-b15a-aa516c1b29a8.png)


**Added The Logic to Check If Current Element is p, It has only one child and that child is img, then unwrap that child.**
![image](https://user-images.githubusercontent.com/46915613/176333869-4db2fd22-cd79-4bc1-8f85-8450e5707ccc.png)


After the Implementation the Syntax Tree Would Be Like This:
![image](https://user-images.githubusercontent.com/46915613/176331300-9a14ddcb-1c1c-41df-99e3-e6e0b64bb131.png)


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion. [**No Issue was Raised Against It**]
- [ ] I have updated the documentation accordingly. [**Documentation Update Not Required**]
