### PR TITLE
docs(querying): add `_params` to api routes

### DIFF
--- a/docs/content/3.guide/2.displaying/2.querying.md
+++ b/docs/content/3.guide/2.displaying/2.querying.md
@@ -147,6 +147,7 @@ The API root path `/api/_content/query` accepts query parameters such as:
 - `/api/_content/query?only=title`
 - `/api/_content/query?sort=size:1`
 - `/api/_content/query?without=body`
+- `/api/_content/query?_params={"where":{"_path":"/hello"},"without":["body"]}`
 
 ### Example
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Added example for `_params` api route endpoint.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
