### PR TITLE
fix: avoid mutating `_layers`

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -356,7 +356,8 @@ export default defineNuxtModule<ModuleOptions>({
     })
 
     // Register user global components
-    for (const layer of nuxt.options._layers.reverse()) {
+    const _layers = [...nuxt.options._layers].reverse()
+    for (const layer of _layers) {
       const srcDir = layer.config.srcDir
       const globalComponents = resolve(srcDir, 'components/content')
       const dirStat = await fs.promises.stat(globalComponents).catch(() => null)


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

We introduced a fix in #1418 to reverse scan layers and regression of #1404. By calling `reverse()` we were mutating original `_layers` too causing whole layer scanning logic after content being broken.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
