### PR TITLE
fix: make sure `components/content` is on top in layers

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -346,7 +346,7 @@ export default defineNuxtModule<ModuleOptions>({
     })
 
     // Register user global components
-    for (const layer of nuxt.options._layers) {
+    for (const layer of nuxt.options._layers.reverse()) {
       const srcDir = layer.config.srcDir
       const globalComponents = resolve(srcDir, 'components/content')
       const dirStat = await fs.promises.stat(globalComponents).catch(() => null)


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

closes #1417, related to nuxt/framework#6382

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

In mutli layer setups the priority of the layers is wrong and needs to be reversed, so that `content` is on top

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
