### PR TITLE
docs: move fetchContentNavigation into function

### DIFF
--- a/docs/content/4.api/2.composables/2.fetch-content-navigation.md
+++ b/docs/content/4.api/2.composables/2.fetch-content-navigation.md
@@ -16,7 +16,7 @@ content/
 
 ```vue [app.vue]
 <script setup>
-const { data: navigation } = await useAsyncData('navigation', fetchContentNavigation())
+const { data: navigation } = await useAsyncData('navigation', () => fetchContentNavigation())
 </script>
 
 <template>


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

The documentation was missing that `fetchContentNavigation()` has to be in a function:

```sh
[nuxt] [request error] [nuxt] [asyncData] handler must be a function.
  at createError (./node_modules/h3/dist/index.mjs:196:15)  
  at Server.nodeHandler (./node_modules/h3/dist/index.mjs:386:21)  
  at processTicksAndRejections (node:internal/process/task_queues:96:5)
```

This is also visible in the [example](https://content.nuxtjs.org/examples/navigation/fetch-content-navigation/)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
