### PR TITLE
Update 6.prose.md

### DIFF
--- a/docs/content/4.api/1.components/6.prose.md
+++ b/docs/content/4.api/1.components/6.prose.md
@@ -272,9 +272,9 @@ To overwrite a prose component, create a component with the same name in your pr
 
 ::
 
-## `ProseParagraph`
+## `ProseP`
 
-[:icon{name="fa-brands:github" class="inline -mt-1 w-6"} Source](https://github.com/nuxt/content/tree/main/src/runtime/components/Prose/ProseParagraph.vue)
+[:icon{name="fa-brands:github" class="inline -mt-1 w-6"} Source](https://github.com/nuxt/content/tree/main/src/runtime/components/Prose/ProseP.vue)
 
 ::code-group
 


### PR DESCRIPTION
fix the wrong prose name of `<p>`

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

the prose name of `<p>` is `ProseP` not `ProseParagraph`

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
