### PR TITLE
fix(`<ContentRenderer>`): prioritize default slot

### DIFF
--- a/src/runtime/components/ContentRenderer.vue
+++ b/src/runtime/components/ContentRenderer.vue
@@ -60,6 +60,15 @@ export default defineComponent({
 
     const { value, excerpt, tag } = ctx
 
+    if (!value && slots?.empty) {
+      // Fallback on `empty` slot.
+      return slots.empty({ value, excerpt, tag, ...this.$attrs })
+    }
+
+    if (slots?.default) {
+      return slots.default({ value, excerpt, tag, ...this.$attrs })
+    }
+
     // Use built-in ContentRendererMarkdown
     if (value && value?._type === 'markdown' && value?.body?.children?.length) {
       return h(
@@ -71,16 +80,6 @@ export default defineComponent({
           ...this.$attrs
         }
       )
-    }
-
-    if (value && slots?.default) {
-      return slots.default({ value, excerpt, tag, ...this.$attrs })
-    } else if (slots?.empty) {
-      // Fallback on `empty` slot.
-      return slots.empty({ value, excerpt, tag, ...this.$attrs })
-    } else if (slots?.default) {
-      // Fallback on `default` slot with undefined `value` if no `empty` slot.
-      return slots.default({ value, excerpt, tag, ...this.$attrs })
     }
 
     // Fallback on JSON.stringify if no slot at all.

--- a/test/features/renderer-markdown.ts
+++ b/test/features/renderer-markdown.ts
@@ -62,5 +62,10 @@ export const testMarkdownRenderer = () => {
       const html = await $fetch('/features/custom-paragraph')
       expect(html).contains('[Paragraph]')
     })
+
+    test('override default slot', async () => {
+      const html = await $fetch('/features/slotted-content-renderer')
+      expect(html).contains('The default slot is overridden')
+    })
   })
 }

--- a/test/fixtures/basic/pages/features/slotted-content-renderer.vue
+++ b/test/fixtures/basic/pages/features/slotted-content-renderer.vue
@@ -1,0 +1,18 @@
+<template>
+  <main>
+    <ContentRenderer :value="data">
+      <Alert>
+        The default slot is overridden.
+      </Alert>
+      <ContentRendererMarkdown :value="data" />
+      <template #empty>
+        <p>No content found.</p>
+      </template>
+    </ContentRenderer>
+  </main>
+</template>
+
+<script setup lang="ts">
+const path = '/'
+const { data } = await useAsyncData(`content-${path}`, () => queryContent().where({ _path: path, draft: { $ne: true } }).findOne())
+</script>


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue
resolves #1459
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Using the default slot in `<ContentRenderer>` did not affect rendered HTML when the content is a markdown file.  
This PR will prioritize the empty slot and the default slot.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
