### PR TITLE
fix(document-driven): Only set 404 status on SSR

### DIFF
--- a/playground/document-driven/content/0.index.md
+++ b/playground/document-driven/content/0.index.md
@@ -7,3 +7,5 @@ description: Hello, here is a description
 # Home
 
 Hello World!
+
+[404](/404)

--- a/src/runtime/pages/document-driven.vue
+++ b/src/runtime/pages/document-driven.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
-import { useNuxtApp, useContent, useContentHead } from '#imports'
+import { useContent, useContentHead, useRequestEvent } from '#imports'
 
 const { page } = useContent()
 
 // Page not found, set correct status code on SSR
-const nuxtApp = useNuxtApp()
-if (!page.value && process.server && nuxtApp.ssrContext) {
-  nuxtApp.ssrContext.res.statusCode = 404
+if (!page.value && process.server) {
+  const event = useRequestEvent()
+  event.res.statusCode = 404
 }
 
 useContentHead(page)

--- a/src/runtime/pages/document-driven.vue
+++ b/src/runtime/pages/document-driven.vue
@@ -1,15 +1,12 @@
 <script setup lang="ts">
-import { createError } from 'h3'
-import { useContent, useContentHead, useRoute } from '#imports'
+import { useNuxtApp, useContent, useContentHead } from '#imports'
 
 const { page } = useContent()
 
-// Page not found
-if (!page.value) {
-  throw createError({
-    statusCode: 404,
-    statusMessage: `Page not found: ${useRoute().path}`
-  })
+// Page not found, set correct status code on SSR
+const nuxtApp = useNuxtApp()
+if (!page.value && process.server && nuxtApp.ssrContext) {
+  nuxtApp.ssrContext.res.statusCode = 404
 }
 
 useContentHead(page)

--- a/test/document-driven.test.ts
+++ b/test/document-driven.test.ts
@@ -52,7 +52,7 @@ describe('fixtures:document-driven', async () => {
       await $fetch('/page-not-found')
     } catch (e) {
       expect(e.response.status).toBe(404)
-      expect(e.response.statusText).toBe('Page not found: /page-not-found')
+      expect(e.response.statusText).toBe('Document not found')
     }
   })
 })

--- a/test/document-driven.test.ts
+++ b/test/document-driven.test.ts
@@ -52,7 +52,7 @@ describe('fixtures:document-driven', async () => {
       await $fetch('/page-not-found')
     } catch (e) {
       expect(e.response.status).toBe(404)
-      expect(e.response.statusText).toBe('Not found')
+      expect(e.response.statusText).toBe('Not Found')
     }
   })
 })

--- a/test/document-driven.test.ts
+++ b/test/document-driven.test.ts
@@ -52,7 +52,7 @@ describe('fixtures:document-driven', async () => {
       await $fetch('/page-not-found')
     } catch (e) {
       expect(e.response.status).toBe(404)
-      expect(e.response.statusText).toBe('Document not found')
+      expect(e.response.statusText).toBe('Not found')
     }
   })
 })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
It should not return a Nuxt error but only set the 404 status code on SSR, when using the dd mode, you can create a `<DocumentDrivenNotFound />` component 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
