### PR TITLE
fix: remove (now deprecated) template utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "detab": "^3.0.1",
     "html-tags": "^3.2.0",
     "json5": "^2.2.1",
+    "knitwork": "^0.1.2",
     "listhen": "^0.2.13",
     "mdast-util-to-hast": "^12.2.0",
     "mdurl": "^1.0.1",

--- a/src/module.ts
+++ b/src/module.ts
@@ -6,14 +6,14 @@ import {
   createResolver,
   addAutoImport,
   addComponentsDir,
-  templateUtils,
   addTemplate
 } from '@nuxt/kit'
+import { genImport, genSafeVariableName } from 'knitwork'
 import type { ListenOptions } from 'listhen'
 // eslint-disable-next-line import/no-named-as-default
 import defu from 'defu'
 import { hash } from 'ohash'
-import { join } from 'pathe'
+import { join, relative } from 'pathe'
 import type { Lang as ShikiLang, Theme as ShikiTheme } from 'shiki-es'
 import { listen } from 'listhen'
 import type { WatchEvent } from 'unstorage'
@@ -302,11 +302,15 @@ export default defineNuxtModule<ModuleOptions>({
       nitroConfig.alias = nitroConfig.alias || {}
       nitroConfig.alias['#content/server'] = resolveRuntimeModule('./server')
 
+      const transformers = contentContext.transformers.map((t) => {
+        const name = genSafeVariableName(relative(nuxt.options.rootDir, t)).replace(/_(45|46|47)/g, '_') + '_' + hash(t)
+        return { name, import: genImport(t, name) }
+      })
+
       nitroConfig.virtual = nitroConfig.virtual || {}
       nitroConfig.virtual['#content/virtual/transformers'] = [
-        // TODO: remove kit usage
-        templateUtils.importSources(contentContext.transformers),
-        `export const transformers = [${contentContext.transformers.map(templateUtils.importName).join(', ')}]`,
+        ...transformers.map(t => t.import),
+        `export const transformers = [${transformers.map(t => t.name).join(', ')}]`,
         'export const getParser = (ext) => transformers.find(p => ext.match(new RegExp(p.extensions.join("|"),  "i")) && p.parse)',
         'export const getTransformers = (ext) => transformers.filter(p => ext.match(new RegExp(p.extensions.join("|"),  "i")) && p.transform)',
         'export default () => {}'


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

resolves https://github.com/nuxt/content/issues/1422

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

An unreleased (and now reverted) change in kit template utils broke nuxt content briefly. This PR implements a TODO to use knitwork directly to generate import names.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
