### PR TITLE
fix(prose-components): use html anchor link in headings

### DIFF
--- a/src/runtime/components/Prose/ProseH2.vue
+++ b/src/runtime/components/Prose/ProseH2.vue
@@ -1,8 +1,8 @@
 <template>
   <h2 :id="id">
-    <NuxtLink :href="`#${id}`">
+    <a :href="`#${id}`">
       <slot />
-    </NuxtLink>
+    </a>
   </h2>
 </template>
 

--- a/src/runtime/components/Prose/ProseH3.vue
+++ b/src/runtime/components/Prose/ProseH3.vue
@@ -1,8 +1,8 @@
 <template>
   <h3 :id="id">
-    <NuxtLink :href="`#${id}`">
+    <a :href="`#${id}`">
       <slot />
-    </NuxtLink>
+    </a>
   </h3>
 </template>
 

--- a/src/runtime/components/Prose/ProseH4.vue
+++ b/src/runtime/components/Prose/ProseH4.vue
@@ -1,8 +1,8 @@
 <template>
   <h4 :id="id">
-    <NuxtLink :href="`#${id}`">
+    <a :href="`#${id}`">
       <slot />
-    </NuxtLink>
+    </a>
   </h4>
 </template>
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

#1380

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

The `<NuxtLink>`s for the heading links are replaced by the HTML anchor element `<a>` to enable focusing on clicking on the link.
The focusing is not working with NuxtLink and as [this discussion](https://github.com/nuxt/framework/discussions/5561#discussioncomment-3007717) points out, can be replaced by the default HTML element.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
