### PR TITLE
docs: fix the link-id for the surround EN v1 docs

### DIFF
--- a/docs/content-v1/en/3.community/1.snippets.md
+++ b/docs/content-v1/en/3.community/1.snippets.md
@@ -145,7 +145,7 @@ even when the current page is showing the higer-positioned document.
 
 </alert>
 
-> Check out the [surround documentation](/fetching#surroundslug-options)
+> Check out the [surround documentation](/fetching#surroundslugorpath-options)
 
 ### Case-Insensitive Sorting
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

Resolves #1318 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Fixes the id in the link to the surround function documentation (EN v1)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
