### PR TITLE
fix(prerender): add extension to prerendered queries

### DIFF
--- a/src/runtime/composables/navigation.ts
+++ b/src/runtime/composables/navigation.ts
@@ -4,13 +4,13 @@ import type { NavItem, QueryBuilder, QueryBuilderParams } from '../types'
 import { jsonStringify } from '../utils/json'
 import { withContentBase } from './utils'
 
-export const fetchContentNavigation = (queryBuilder?: QueryBuilder | QueryBuilderParams) => {
+export const fetchContentNavigation = (queryBuilder?: QueryBuilder | QueryBuilderParams): Promise<Array<NavItem>> => {
   let params = queryBuilder
 
   // When params is an instance of QueryBuilder then we need to pick the params explicitly
   if (typeof params?.params === 'function') { params = params.params() }
 
-  const apiPath = withContentBase(params ? `/navigation/${hash(params)}` : '/navigation')
+  const apiPath = withContentBase(params ? `/navigation/${hash(params)}.json` : '/navigation')
 
   // Add `prefetch` to `<head>` in production
   if (!process.dev && process.server) {
@@ -21,7 +21,7 @@ export const fetchContentNavigation = (queryBuilder?: QueryBuilder | QueryBuilde
     })
   }
 
-  return $fetch<Array<NavItem>>(apiPath, {
+  return $fetch(apiPath, {
     method: 'GET',
     responseType: 'json',
     params: {

--- a/src/runtime/composables/query.ts
+++ b/src/runtime/composables/query.ts
@@ -24,7 +24,7 @@ export const createQueryFetch = <T = ParsedContent>(path?: string) => (query: Qu
 
   const params = query.params()
 
-  const apiPath = withContentBase(process.dev ? '/query' : `/query/${hash(params)}`)
+  const apiPath = withContentBase(process.dev ? '/query' : `/query/${hash(params)}.json`)
 
   // Prefetch the query
   if (!process.dev && process.server) {

--- a/src/runtime/utils/query.ts
+++ b/src/runtime/utils/query.ts
@@ -12,7 +12,7 @@ const parseQueryParams = (body: string) => {
 
 const memory = {}
 export const getContentQuery = (event: CompatibilityEvent): QueryBuilderParams => {
-  const { qid } = event.context.params
+  const qid = event.context.params.qid?.replace(/.json$/, '')
   const query: any = useQuery(event) || {}
 
   // Using /api/_content/query/:qid?_params=....


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue
resolves #1454
resolves #1281

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Add `.json` extension to pre-rendered queries. 
The issue here is that `npx serve` with `-s` option, redirects all URLs (without extension) to `index.html` and therefore serving generated websites with `nuxi preview` return 404 for API routes.

In current state, `npx nuxi preview` and `npx serve -s .output/public` does not work and only `npx serve .output/public` works properly.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
