### PR TITLE
fix(ContentRendererMarkdown): preload components used in content

### DIFF
--- a/src/runtime/plugins/documentDriven.ts
+++ b/src/runtime/plugins/documentDriven.ts
@@ -180,6 +180,18 @@ export default defineNuxtPlugin((nuxt) => {
       _page,
       _surround
     ]) => {
+      // Find used layout
+      const layoutName = findLayout(to, _page, _navigation, _globals)
+
+      // Prefetch layout component
+      const layout = layouts[layoutName]
+
+      if (layout && layout?.__asyncLoader && !layout.__asyncResolved) {
+        await layout.__asyncLoader()
+      }
+      // Apply layout
+      to.meta.layout = layoutName
+
       if (_navigation) {
         navigation.value = _navigation
       }
@@ -192,25 +204,13 @@ export default defineNuxtPlugin((nuxt) => {
         surround.value = _surround
       }
 
-      if (_page) {
-        // Use `redirect` key to redirect to another page
-        if (_page?.redirect) { return _page?.redirect }
+      // Use `redirect` key to redirect to another page
+      if (_page?.redirect) { return _page?.redirect }
 
+      if (_page) {
         // Update values
         page.value = _page
       }
-
-      // Find used layout
-      const layoutName = findLayout(to, _page, _navigation, _globals)
-
-      // Prefetch layout component
-      const layout = layouts[layoutName]
-      if (layout && layout?.__asyncLoader && !layout.__asyncResolved) {
-        await layout.__asyncLoader()
-      }
-
-      // Apply layout
-      to.meta.layout = layoutName
     })
   }
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Preload component used content to prevent lazy loading and creating layout shifting.

However, using the async setup function in `ContentRendererMarkdown` causes a new issue.
<img width="885" alt="Screenshot 2022-06-29 at 15 48 43" src="https://user-images.githubusercontent.com/2047945/176452727-a5810449-14d2-487b-9787-e0ef1231f935.png">

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
