### PR TITLE
feat: disable document driven with route meta

### DIFF
--- a/docs/content/3.guide/1.writing/7.document-driven.md
+++ b/docs/content/3.guide/1.writing/7.document-driven.md
@@ -178,7 +178,7 @@ definePageMeta({
 
 ### Control data
 
-To control docuemnt driven data you can pass an object to `documentDriven` meta key and enable/disable specific parts of it.
+To control document driven data you can pass an object to `documentDriven` meta key and enable/disable specific parts of it.
 
 ```html
 <script setup lang="ts">

--- a/docs/content/3.guide/1.writing/7.document-driven.md
+++ b/docs/content/3.guide/1.writing/7.document-driven.md
@@ -160,6 +160,38 @@ const { theme } = useContent().globals
 
 Any changes to these files will be automatically reflected in the application during development.
 
+## Disable or control the page data
+
+Using special `documentDriven` meta in your pages, you can disable this feature for specific route or control it's behavior.
+
+### Disable document driven
+
+Setting `documentDriven` to `false` will disable document driven. This means that exposed refs from `useContent()` will be `undefined`.
+
+```html
+<script setup lang="ts">
+definePageMeta({
+  documentDriven: false
+})
+</script>
+```
+
+### Control data
+
+To control docuemnt driven data you can pass an object to `documentDriven` meta key and enable/disable specific parts of it.
+
+```html
+<script setup lang="ts">
+definePageMeta({
+  documentDriven: {
+    page: true, // Keep page fetching enabled
+    surround: false // Disable surround fetching
+  }
+})
+</script>
+```
+
+
 ## Example
 
 Jump into the [Document Driven Example](/examples/essentials/document-driven) to see a working example.

--- a/src/runtime/plugins/documentDriven.ts
+++ b/src/runtime/plugins/documentDriven.ts
@@ -47,7 +47,7 @@ export default defineNuxtPlugin((nuxt) => {
 
   const refresh = async (to: RouteLocationNormalized | RouteLocationNormalizedLoaded, force: boolean = false) => {
     const routeConfig = (to.meta.documentDriven || {}) as any
-    // Document drive disabled on route
+    // Disabled document driven mode on next route
     if (to.meta.documentDriven === false) {
       return
     }

--- a/test/document-driven.test.ts
+++ b/test/document-driven.test.ts
@@ -13,4 +13,18 @@ describe('fixtures:document-driven', async () => {
 
     expect(html).contains('Home | Document Driven Fixture')
   })
+
+  test('disabled document driven', async () => {
+    const html = await $fetch('/disabled')
+
+    expect(html).contains('<div>surround: </div>')
+    expect(html).contains('<div>page: </div>')
+  })
+
+  test('disabled surround document driven', async () => {
+    const html = await $fetch('/no-surround')
+
+    expect(html).contains('<div>surround: </div>')
+    expect(html).contains('<div>page: {')
+  })
 })

--- a/test/features/navigation.ts
+++ b/test/features/navigation.ts
@@ -12,7 +12,6 @@ export const testNavigation = () => {
           _params: jsonStringify(query)
         }
       })
-      console.log(JSON.stringify(list, null, 2))
 
       expect(list.find(item => item._path === '/')).toBeTruthy()
       expect(list.find(item => item._path === '/').children).toBeUndefined()

--- a/test/fixtures/document-driven/content/no-surround.md
+++ b/test/fixtures/document-driven/content/no-surround.md
@@ -1,0 +1,1 @@
+# Surround disabled in document driven

--- a/test/fixtures/document-driven/pages/disabled.vue
+++ b/test/fixtures/document-driven/pages/disabled.vue
@@ -1,0 +1,15 @@
+<template>
+  <div>
+    Document driven is disabled for this page
+    <div>page: {{ page }}</div>
+    <div>surround: {{ surround }}</div>
+  </div>
+</template>
+
+<script setup lang="ts">
+definePageMeta({
+  documentDriven: false
+})
+
+const { page, surround } = useContent()
+</script>

--- a/test/fixtures/document-driven/pages/no-surround.vue
+++ b/test/fixtures/document-driven/pages/no-surround.vue
@@ -1,0 +1,17 @@
+<template>
+  <div>
+    Document driven page is disabled for this route
+    <div>page: {{ page }}</div>
+    <div>surround: {{ surround }}</div>
+  </div>
+</template>
+
+<script setup lang="ts">
+definePageMeta({
+  documentDriven: {
+    surround: false
+  }
+})
+
+const { page, surround } = useContent()
+</script>


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Allow disabling/modifying document-driven 
```vue
<script setup>
definePageMeta({
  documentDriven: false,
  // Or if need content but no surround
  documentDriven: {
    page: true,
    surround: false,
  },
});
</script>
```

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
