### PR TITLE
docs: missing `,`

### DIFF
--- a/docs/content/4.api/3.configuration.md
+++ b/docs/content/4.api/3.configuration.md
@@ -224,7 +224,7 @@ export default defineNuxtConfig({
         // Default theme (same as single string)
         default: 'github-light',
         // Theme used if `html.dark`
-        dark: 'github-dark'
+        dark: 'github-dark',
         // Theme used if `html.sepia`
         sepia: 'monokai'
       }


### PR DESCRIPTION
Missing a `,` in the docs. 