### PR TITLE
docs(v1/pt): prepare the ground to translate documentation to portuguese

### DIFF
--- a/docs/content-v1/pt/1.getting-started/1.introduction.md
+++ b/docs/content-v1/pt/1.getting-started/1.introduction.md
@@ -1,0 +1,61 @@
+---
+title: Introduction
+description: 'Empower your NuxtJS application with the @nuxt/content module: write in a content/ directory and fetch your Markdown, JSON, YAML and CSV files through a MongoDB-like API, acting as a Git-based Headless CMS.'
+---
+
+## Features
+
+::list
+- Blazing fast hot reload in development
+- Vue components in Markdown
+- Full-text search
+- Support static site generation with `nuxt generate`
+- Powerful QueryBuilder API (MongoDB like)
+- Syntax highlighting to code blocks in markdown files using PrismJS.
+- Table of contents generation
+- Handles Markdown, CSV, YAML, JSON(5), XML
+- Extend with custom parsers
+- Extend with hooks
+::
+
+## Videos
+
+Demonstration of using `$content` and `<nuxt-content>` to display Markdown pages:
+
+<video poster="https://res.cloudinary.com/nuxt/video/upload/v1588091670/nuxt-content_wxnjje.jpg" loop playsinline controls>
+  <source src="https://res.cloudinary.com/nuxt/video/upload/q_auto/v1588091670/nuxt-content_wxnjje.webm" type="video/webm" />
+  <source src="https://res.cloudinary.com/nuxt/video/upload/q_auto/v1588091670/nuxt-content_wxnjje.mp4" type="video/mp4" />
+  <source src="https://res.cloudinary.com/nuxt/video/upload/q_auto/v1588091670/nuxt-content_wxnjje.ogv" type="video/ogg" />
+</video>
+
+Using `$content()` on a directory to list, filter and search content:
+
+<video poster="https://res.cloudinary.com/nuxt/video/upload/v1588095794/nuxt-content-movies_c0cq9p.jpg" loop playsinline controls>
+  <source src="https://res.cloudinary.com/nuxt/video/upload/q_auto/v1588095794/nuxt-content-movies_c0cq9p.webm" type="video/webm" />
+  <source src="https://res.cloudinary.com/nuxt/video/upload/q_auto/v1588095794/nuxt-content-movies_c0cq9p.mp4" type="video/mp4" />
+  <source src="https://res.cloudinary.com/nuxt/video/upload/q_auto/v1588095794/nuxt-content-movies_c0cq9p.ogv" type="video/ogg" />
+</video>
+
+## Tutorial
+
+[Create a blog with Nuxt Content](https://nuxtjs.org/blog/creating-blog-with-nuxt-content)
+
+## Testimonials
+
+<blockquote class="twitter-tweet"><p lang="en" dir="ltr">Really enjoy working with the <a href="https://twitter.com/nuxt_js?ref_src=twsrc%5Etfw">@nuxt_js</a> content module more and more. Especially from a developer perspective. The api is easy to learn and really powerful. Give it a try if you haven&#39;t already.</p>&mdash; Rasmus Langvad (@rlangvad) <a href="https://twitter.com/rlangvad/status/1352940444200669186?ref_src=twsrc%5Etfw">January 23, 2021</a></blockquote>
+
+<blockquote class="twitter-tweet"><p lang="en" dir="ltr">Adding an FAQ to <a href="https://twitter.com/turnaudio?ref_src=twsrc%5Etfw">@TurnAudio</a> using <a href="https://twitter.com/nuxt_js?ref_src=twsrc%5Etfw">@nuxt_js</a> nuxt/content. Really great module for organizing a little bit of content within your static website <a href="https://t.co/o2uA9Lvmuu">https://t.co/o2uA9Lvmuu</a></p>&mdash; Lee Martin (@leemartin) <a href="https://twitter.com/leemartin/status/1290374428107341830?ref_src=twsrc%5Etfw">August 3, 2020</a></blockquote>
+
+<blockquote class="twitter-tweet"><p lang="en" dir="ltr">Wanted to try out <a href="https://twitter.com/nuxt_js?ref_src=twsrc%5Etfw">@nuxt_js</a> new content theme doc, was a blast!<br><br>Managed to hack its interals to extend its Tailwind config with mine hihihi... <a href="https://t.co/fuXXOBKXYE">pic.twitter.com/fuXXOBKXYE</a></p>&mdash; lihbr (@li_hbr) <a href="https://twitter.com/li_hbr/status/1289536277897834497?ref_src=twsrc%5Etfw">August 1, 2020</a></blockquote>
+
+<blockquote class="twitter-tweet"><p lang="en" dir="ltr">On an upper <a href="https://twitter.com/nuxt_js?ref_src=twsrc%5Etfw">@nuxt_js</a> is the most exciting thing in web for me right now, everything they put out is golden. The content module is phenomenal.</p>&mdash; Liam Hall - Three Bears (@wearethreebears) <a href="https://twitter.com/wearethreebears/status/1289345099214725120?ref_src=twsrc%5Etfw">July 31, 2020</a></blockquote>
+
+<blockquote class="twitter-tweet"><p lang="en" dir="ltr">I&#39;ve been working on a new portfolio/blog today with <a href="https://twitter.com/tailwindcss?ref_src=twsrc%5Etfw">@tailwindcss</a> and <a href="https://twitter.com/nuxt_js?ref_src=twsrc%5Etfw">@nuxt_js</a>. I&#39;m blown away by Nuxt Content.</p>&mdash; Cameron Baney (@cameronbaney) <a href="https://twitter.com/cameronbaney/status/1289671455559413761?ref_src=twsrc%5Etfw">August 1, 2020</a></blockquote>
+
+<blockquote class="twitter-tweet"><p lang="en" dir="ltr">Docs powered by the new <a href="https://twitter.com/nuxt_js?ref_src=twsrc%5Etfw">@nuxt_js</a> content plugin and stored in <a href="https://twitter.com/Netlify?ref_src=twsrc%5Etfw">@Netlify</a> what a time to be a developer</p>&mdash; Alfonso Bribiesca (@alfonsobries) <a href="https://twitter.com/alfonsobries/status/1288653236833062913?ref_src=twsrc%5Etfw">July 30, 2020</a></blockquote>
+
+<blockquote class="twitter-tweet"><p lang="en" dir="ltr">The new vee-validate v4 documentation is using <a href="https://twitter.com/nuxt_js?ref_src=twsrc%5Etfw">@nuxt_js</a> content module and so far it is too damn good 🔥<br><br>I like being able to create my own layouts and &quot;on this page&quot; and &quot;menu&quot; components, in other words, to be in full control 🎮</p>&mdash; Abdelrahman Awad (@logaretm) <a href="https://twitter.com/logaretm/status/1287526576847048705?ref_src=twsrc%5Etfw">July 26, 2020</a></blockquote>
+
+<blockquote class="twitter-tweet"><p lang="en" dir="ltr">Decided to build a blog with <a href="https://twitter.com/nuxt_js?ref_src=twsrc%5Etfw">@nuxt_js</a> content module. I mean, it&#39;s rapid and lightning quick to setup. Super nice experience thus far 👌</p>&mdash; 𝖊𝖗𝖉 (@erd_xyz) <a href="https://twitter.com/erd_xyz/status/1286395125447483394?ref_src=twsrc%5Etfw">July 23, 2020</a></blockquote>
+
+<script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>

--- a/docs/content-v1/pt/1.getting-started/2.installation.md
+++ b/docs/content-v1/pt/1.getting-started/2.installation.md
@@ -1,0 +1,50 @@
+---
+title: Installation
+description: 'Install @nuxt/content in only two steps in your Nuxt project.'
+---
+
+Add `@nuxt/content` dependency to your project:
+
+::code-group
+  ```bash [Yarn]
+  yarn add @nuxt/content
+  ```
+
+  ```bash [NPM]
+  npm install @nuxt/content
+  ```
+::
+
+Then, add `@nuxt/content` to the `modules` section of `nuxt.config.js`:
+
+```js [nuxt.config.js]
+{
+  modules: [
+    '@nuxt/content'
+  ],
+  content: {
+    // Options
+  }
+}
+```
+
+## TypeScript
+
+Add the types to your "types" array in tsconfig.json after the `@nuxt/types` (Nuxt 2.9.0+) or `@nuxt/vue-app` entry.
+
+**tsconfig.json**
+
+```json
+{
+  "compilerOptions": {
+    "types": [
+      "@nuxt/types",
+      "@nuxt/content"
+    ]
+  }
+}
+```
+
+> **Why?**
+>
+> Because of the way Nuxt works the `$content` property on the context has to be merged into the Nuxt `Context` interface via [declaration merging](https://www.typescriptlang.org/docs/handbook/declaration-merging.html). Adding `@nuxt/content` to your types will import the types from the package and make TypeScript aware of the additions to the `Context` interface.

--- a/docs/content-v1/pt/1.getting-started/2.installation.md
+++ b/docs/content-v1/pt/1.getting-started/2.installation.md
@@ -7,11 +7,11 @@ Add `@nuxt/content` dependency to your project:
 
 ::code-group
   ```bash [Yarn]
-  yarn add @nuxt/content
+  yarn add @nuxt/content@^1
   ```
 
   ```bash [NPM]
-  npm install @nuxt/content
+  npm install @nuxt/content@^1
   ```
 ::
 

--- a/docs/content-v1/pt/1.getting-started/3.writing.md
+++ b/docs/content-v1/pt/1.getting-started/3.writing.md
@@ -1,0 +1,670 @@
+---
+title: Writing content
+description: 'Learn how to write your content/, supporting Markdown, YAML, CSV and JSON.'
+multiselectOptions:
+  - VuePress
+  - Gridsome
+  - Nuxt
+---
+
+First of all, create a `content/` directory in your project:
+
+```bash
+content/
+  articles/
+    article-1.md
+    article-2.md
+  home.md
+```
+
+This module will parse `.md`, `.yaml`, `.yml`, `.csv`, `.json`, `.json5`, `.xml` files and generate the following properties:
+
+- `dir`
+- `path`
+- `slug`
+- `extension` (ex: `.md`)
+- `createdAt`
+- `updatedAt`
+
+The `createdAt` and `updatedAt` properties are based on the file's actual created & updated datetime, but you can override them by defining your own `createdAt` and `updatedAt` values. This is especially useful if you are migrating your past blog posts where the `createdAt` can be months or years ago.
+
+## Markdown
+
+This module converts your `.md` files into a JSON AST tree structure, stored in a `body` variable.
+
+Make sure to use the `<nuxt-content>` component to display the `body` of your markdown content, see [displaying content](/displaying).
+
+> You can check the [basic syntax guide](https://www.markdownguide.org/basic-syntax) to help you master Markdown
+
+### Front Matter
+
+You can add a YAML front matter block to your markdown files. The front matter must be the first thing in the file and must take the form of valid YAML set between triple-dashed lines. Here is a basic example:
+
+```md
+---
+title: Introduction
+description: Learn how to use @nuxt/content.
+---
+```
+
+These variables will be injected into the document:
+
+```json
+{
+  body: Object
+  excerpt: Object
+  title: "Introduction"
+  description: "Learn how to use @nuxt/content."
+  dir: "/"
+  extension: ".md"
+  path: "/index"
+  slug: "index"
+  toc: Array
+  createdAt: DateTime
+  updatedAt: DateTime
+}
+```
+
+### Excerpt
+
+Content excerpt or summary can be extracted from the content using `<!--more-->` as a divider.
+
+```md
+---
+title: Introduction
+---
+
+Learn how to use @nuxt/content.
+<!--more-->
+Full amount of content beyond the more divider.
+```
+
+Description property will contain the excerpt content unless defined within the Front Matter props.
+
+<alert type="info">
+
+Be careful to enter <code>&lt;!--more--&gt;</code> exactly; i.e., all lowercase and with no whitespace.
+
+</alert>
+
+Example variables will be injected into the document:
+
+```json
+{
+  body: Object
+  title: "Introduction"
+  description: "Learn how to use @nuxt/content."
+  dir: "/"
+  excerpt: Object
+  extension: ".md"
+  path: "/index"
+  slug: "index"
+  toc: Array
+  createdAt: DateTime
+  updatedAt: DateTime
+}
+```
+
+### Headings
+
+This module automatically adds an `id` and a `link` to each heading.
+
+Say we have the following markdown file:
+
+```md[home.md]
+# Lorem ipsum
+## dolor—sit—amet
+### consectetur &amp; adipisicing
+#### elit
+##### elit
+```
+
+It will be transformed to its JSON AST structure, and by using the `nuxt-content` component, it will render HTML like:
+
+```html
+<h1 id="lorem-ipsum-"><a href="#lorem-ipsum-" aria-hidden="true" tabindex="-1"><span class="icon icon-link"></span></a>Lorem ipsum</h1>
+<h2 id="dolorsitamet"><a href="#dolorsitamet" aria-hidden="true" tabindex="-1"><span class="icon icon-link"></span></a>dolor—sit—amet</h2>
+<h3 id="consectetur--adipisicing"><a href="#consectetur--adipisicing" aria-hidden="true" tabindex="-1"><span class="icon icon-link"></span></a>consectetur &#x26; adipisicing</h3>
+<h4 id="elit"><a href="#elit" aria-hidden="true" tabindex="-1"><span class="icon icon-link"></span></a>elit</h4>
+<h5 id="elit-1"><a href="#elit-1" aria-hidden="true" tabindex="-1"><span class="icon icon-link"></span></a>elit</h5>
+```
+
+> The links in headings are empty and therefore hidden, so it's up to you to style them. For an example, try hovering one of the headers in these docs.
+
+### Links
+
+Links are transformed to add valid `target` and `rel` attributes using [remark-external-links](https://github.com/remarkjs/remark-external-links). You can check [here](/configuration#markdown) to learn how to configure this plugin.
+
+Relative links are also automatically transformed to [nuxt-link](https://nuxtjs.org/api/components-nuxt-link/) to provide navigation between page components with enhanced performance through smart prefetching.
+
+Here is an example using external, relative, markdown and html links:
+
+```md
+---
+title: Home
+---
+
+## Links
+
+<nuxt-link to="/articles">Nuxt Link to Blog</nuxt-link>
+
+<a href="/articles">Html Link to Blog</a>
+
+[Markdown Link to Blog](/articles)
+
+<a href="https://nuxtjs.org">External link html</a>
+
+[External Link markdown](https://nuxtjs.org)
+```
+
+### Footnotes
+
+This module supports extended markdown syntax for footnotes using [remark-footnotes](https://github.com/remarkjs/remark-footnotes). You can check [here](/configuration#markdown) to learn how to configure this plugin.
+
+Here is an example using footnotes:
+
+```md
+Here's a simple footnote,[^1] and here's a longer one.[^bignote]
+
+[^1]: This is the first footnote.
+
+[^bignote]: Here's one with multiple paragraphs and code.
+
+    Indent paragraphs to include them in the footnote.
+
+    `{ my code }`
+
+    Add as many paragraphs as you like.
+```
+
+> You can check the [extended syntax guide](https://www.markdownguide.org/extended-syntax/#footnotes) for more information about footnotes.
+
+### Codeblocks
+
+This module automatically wraps codeblocks and applies [PrismJS](https://prismjs.com) classes (see [syntax highlighting](/writing#syntax-highlighting)).
+
+Codeblocks in Markdown are wrapped inside 3 backticks. Optionally, you can define the language of the codeblock to enable specific syntax highlighting.
+
+Originally markdown did not support filenames or highlighting specific lines inside codeblocks. However, this module allows it with its own custom syntax:
+
+- Highlighted line numbers inside curly braces
+- Filename inside square brackets
+
+<pre class="language-js">
+```js{1,3-5}[server.js]
+const http = require('http')
+const bodyParser = require('body-parser')
+
+http.createServer((req, res) => {
+  bodyParser.parse(req, (error, body) => {
+    res.end(body)
+  })
+}).listen(3000)
+```
+</pre>
+
+After rendering with the `nuxt-content` component, it should look like this (without the filename yet):
+
+```html[server.js]
+<div class="nuxt-content-highlight">
+  <span class="filename">server.js</span>
+  <pre class="language-js" data-line="1,3-5">
+    <code>
+      ...
+    </code>
+  </pre>
+</div>
+```
+
+Line numbers are added to the `pre` tag in `data-line` attribute.
+
+> Check out [this comment](https://github.com/nuxt/content/issues/28#issuecomment-633246962) on how to render prism line numbers.
+
+Filename will be converted to a span with a `filename` class. It's up to you to style it.
+
+> Check out [the main.css file](https://github.com/nuxt/content/blob/dev/packages/theme-docs/src/assets/css/main.css#L56) of this documentation for an example on styling filenames.
+
+### Syntax highlighting
+
+It supports by default code highlighting using [PrismJS](https://prismjs.com) and injects the theme defined in options into your Nuxt.js app, see [configuration](/configuration#markdownprismtheme).
+
+### HTML
+
+You can write HTML in your Markdown:
+
+```md[home.md]
+---
+title: Home
+---
+
+## HTML
+
+<p><span class="note">A mix of <em>Markdown</em> and <em>HTML</em>.</span></p>
+```
+
+Beware that when placing Markdown inside a component, it must be preceded and followed by an empty line, otherwise the whole block is treated as custom HTML.
+
+**This won't work:**
+
+```html
+<div class="note">
+  *Markdown* and <em>HTML</em>.
+</div>
+```
+
+**But this will:**
+
+```html
+<div class="note">
+
+  *Markdown* and <em>HTML</em>.
+
+</div>
+```
+
+**As will this**:
+
+```html
+<span class="note">*Markdown* and <em>HTML</em>.</span>
+```
+
+### Vue components
+
+You can use global Vue components or locally registered in the page you're displaying your markdown.
+
+<alert type="warning">
+
+An issue exists with locally registered components and live edit in development, since **v1.5.0** you can disable it by setting `liveEdit: false` (see [configuration](/configuration#liveedit)).
+
+</alert>
+
+Since `@nuxt/content` operates under the assumption that all Markdown is provided by the author (and not via third-party user submission), sources are processed in full (tags included), with a couple of caveats from [rehype-raw](https://github.com/rehypejs/rehype-raw):
+
+1. You need to refer to your components and their props by kebab case naming:
+
+```html
+Use <my-component :my-prop="myValue"> instead of <MyComponent :myProp="myValue">
+```
+
+2. You cannot use self-closing tags, i.e., **this won't work**:
+
+```html
+<my-component/>
+```
+
+But **this will**:
+
+```html
+<my-component></my-component>
+```
+
+**Example**
+
+Say we have a Vue component called [ExampleMultiselect.vue](https://github.com/nuxt/content/blob/master/docs/components/global/examples/ExampleMultiselect.vue):
+
+```md[home.md]
+Please choose a *framework*:
+
+<example-multiselect :options="['Vue', 'React', 'Angular', 'Svelte']"></example-multiselect>
+```
+
+**Result**
+
+<div class="border rounded-md p-2 mb-2 bg-gray-200 dark:bg-gray-800">
+Please choose a <i>framework</i>:
+
+<example-multiselect :options="['Vue', 'React', 'Angular', 'Svelte']"></example-multiselect>
+
+</div>
+
+You can also define the options for components in your front matter:
+
+```md[home.md]
+---
+multiselectOptions:
+  - VuePress
+  - Gridsome
+  - Nuxt
+---
+
+<example-multiselect :options="multiselectOptions"></example-multiselect>
+```
+
+<div class="border rounded-md p-2 mb-2 bg-gray-200 dark:bg-gray-800">
+
+<example-multiselect :options="multiselectOptions"></example-multiselect>
+
+</div>
+
+<alert type="info">
+
+These components will be rendered using the `<nuxt-content>` component, see [displaying content](/displaying#component).
+
+</alert>
+
+#### Templates
+
+You can use `template` tags for content distribution inside your Vue.js components:
+
+```html
+<my-component>
+  <template #named-slot>
+    <p>Named slot content.</p>
+  </template>
+</my-component>
+```
+
+However, you cannot render
+[dynamic content](https://vuejs.org/v2/guide/syntax.html) nor use
+[slot props](https://vuejs.org/v2/guide/components-slots.html#Scoped-Slots). I.e.,
+**this wont work**:
+
+```html
+<my-component>
+  <template #named-slot="slotProps">
+    <p>{{ slotProps.someProperty }}</p>
+  </template>
+</my-component>
+```
+
+#### Global components
+
+Since **v1.4.0** and Nuxt **v2.13.0**, you can now put your components in `components/global/` directory so you don't have to import them in your pages.
+
+```bash
+components/
+  global/
+    Hello.vue
+content/
+  home.md
+```
+
+Then in `content/home.md`, you can use `<hello></hello>` component without having to worry about importing it in your page.
+
+### Table of contents
+
+When fetching a document, we have access to a toc property which is an array of all the titles. Each title has an `id` so that it is possible to link to, a depth which is the type of heading it is. Only h2 and h3 titles are used for the toc. There is also a text property which is the text of the title.
+
+```json
+{
+  "toc": [{
+    "id": "welcome",
+    "depth": 2,
+    "text": "Welcome!"
+  }]
+}
+```
+
+> Take a look at the right side of this page for an example.
+
+<alert type="info">
+
+Check out [this snippet](/snippets#table-of-contents) on how to implement a table of contents into your app
+
+</alert>
+
+### Example
+
+A file `content/home.md`:
+
+```md
+---
+title: Home
+---
+
+## Welcome!
+```
+
+Will be transformed into:
+
+```json
+{
+  "dir": "/",
+  "slug": "home",
+  "path": "/home",
+  "extension": ".md",
+  "title": "Home",
+  "toc": [
+    {
+      "id": "welcome",
+      "depth": 2,
+      "text": "Welcome!"
+    }
+  ],
+  "body": {
+    "type": "root",
+    "children": [
+      {
+        "type": "element",
+        "tag": "h2",
+        "props": {
+          "id": "welcome"
+        },
+        "children": [
+          {
+            "type": "element",
+            "tag": "a",
+            "props": {
+              "ariaHidden": "true",
+              "href": "#welcome",
+              "tabIndex": -1
+            },
+            "children": [
+              {
+                "type": "element",
+                "tag": "span",
+                "props": {
+                  "className": [
+                    "icon",
+                    "icon-link"
+                  ]
+                },
+                "children": []
+              }
+            ]
+          },
+          {
+            "type": "text",
+            "value": "Welcome!"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+We internally add a `text` key with the markdown body that will be used for [searching](/fetching#searchfield-value) or [extending](/advanced#contentfilebeforeinsert) it.
+
+## JSON / JSON5
+
+Data defined will be injected into the document.
+
+> No body will be generated.
+
+### Arrays
+
+<badge>v0.10.0+</badge>
+
+You can now use arrays inside your `.json` files. Objects will be flattened and inserted into the collection. You can [fetch](/fetching) your content in the same way as your used to.
+
+<alert type="warning">
+
+Since the `slug` is by default taken from the path and missing in this case, you have to define it in your objects for this feature to work properly.
+
+</alert>
+
+> Check out our [example](https://github.com/nuxt/content/tree/dev/example) with articles and authors.
+
+### Example
+
+A file `content/home.json`:
+
+```json
+{
+  "title": "Home",
+  "description": "Welcome!"
+}
+```
+
+Will be transformed into:
+
+```json
+{
+  "dir": "/",
+  "slug": "home",
+  "path": "/home",
+  "extension": ".json",
+  "title": "Home",
+  "description": "Welcome!"
+}
+```
+
+A file `content/authors.json`:
+
+```json
+[
+  {
+    "name": "Sébastien Chopin",
+    "slug": "atinux"
+  },
+  {
+    "name": "Krutie Patel",
+    "slug": "krutiepatel"
+  },
+  {
+    "name": "Sergey Bedritsky",
+    "slug": "sergeybedritsky"
+  }
+]
+```
+
+Will be transformed into:
+
+```json
+[
+  {
+    "name": "Sébastien Chopin",
+    "slug": "atinux",
+    "dir": "/authors",
+    "path": "/authors/atinux",
+    "extension": ".json"
+  },
+  {
+    "name": "Krutie Patel",
+    "slug": "krutiepatel",
+    "dir": "/authors",
+    "path": "/authors/krutiepatel",
+    "extension": ".json"
+  },
+  {
+    "name": "Sergey Bedritsky",
+    "slug": "sergeybedritsky",
+    "dir": "/authors",
+    "path": "/authors/sergeybedritsky",
+    "extension": ".json"
+  }
+]
+```
+
+## CSV
+
+Rows will be assigned to body variable.
+
+### Example
+
+A file `content/home.csv`:
+
+```csv
+title, description
+Home, Welcome!
+```
+
+Will be transformed into:
+
+```json
+{
+  "dir": "/",
+  "slug": "home",
+  "path": "/home",
+  "extension": ".csv",
+  "body": [
+    {
+      "title": "Home",
+      "description": "Welcome!"
+    }
+  ]
+}
+```
+
+## XML
+
+XML will be parsed
+
+### Example
+
+A file `content/home.xml`:
+
+```xml
+<xml>
+  <item prop="abc">
+    <title>Title</title>
+    <description>Hello World</description>
+  </item>
+</xml>
+```
+
+Will be transformed into:
+
+```json
+{
+  "dir": "/",
+  "slug": "home",
+  "path": "/home",
+  "extension": ".xml",
+  "body": {
+    "xml": {
+      "item": [
+        {
+          "$": {
+            "prop": "abc"
+          },
+          "title": [
+            "Title"
+          ],
+          "description": [
+            "Hello World"
+          ]
+      }
+    ]
+  }
+}
+```
+
+## YAML / YML
+
+Data defined will be injected into the document.
+
+> No body will be generated.
+
+### Example
+
+A file `content/home.yaml`:
+
+```yaml
+title: Home
+description: Welcome!
+```
+
+Will be transformed into:
+
+```json
+{
+  "dir": "/",
+  "slug": "home",
+  "path": "/home",
+  "extension": ".yaml",
+  "title": "Home",
+  "description": "Welcome!"
+}
+```

--- a/docs/content-v1/pt/1.getting-started/4.fetching.md
+++ b/docs/content-v1/pt/1.getting-started/4.fetching.md
@@ -1,0 +1,252 @@
+---
+title: Fetching content
+description: 'Learn how to fetch your static content with $content in your Nuxt.js project.'
+---
+
+This module globally injects `$content` instance, meaning that you can access it anywhere using `this.$content`. For plugins, asyncData, nuxtServerInit and Middleware, you can access it from `context.$content`.
+
+## Methods
+
+### $content(path, options?)
+
+- `path`
+  - Type: `String`
+  - Default: `/`
+- `options`
+  - Type: `Object`
+  - Default: `{}`
+  - Version: **>= v1.3.0**
+- `options.deep`
+  - Type: `Boolean`
+  - Default: `false`
+  - Version: **>= v1.3.0**
+  - *Fetch files from subdirectories*
+- `options.text`
+  - Type: `Boolean`
+  - Default: `false`
+  - Version: **>= v1.4.0**
+  - *Returns the original markdown content in a `text` variable*
+- Returns a chain sequence
+
+> You can also give multiple arguments: `$content('articles', params.slug)` will be translated to `/articles/${params.slug}`
+
+`path` can be a file or a directory. If `path` is a file, `fetch()` will return an `Object`, if it's a directory it will return an `Array`.
+
+All the methods below can be chained and return a chain sequence, except `fetch` which returns a `Promise`.
+
+### only(keys)
+
+- `keys`
+  - Type: `Array` | `String`
+  - `required`
+
+Select a subset of fields.
+
+```js
+const { title } = await this.$content('article-1').only(['title']).fetch()
+```
+
+### without(keys)
+
+- `keys`
+  - Type: `Array` | `String`
+  - `required`
+
+Remove a subset of fields.
+
+```js
+const { title, ...propsWithoutBody } = await this.$content('article-1').without(['body']).fetch()
+```
+
+### where(query)
+
+- `query`
+  - Type: `Object`
+  - `required`
+
+Filter results by query.
+
+Where queries are based on subset of mongo query syntax, it handles for example: `$eq`, `$ne`, `$gt`, `$gte`, `$lt`, `$lte`, `$in`, ...
+
+```js
+// implicit (assumes $eq operator)
+const articles = await this.$content('articles').where({ title: 'Home' }).fetch()
+// explicit $eq
+const articles = await this.$content('articles').where({ title: { $eq: 'Home' } }).fetch()
+
+// $gt
+const articles = await this.$content('articles').where({ age: { $gt: 18 } }).fetch()
+// $in
+const articles = await this.$content('articles').where({ name: { $in: ['odin', 'thor'] } }).fetch()
+```
+
+In order to filter in objects and array you need to enable nestedProperties, see [configuration](/configuration#nestedproperties).
+
+```js
+const products = await this.$content('products').where({ 'categories.slug': { $contains: 'top' } }).fetch()
+
+const products = await this.$content('products').where({ 'categories.slug': { $contains: ['top', 'woman'] } }).fetch()
+```
+
+> This module uses LokiJS under the hood, you can check for [query examples](https://github.com/techfort/LokiJS/wiki/Query-Examples#find-queries).
+
+### sortBy(key, direction)
+
+- `key`
+  - Type: `String`
+  - `required`
+- `direction`
+  - Type: `String`
+  - Value: `'asc'` or `'desc'`
+  - Default: `'asc'`
+
+Sort results by key.
+
+```js
+const articles = await this.$content('articles').sortBy('title').fetch()
+```
+
+> Can be chained multiple times to sort on multiple fields.
+
+<alert type="warning">
+
+`sortBy` method does **case-sensitive** sort, which is currently not configurable.
+
+If you need case-insensitive sorting, check out [this snippet](/snippets#case-insensitive-sorting) on how to work around it.
+
+</alert>
+
+### limit(n)
+
+- `n`
+  - Type: `String` | `Number`
+  - `required`
+
+Limit number of results.
+
+```js
+// fetch only 5 articles
+const articles = await this.$content('articles').limit(5).fetch()
+```
+
+### skip(n)
+
+- `n`
+  - Type: `String` | `Number`
+  - `required`
+
+Skip results.
+
+```js
+// fetch the next 5 articles
+const articles = await this.$content('articles').skip(5).limit(5).fetch()
+```
+
+### search(field, value)
+
+- `field`
+  - Type: `String`
+  - `required`
+- `value`
+  - Type: `String`
+
+Performs a full-text search on a field. `value` is optional, in this case `field` is the `value` and search will be performed on all defined full-text search fields.
+
+The fields you want to search on must be defined in options in order to be indexed, see [configuration](/configuration#fulltextsearchfields).
+
+Using an empty string as parameter will skip the search.
+
+```js
+// Search on field title
+const articles = await this.$content('articles').search('title', 'welcome').fetch()
+// Search on all pre-defined fields
+const articles = await this.$content('articles').search('welcome').fetch()
+// Search will be skipped if the search string is empty
+const articles = await this.$content('articles').search('').fetch()
+```
+
+<alert type="info">
+
+Check out [this snippet](/snippets#search) on how to implement search into your app
+
+</alert>
+
+### surround(slugOrPath, options)
+
+- `slugOrPath`
+  - Type: `String`
+  - `required`
+- `options`
+  - Type: `Object`
+  - Default: `{ before: 1, after: 1}`
+
+Get prev and next results around a specific slug or path.
+
+You will always obtain an array of fixed length filled with the maching document or `null`.
+
+```js
+const [prev, next] = await this.$content('articles')
+  .only(['title', 'path'])
+  .sortBy('date')
+  .where({ isArchived: false })
+  .surround('article-2')
+  .fetch()
+
+// Returns
+[
+  {
+    title: 'Article 1',
+    path: 'article-1'
+  },
+  null // no article-3 here
+]
+```
+
+> `search`, `limit` and `skip` are ineffective when using this method.
+
+<alert type="warning">
+
+Getting results based on `path` is only supported since v1.12.0
+
+</alert>
+
+<alert type="info">
+
+Check out [this snippet](/snippets#prev-and-next) on how to implement prev and next links into your app
+
+</alert>
+
+### fetch()
+
+- Returns: `Promise<Object>` | `Promise<Array>`
+
+Ends the chain sequence and collects data.
+
+### catch()
+
+Checks if the `.md` file exists in content directory or not.
+
+It should be inserted after the `fetch()`.
+
+## Example
+
+```js
+const articles = await this.$content('articles')
+  .only(['title', 'date', 'authors'])
+  .sortBy('date', 'asc')
+  .limit(5)
+  .skip(10)
+  .where({
+    tags: 'testing',
+    isArchived: false,
+    date: { $gt: new Date('2020-03-31') },
+    rating: { $gte: 3 }
+  })
+  .search('welcome')
+  .fetch()
+  .catch((err) => {
+     error({ statusCode: 404, message: 'Page not found' })
+  })
+```
+
+> You can check how to use the [Content API](/advanced#api-endpoint) in development.

--- a/docs/content-v1/pt/1.getting-started/5.displaying.md
+++ b/docs/content-v1/pt/1.getting-started/5.displaying.md
@@ -1,0 +1,102 @@
+---
+title: Displaying content
+description: 'You can use `<nuxt-content>` component directly in your template to display your Markdown.'
+---
+
+<alert type="info">This section is only for Markdown files.</alert>
+
+## Component
+
+### Page Body
+
+You can use `<nuxt-content>` component directly in your template to display the page body:
+
+```vue
+<template>
+  <article>
+    <h1>{{ page.title }}</h1>
+    <nuxt-content :document="page" />
+  </article>
+</template>
+
+<script>
+export default {
+  async asyncData ({ $content }) {
+    const page = await $content('home').fetch()
+
+    return {
+      page
+    }
+  }
+}
+</script>
+```
+
+
+**Props:**
+- document:
+  - Type: `Object`
+  - `required`
+- tag:
+  - Type: `String`
+
+Learn more about what you can write in your markdown file in the [writing content](/writing#markdown) section.
+
+### Excerpt
+
+If you are utilizing the [excerpt](/writing#excerpt) feature, you can display the content of your excerpt using the following model:
+
+```vue
+<template>
+  <article>
+    <h1>{{ page.title }}</h1>
+    <nuxt-content :document="{ body: page.excerpt }" />
+  </article>
+</template>
+
+<script>
+export default {
+  async asyncData ({ $content }) {
+    const page = await $content('home').fetch()
+
+    return {
+      page
+    }
+  }
+}
+</script>
+```
+
+## Root Element
+
+`<nuxt-content>` component will add a `div` element as the root of the content by default. You can change this by setting the `tag` prop. Below example will use `article` as the root element.
+
+```vue
+<nuxt-content :document="doc" tag="article">
+```
+
+## Style
+
+Depending on what you're using to design your app, you may need to write some style to properly display the markdown.
+
+`<nuxt-content>` component will automatically add a `.nuxt-content` class. You can use it to customize your styles:
+
+```css
+.nuxt-content h1 {
+  /* my custom h1 style */
+}
+```
+
+> You can find an example in the theme-docs [main.css](https://github.com/nuxt/content/blob/master/packages/theme-docs/src/assets/css/main.css) file. You can also take a look at the [TailwindCSS Typography plugin](https://tailwindcss.com/docs/typography-plugin) to style your markdown content like we do in the `@nuxt/content-theme-docs`.
+
+## Live Editing
+
+> Available in version **>= v1.4.0**
+
+**In development**, you can edit your content by **double-clicking** on the `<nuxt-content>` component. A textarea will allow you to edit the content of the current file and will save it on the file-system.
+
+<video poster="https://res.cloudinary.com/nuxt/video/upload/v1588091670/nuxt-content-ui_otfj5y.jpg" loop playsinline controls>
+  <source src="https://res.cloudinary.com/nuxt/video/upload/v1588091670/nuxt-content-ui_otfj5y.webm" type="video/webm" />
+  <source src="https://res.cloudinary.com/nuxt/video/upload/v1592314331/nuxt-content-ui_otfj5y.mp4" type="video/mp4" />
+  <source src="https://res.cloudinary.com/nuxt/video/upload/v1588091670/nuxt-content-ui_otfj5y.ogv" type="video/ogg" />
+</video>

--- a/docs/content-v1/pt/1.getting-started/6.configuration.md
+++ b/docs/content-v1/pt/1.getting-started/6.configuration.md
@@ -1,0 +1,546 @@
+---
+title: Configuration
+description: 'You can configure @nuxt/content with the content property in your nuxt.config.js.'
+---
+
+You can configure `@nuxt/content` with the `content` property in your `nuxt.config.js`.
+
+```js [nuxt.config.js]
+export default {
+  content: {
+    // My custom configuration
+  }
+}
+```
+
+Before diving into the individual attributes, please have a look [at the default settings](#defaults) of the module.
+
+## Merging defaults
+
+You can define every option either as function or as static value (primitives, objects, arrays, ...).
+If you use a function, the default value will be provided as the first argument.
+
+If you *don't* use a function to define you properties, the module will try to
+merge them with the default values. This can be handy for `markdown.remarkPlugins`, `markdown.rehypePlugins` and so on because
+the defaults are quite sensible. If you don't want to have the defaults included, just use a function.
+
+## Properties
+
+### `apiPrefix`
+
+- Type: `String`
+- Default: `'/_content'`
+
+Route that will be used for client-side API calls and SSE.
+
+```js [nuxt.config.js]
+content: {
+  // $content api will be served on localhost:3000/content-api
+  apiPrefix: 'content-api'
+}
+```
+
+### `dir`
+
+- Type: `String`
+- Default: `'content'`
+
+Directory used for writing content.
+You can give an absolute path, if relative, it will be resolved with Nuxt [srcDir](https://nuxtjs.org/api/configuration-srcdir).
+
+```js [nuxt.config.js]
+content: {
+  dir: 'my-content' // read content from my-content/
+}
+```
+
+### `fullTextSearchFields`
+
+- Type: `Array`
+- Default: `['title', 'description', 'slug', 'text']`
+
+Fields that needs to be indexed to be searchable, learn more about search [here](/fetching#searchfield-value).
+
+`text` is a special key that contains your Markdown before being parsed to AST.
+
+```js [nuxt.config.js]
+content: {
+  // Only search in title and description
+  fullTextSearchFields: ['title', 'description']
+}
+```
+
+### `nestedProperties`
+
+- Type `Array`
+- Default: `[]`
+- Version: **>= v1.3.0**
+
+Register nested properties to handle dot-notation and deep filtering.
+
+```js [nuxt.config.js]
+content: {
+  nestedProperties: ['categories.slug']
+}
+```
+
+### `liveEdit`
+
+- Type `Boolean`
+- Default: `true`
+- Version: **>= v1.5.0**
+
+Disable live edit mode in development:
+
+```js [nuxt.config.js]
+content: {
+  liveEdit: false
+}
+```
+
+### `markdown`
+
+This module uses [remark](https://github.com/remarkjs/remark) and [rehype](https://github.com/rehypejs/rehype) under the hood to compile markdown files into JSON AST that will be stored into the `body` variable.
+
+::alert{type="info"}
+The following explanation is valid for both `remarkPlugins` and `rehypePlugins`
+::
+
+To configure how the module will parse Markdown, you can:
+
+- Add a new plugin to the defaults:
+
+```js [nuxt.config.js]
+export default {
+  content: {
+    markdown: {
+      remarkPlugins: ['remark-emoji']
+    }
+  }
+}
+```
+
+- Override the default plugins:
+
+```js [nuxt.config.js]
+export default {
+  content: {
+    markdown: {
+      remarkPlugins: () => ['remark-emoji']
+    }
+  }
+}
+```
+
+- Use local plugins
+
+```js [nuxt.config.js]
+export default {
+  content: {
+    markdown: {
+      remarkPlugins: [
+        '~/plugins/my-custom-remark-plugin.js'
+      ]
+    }
+  }
+}
+```
+
+- Provide options directly in the definition
+
+```js [nuxt.config.js]
+export default {
+  content: {
+    markdown: {
+      remarkPlugins: [
+        ['remark-emoji', { emoticon: true }]
+      ]
+    }
+  }
+}
+```
+
+- Provide options using the name of the plugin in `camelCase`
+
+```js [nuxt.config.js]
+export default {
+  content: {
+    markdown: {
+      // https://github.com/remarkjs/remark-external-links#options
+      remarkExternalLinks: {
+        target: '_self',
+        rel: 'nofollow'
+      }
+    }
+  }
+}
+```
+
+::alert{type="warning"}
+When adding a new plugin, make sure to install it in your dependencies:
+::
+
+::code-group
+  ```bash [Yarn]
+  yarn add remark-emoji
+  ```
+
+  ```bash [NPM]
+  npm install remark-emoji
+  ```
+::
+
+```js [nuxt.config.js]
+export default {
+  content: {
+    markdown: {
+      remarkPlugins: ['remark-emoji']
+    }
+  }
+}
+```
+
+### `markdown.tocDepth`
+
+- Type: `Number`
+- Default: `3`
+- Version: **>= v1.11.0**
+
+You can change maximum heading depth to include in the table of contents.
+
+### `markdown.remarkPlugins`
+
+- Type: `Array`
+- Default: `['remark-squeeze-paragraphs', 'remark-slug', 'remark-autolink-headings', 'remark-external-links', 'remark-footnotes']`
+- Version: **>= v1.4.0**
+
+> You can take a look at the list of [remark plugins](https://github.com/remarkjs/remark/blob/master/doc/plugins.md#list-of-plugins).
+
+### `markdown.rehypePlugins`
+
+- Type: `Array`
+- Default: `['rehype-minify-whitespace', 'rehype-sort-attribute-values', 'rehype-sort-attributes', 'rehype-raw']`
+- Version: **>= v1.4.0**
+
+> You can take a look at the list of [rehype plugins](https://github.com/rehypejs/rehype/blob/master/doc/plugins.md#list-of-plugins).
+
+### `markdown.basePlugins`
+
+::alert{type="warning"}
+Deprecated. Use `markdown.remarkPlugins` as a function instead.
+::
+
+### `markdown.plugins`
+
+::alert{type="warning"}
+Deprecated. Use `markdown.remarkPlugins` as an array instead.
+::
+
+### `markdown.prism.theme`
+
+- Type: `String`
+- Default: `'prismjs/themes/prism.css'`
+
+This module handles code highlighting in markdown content using [PrismJS](https://prismjs.com).
+
+It automatically pushes the desired PrismJS theme in your Nuxt.js config, so if you want to use a different theme than the default one, for example [prism-themes](https://github.com/PrismJS/prism-themes):
+
+::code-group
+  ```bash [Yarn]
+  yarn add prism-themes
+  ```
+
+  ```bash [NPM]
+  npm install prism-themes
+  ```
+::
+
+```js [nuxt.config.js]
+content: {
+  markdown: {
+    prism: {
+      theme: 'prism-themes/themes/prism-material-oceanic.css'
+    }
+  }
+}
+```
+
+To disable the inclusion of the theme, set prism to `false`:
+
+```js [nuxt.config.js]
+content: {
+  markdown: {
+    prism: {
+      theme: false
+    }
+  }
+}
+```
+
+### `markdown.highlighter`
+
+- Type: `Highlighter` | `PromisedHighlighter`
+- Version: **>=1.9.0**
+
+You can change the default code highlighter in markdown content by using this option. As an example, we use [highlight.js](https://highlightjs.org/).
+
+```js [nuxt.config.js]
+import highlightjs from 'highlight.js'
+
+export default {
+  content: {
+    markdown: {
+      highlighter(rawCode, lang) {
+        const highlightedCode = highlightjs.highlight(rawCode, { language: lang }).value
+
+        // We need to create a wrapper, because
+        // the returned code from highlight.js
+        // is only the highlighted code.
+        return `<pre><code class="hljs ${lang}">${highlightedCode}</code></pre>`
+      }
+    }
+  }
+}
+```
+
+<alert type="info">
+
+When `markdown.highlighter` is defined, it will automatically disable the inclusion of the Prism theme.
+
+</alert>
+
+<alert type="warning">
+
+Don't forget to add the corresponding style manually if you define `markdown.highlighter`.
+
+</alert>
+
+It returns a `string` or [HAST](https://github.com/syntax-tree/hast) (Hypertext Abstract Syntax Tree). You can build HAST by passing the 4th argument. It consits of `h`, `node` and `u`.
+
+```js [nuxt.config.js]
+import highlightjs from 'highlight.js'
+
+export default {
+  content: {
+    markdown: {
+      highlighter(rawCode, lang, _, { h, node, u }) {
+        const highlightedCode = highlightjs.highlight(rawCode, { language: lang }).value
+
+        // We can use ast helper to create the wrapper
+        const childs = []
+        childs.push(
+          h(node, 'pre', [
+            h(node, 'code', { className: ['hljs', lang] }, [
+              u('raw', highlightedCode)
+            ])
+          ])
+        )
+
+        return h(
+          node,
+          'div',
+          { className: 'highlighted-with-highlightjs' },
+          childs
+        )
+      }
+    }
+  }
+}
+```
+
+After rendering with the `nuxt-content` component, it will look like this:
+
+```html
+<div class="highlighted-with-highlightjs">
+  <pre class="language-<lang>">
+    <code>
+      ...
+    </code>
+  </pre>
+</div>
+```
+
+You can also get the line highlight and file name value from the 3rd argument. Combining them with the HAST, you can pass it to the client.
+
+```js [nuxt.config.js]
+import highlightjs from 'highlight.js'
+
+export default {
+  content: {
+    markdown: {
+      highlighter(rawCode, lang, { lineHighlights, fileName }, { h, node, u }) {
+        const highlightedCode = highlightjs.highlight(rawCode, { language: lang }).value
+
+        const childs = []
+        const props = {
+          className: `language-${lang}`,
+          dataLine: lineHighlights,
+          dataFileName: fileName
+        }
+        childs.push(
+          h(node, 'pre', [
+            h(node, 'code', props, [
+              u('raw', highlightedCode)
+            ])
+          ])
+        )
+
+        return h(
+          node,
+          'div',
+          { className: 'highlighted-with-highlightjs' },
+          childs
+        )
+      }
+    }
+  }
+}
+```
+
+Then the returned code will look like this:
+
+```html
+<div class="highlighted-with-highlightjs">
+  <pre class="language-<lang>" data-line="<line>" data-file-name="<file-name>">
+    <code>
+      ...
+    </code>
+  </pre>
+</div>
+```
+
+> You can learn more about `h`, `node` and `u` from [mdast-util-to-hast](https://github.com/syntax-tree/mdast-util-to-hast), [Universal Syntax Tree](https://github.com/syntax-tree/unist#node) and [unist-builder](https://github.com/syntax-tree/unist-builder)
+
+If you need to get the highlighter from promised-returned-package/function, you can do it this way:
+
+```js [nuxt.config.js]
+import { getHighlighter } from 'example-highlighter'
+
+export default {
+  content: {
+    markdown: {
+      async highlighter() {
+        const highlighter = await getHighlighter()
+
+        return (rawCode, lang) => {
+          return highlighter.highlight(rawCode, { language: lang })
+        }
+      }
+    }
+  }
+}
+```
+
+> You can head over to [Snippets - Custom Highlighter](/snippets#custom-highlighter) section to see more example.
+
+### `yaml`
+
+- Type: `Object`
+- Default: `{}`
+
+This module uses `js-yaml` to parse `.yaml`, `.yml` files. You can check here for [options](https://github.com/nodeca/js-yaml#api).
+
+Note that we force `json: true` option.
+
+
+### `xml`
+
+- Type: `Object`
+- Default: `{}`
+
+This module uses `xml2js` to parse `.xml` files. You can check here for [options](https://www.npmjs.com/package/xml2js#options).
+
+### `csv`
+
+- Type: `Object`
+- Default: `{}`
+
+This module uses `node-csvtojson` to parse csv files. You can check here for [options](https://github.com/Keyang/node-csvtojson#parameters).
+
+### `extendParser`
+
+- Type: `Object`
+- Default `{}`
+
+With this option you can define your own parsers for other file types. Also you can **overwrite** the default parser!
+
+To add your custom parser write a function that gets as an argument the content of the file and returns the extracted data.
+
+**Example**
+
+```js [nuxt.config.js]
+const parseTxt = file => file.split('\n').map(line => line.trim())
+
+// in Config:
+
+{
+  extendParser: {
+    '.txt': parseTxt
+  }
+}
+```
+
+### `editor`
+
+You can provide a custom editor for editing your markdown files in development. Set the `editor` option to a path to your editor component. The code of the default editor you can find [here](https://github.com/nuxt/content/blob/master/packages/content/templates/editor.vue).
+
+
+```js [nuxt.config.js]
+content: {
+  editor: '~/path/to/editor/component.vue'
+}
+```
+
+Your component should implement the following:
+
+1. `v-model` for getting the markdown code.
+2. prop `isEditing` is a boolean with the information if the editing is started and the component is shown. (this is optional)
+3. when finished editing your component has to emit `endEdit`
+
+
+You should be aware that you get the full markdown file content so this includes the front-matter. You can use `gray-matter` to split and join the markdown and the front-matter.
+
+### `useCache`
+
+- Type: `Boolean`
+- Default: `false`
+
+When `true`, the production server (`nuxt start`) will use cached version of the content (generated after running `nuxt build`) instead of parsing files. This improves app startup time, but makes app unaware of any content changes.
+
+## Defaults
+
+```js [nuxt.config.js]
+export default {
+  content: {
+    editor: '~/.nuxt/content/editor.vue',
+    apiPrefix: '_content',
+    dir: 'content',
+    fullTextSearchFields: ['title', 'description', 'slug', 'text'],
+    nestedProperties: [],
+    liveEdit: true,
+    useCache: false,
+    markdown: {
+      remarkPlugins: [
+        'remark-squeeze-paragraphs',
+        'remark-slug',
+        'remark-autolink-headings',
+        'remark-external-links',
+        'remark-footnotes'
+      ],
+      rehypePlugins: [
+        'rehype-minify-whitespace',
+        'rehype-sort-attribute-values',
+        'rehype-sort-attributes',
+        'rehype-raw'
+      ],
+      prism: {
+        theme: 'prismjs/themes/prism.css'
+      }
+    },
+    yaml: {},
+    csv: {},
+    xml: {},
+    extendParser: {}
+  }
+}
+```

--- a/docs/content-v1/pt/1.getting-started/7.advanced.md
+++ b/docs/content-v1/pt/1.getting-started/7.advanced.md
@@ -1,0 +1,253 @@
+---
+title: Advanced
+description: 'Learn advanced usage of @nuxt/content module.'
+---
+
+## Programmatic Usage
+
+`$content` is accessible from **@nuxt/content**.
+
+<alert type="warning">
+
+Beware that you can access it only **after the module has been loaded** by Nuxt. `require('@nuxt/content')` should happen in hooks or internal Nuxt methods.
+
+</alert>
+
+```js
+export default {
+  modules: [
+    '@nuxt/content'
+  ],
+  generate: {
+    async ready () {
+      const { $content } = require('@nuxt/content')
+      const files = await $content().only(['slug']).fetch()
+      console.log(files)
+    }
+  }
+}
+```
+
+### Static Site Generation
+
+Since Nuxt 2.14+, `nuxt generate` has a crawler feature integrated which will crawl all your links and generate your routes based on those links. Therefore you do not need to do anything in order for your dynamic routes to be crawled.
+
+Also, `nuxt generate` will automagically skip webpack build step when no code has been changed and use the previous build using cache. The content module integrates with this feature to ignore changes inside the `content/` folder. In other terms, when changing the content of your site and deploying, the build will be skipped.
+
+> Learn more in [this article](https://nuxtjs.org/blog/nuxt-static-improvements).
+
+When using Nuxt <= 2.12, you might need to specify the dynamic routes with [generate.routes](https://nuxtjs.org/api/configuration-generate/#routes)
+
+**Example**
+
+```js{}[nuxt.config.js]
+export default {
+  modules: [,
+    '@nuxt/content'
+  ],
+  generate: {
+    async routes () {
+      const { $content } = require('@nuxt/content')
+      const files = await $content({ deep: true }).only(['path']).fetch()
+
+      return files.map(file => file.path === '/index' ? '/' : file.path)
+    }
+  }
+}
+```
+
+<alert type="warning">
+
+Recommended to use Nuxt 2.14+ with `nuxt generate` because it's awesome!
+
+</alert>
+
+## Hooks
+
+The module adds some hooks you can use:
+
+### `content:file:beforeParse`
+
+Allows you to modify the contents of a file before it is handled by the parsers.
+
+Arguments:
+- `file`
+ - Type: `Object`
+ - Properties:
+   - path: `String`
+   - extension: `String` (ex: `.md`)
+   - data: `String`
+
+**Example**
+
+Changing all appearances of `react` to `vue` in all Markdown files:
+
+```js{}[nuxt.config.js]
+hooks: {
+  'content:file:beforeParse': (file) => {
+    if (file.extension !== '.md') return
+    file.data = file.data.replace(/react/g, 'vue')
+  }
+}
+```
+
+### `content:file:beforeInsert`
+
+Allows you to add data to a document before it is stored.
+
+Arguments:
+- `document`
+  - Type: `Object`
+  - Properties:
+    - See [writing content](/writing)
+- `database`
+  - Type: `Object`
+  - Properties:
+    - See [type definition](https://github.com/nuxt/content/blob/master/packages/content/types/database.d.ts)
+
+**Example**
+
+When building a blog, you can use `file:beforeInsert` to add `readingTime` to a document using [reading-time](https://github.com/ngryman/reading-time).
+
+> `text` is the body content of a markdown file before it is transformed to JSON AST. You can use at this point, but it is not returned by the API.
+
+```js{}[nuxt.config.js]
+export default {
+  modules: [,
+    '@nuxt/content'
+  ],
+  hooks: {
+    'content:file:beforeInsert': (document) => {
+      if (document.extension === '.md') {
+        const { time } = require('reading-time')(document.text)
+
+        document.readingTime = time
+      }
+    }
+  }
+}
+```
+
+**Example**
+
+You might want to parse markdown inside a `.json` file. You can access the parsers from the `database` object:
+
+```js{}[nuxt.config.js]
+export default {
+  modules: [,
+    '@nuxt/content'
+  ],
+  hooks: {
+    'content:file:beforeInsert': async (document, database) => {
+      if (document.extension === '.json' && document.body) {
+        const data = await database.markdown.toJSON(document.body)
+
+        Object.assign(document, data)
+      }
+    }
+  }
+}
+```
+
+### `content:options`
+
+Extend the content options, useful for modules that wants to read content options when normalized and apply updated to it.
+
+Arguments:
+- `options`
+  - Type: `Object`
+  - Properties:
+    - See [configuration](/configuration#properties)
+
+**Example**
+
+```js{}[nuxt.config.js]
+export default {
+  modules: [,
+    '@nuxt/content'
+  ],
+  hooks: {
+    'content:options': (options) => {
+      console.log('Content options:', options)
+    }
+  }
+}
+```
+
+## Handling Hot Reload
+
+<alert type="info">
+
+When you are in development mode, the module will automatically call `nuxtServerInit` store action (if defined) and `$nuxt.refresh()` to refresh the current page.
+
+</alert>
+
+In case you want to listen to the event to do something more, you can listen on `content:update` event on client-side using `$nuxt.$on('content:update')`:
+
+```js{}[plugins/update.client.js]
+export default function ({ store }) {
+  // Only in development
+  if (process.dev) {
+    window.onNuxtReady(($nuxt) => {
+      $nuxt.$on('content:update', ({ event, path }) => {
+        // Refresh the store categories
+        store.dispatch('fetchCategories')
+      })
+    })
+  }
+}
+```
+
+And then add your plugin in your `nuxt.config.js`:
+
+```js{}[nuxt.config.js]
+export default {
+  plugins: [
+    '@/plugins/update.client.js'
+  ]
+}
+```
+
+Now everytime you will update a file in your `content/` directory, it will also dispatch the `fetchCategories` method.
+This documentation uses it actually. You can learn more by looking at [plugins/init.js](https://github.com/nuxt/content/blob/master/docs/plugins/init.js).
+
+## API Endpoint
+
+This module exposes an API endpoint in development so you can easily see the JSON of each directory or file, it is available on [http://localhost:3000/_content/](http://localhost:3000/_content/). The prefix is `_content` by default and can be configured with the [apiPrefix](/configuration#apiprefix) property.
+
+**Example**
+
+```bash
+-| content/
+---| articles/
+------| hello-world.md
+---| index.md
+---| settings.json
+```
+
+Will expose on `localhost:3000`:
+- `/_content/articles`: list the files in `content/articles/`
+- `/_content/articles/hello-world`: get `hello-world.md` as JSON
+- `/_content/index`: get `index.md` as JSON
+- `/_content/settings`: get `settings.json` as JSON
+- `/_content`: list `index` and `settings`
+
+The endpoint is accessible on `GET` and `POST` request, so you can use query params: [http://localhost:3000/_content/articles?only=title&only=description&limit=10](http://localhost:3000/_content/articles?only=title&only=description&limit=10).
+
+Since **v1.4.0**, this endpoint also supports `where` in query params:
+
+- All the keys that don't belong to any of the default ones will be applied to `where`
+
+`http://localhost:3000/_content/articles?author=...`
+
+- You can use `$operators` with `_`:
+
+`http://localhost:3000/_content/articles?author_regex=...`
+
+> This module uses LokiJS under the hood. You can check here for [query examples](https://github.com/techfort/LokiJS/wiki/Query-Examples#find-queries).
+
+- You can use [nested properties](/configuration#nestedproperties):
+
+`http://localhost:3000/_content/products?categories.slug_contains=top`
+
+> You can learn more about that endpoint in [lib/middleware.js](https://github.com/nuxt/content/blob/main/packages/content/lib/middleware.js).

--- a/docs/content-v1/pt/1.getting-started/_dir.yml
+++ b/docs/content-v1/pt/1.getting-started/_dir.yml
@@ -1,0 +1,1 @@
+title: 'Getting Started'

--- a/docs/content-v1/pt/2.examples/1.basic.md
+++ b/docs/content-v1/pt/2.examples/1.basic.md
@@ -1,0 +1,8 @@
+---
+title: Basic Usage
+description: 'Live example of basic usage of Nuxt Content on CodeSandbox.'
+toc: false
+---
+
+::sandbox{src="https://codesandbox.io/embed/nuxt-content-playground-l164h?hidenavigation=1&theme=dark"}
+::

--- a/docs/content-v1/pt/2.examples/2.tailwindcss-typography.md
+++ b/docs/content-v1/pt/2.examples/2.tailwindcss-typography.md
@@ -1,0 +1,8 @@
+---
+title: TailwindCSS
+description: 'Live example of Nuxt Content with TailwindCSS Typography plugin on CodeSandbox.'
+toc: false
+---
+
+::sandbox{src="https://codesandbox.io/embed/nuxt-content-tailwindcss-typography-xq04z?hidenavigation=1&theme=dark"}
+::

--- a/docs/content-v1/pt/2.examples/3.docs-theme.md
+++ b/docs/content-v1/pt/2.examples/3.docs-theme.md
@@ -1,0 +1,8 @@
+---
+title: Docs Theme
+description: 'Live example of Nuxt Content docs theme on CodeSandbox.'
+toc: false
+---
+
+::sandbox{src="https://codesandbox.io/embed/nuxt-content-docs-theme-playground-inwxb?hidenavigation=1&theme=dark"}
+::

--- a/docs/content-v1/pt/3.community/1.snippets.md
+++ b/docs/content-v1/pt/3.community/1.snippets.md
@@ -145,7 +145,7 @@ even when the current page is showing the higer-positioned document.
 
 </alert>
 
-> Check out the [surround documentation](/fetching#surroundslug-options)
+> Check out the [surround documentation](/fetching#surroundslugorpath-options)
 
 ### Case-Insensitive Sorting
 

--- a/docs/content-v1/pt/3.community/1.snippets.md
+++ b/docs/content-v1/pt/3.community/1.snippets.md
@@ -1,0 +1,435 @@
+---
+title: Snippets
+description: 'Learn how to implement @nuxt/content into your app with these code snippets.'
+category: Community
+subtitle: 'Check out these code snippets that can be copied directly into your application.'
+version: 1.1
+---
+
+## Usage
+
+### asyncData
+
+```js
+export default {
+  async asyncData({ $content, params }) {
+    const article = await $content('articles', params.slug).fetch()
+
+    return {
+      article
+    }
+  }
+}
+```
+
+### head
+
+Add dynamic metas based on title and description defined in the [front-matter](https://content.nuxtjs.org/writing#front-matter):
+
+```js
+export default {
+  async asyncData({ $content, params }) {
+    const article = await $content('articles', params.slug).fetch()
+
+    return {
+      article
+    }
+  },
+  head() {
+    return {
+      title: this.article.title,
+      meta: [
+        { hid: 'description', name: 'description', content: this.article.description },
+        // Open Graph
+        { hid: 'og:title', property: 'og:title', content: this.article.title },
+        { hid: 'og:description', property: 'og:description', content: this.article.description },
+        // Twitter Card
+        { hid: 'twitter:title', name: 'twitter:title', content: this.article.title },
+        { hid: 'twitter:description', name: 'twitter:description', content: this.article.description }
+      ]
+    }
+  }
+}
+```
+
+## Features
+
+### Search
+
+Add a search input component by using watch:
+
+```vue
+<template>
+  <div>
+    <input v-model="query" type="search" autocomplete="off" />
+
+    <ul v-if="articles.length">
+      <li v-for="article of articles" :key="article.slug">
+        <NuxtLink :to="{ name: 'blog-slug', params: { slug: article.slug } }">{{ article.title }}</NuxtLink>
+      </li>
+    </ul>
+  </div>
+</template>
+
+<script>
+export default {
+  data () {
+    return {
+      query: '',
+      articles: []
+    }
+  },
+  watch: {
+    async query (query) {
+      if (!query) {
+        this.articles = []
+        return
+      }
+
+      this.articles = await this.$content('articles')
+        .only(['title', 'slug'])
+        .sortBy('createdAt', 'asc')
+        .limit(12)
+        .search(query)
+        .fetch()
+    }
+  }
+}
+</script>
+```
+
+> Check out the [search documentation](/fetching#searchfield-value)
+
+### Prev and Next
+
+Add previous and next links using the `surround` method:
+
+```vue
+<template>
+  <div>
+    <NuxtLink v-if="prev" :to="{ name: 'blog-slug', params: { slug: prev.slug } }">
+      {{ prev.title }}
+    </NuxtLink>
+
+    <NuxtLink v-if="next" :to="{ name: 'blog-slug', params: { slug: next.slug } }">
+      {{ next.title }}
+    </NuxtLink>
+  </div>
+</template>
+
+<script>
+export default {
+  async asyncData({ $content, params }) {
+    const [prev, next] = await $content('articles')
+      .only(['title', 'slug'])
+      .sortBy('createdAt', 'asc')
+      .surround(params.slug)
+      .fetch()
+
+    return {
+      prev,
+      next
+    }
+  }
+}
+</script>
+```
+
+<alert type="info">
+
+If more than one document has the same slug, you should set `path` as the first argument of the `surround` method, instead of `slug`.
+This is because Nuxt Content finds previous and next documents based on the one that matched first.
+
+For example, if you sort documents according to `position`, the lower-positioned document will be always used for calculation,
+even when the current page is showing the higer-positioned document.
+
+</alert>
+
+> Check out the [surround documentation](/fetching#surroundslug-options)
+
+### Case-Insensitive Sorting
+
+It is needed to work around Nuxt Content's case-sensitive sorting, to add extra properties to documents, whose value is lower-cased.
+
+```js [nuxt.config.js]
+export default {
+  hooks: {
+    'content:file:beforeInsert': (document) => {
+      if (document.extension === '.md') {
+        Object.entries(document).forEach(([key, value]) => {
+          const _key = `case_insensitive__${key}`; // prefix is arbitrary
+
+          if (!document[_key] && typeof value === 'string') {
+            document[_key] = value.toLocaleLowerCase();
+          }
+        });
+      }
+    }
+  }
+};
+```
+
+Then, call `sortBy` method with the extra prop's key by which to sort.
+
+```ts
+export default {
+  async asyncData({ $content, params }) {
+    const articles = await $content('articles', params.slug)
+      .sortBy('case_insensitive__title', 'asc') // Set prefixed prop
+      .fetch()
+
+    return {
+      articles
+    }
+  }
+}
+```
+
+> Check out the [`sortBy` documentation](/fetching#sortbykey-direction)
+
+### Table of contents
+
+Add a table of contents by looping over our array of toc and use the `id` to link to it and the `text` to show the title. We can use the `depth` to style the titles differently:
+
+```vue
+<template>
+  <ul>
+    <li
+      v-for="link of article.toc"
+      :key="link.id"
+      :class="{ 'toc2': link.depth === 2, 'toc3': link.depth === 3 }"
+    >
+      <NuxtLink :to="`#${link.id}`">{{ link.text }}</NuxtLink>
+    </li>
+  </ul>
+</template>
+
+<script>
+export default {
+  async asyncData({ $content, params }) {
+    const article = await $content('articles', params.slug)
+      .fetch()
+
+    return {
+      article
+    }
+  }
+}
+</script>
+```
+
+> Check out the [Table of contents documentation](/writing#table-of-contents)
+
+### Dynamic routing
+
+Let's say you want to create an app with routes following the `content/` file structure. You can do so by creating a `pages/_.vue` component:
+
+```vue[pages/_.vue]
+<script>
+export default {
+  async asyncData ({ $content, app, params, error }) {
+    const path = `/${params.pathMatch || 'index'}`
+    const [article] = await $content({ deep: true }).where({ path }).fetch()
+
+    if (!article) {
+      return error({ statusCode: 404, message: 'Article not found' })
+    }
+
+    return {
+      article
+    }
+  }
+}
+</script>
+```
+
+This way, if you go the `/themes/docs` route, it will display the `content/themes/docs.md` file. If you need an index page for your directories, you need to create a file with the same name as the directory:
+
+```bash
+content/
+  themes/
+    docs.md
+  themes.md
+```
+
+<alert type="warning">
+
+Don't forget to prefix your calls with the current locale if you're using `nuxt-i18n`.
+
+</alert>
+
+### Custom Highlighter
+
+#### Highlight.js
+
+```js{}[nuxt.config.js]
+import highlightjs from 'highlight.js'
+
+const wrap = (code, lang) => `<pre><code class="hljs ${lang}">${code}</code></pre>`
+
+export default {
+  // Complete themes: https://github.com/highlightjs/highlight.js/tree/master/src/styles
+  css: ['highlight.js/styles/nord.css'],
+
+  modules: ['@nuxt/content'],
+
+  content: {
+    markdown: {
+      highlighter(rawCode, lang) {
+        if (!lang) {
+          return wrap(highlightjs.highlightAuto(rawCode).value, lang)
+        }
+        return wrap(highlightjs.highlight(rawCode, { language: lang }).value, lang)
+      }
+    }
+  }
+}
+```
+
+#### Shiki
+
+[Shiki](https://github.com/shikijs/shiki) is syntax highlighter that uses TexMate grammar and colors the tokens with VS Code themes. It will generate HTML that looks like exactly your code in VS Code.
+
+You don't need to add custom styling, because Shiki will inline it in the HTML.
+
+```js{}[nuxt.config.js]
+import shiki from 'shiki'
+
+export default {
+  modules: ['@nuxt/content'],
+
+  content: {
+    markdown: {
+      async highlighter() {
+        const highlighter = await shiki.getHighlighter({
+          // Complete themes: https://github.com/shikijs/shiki/tree/master/packages/themes
+          theme: 'nord'
+        })
+        return (rawCode, lang) => {
+          return highlighter.codeToHtml(rawCode, lang)
+        }
+      }
+    }
+  }
+}
+```
+
+#### Shiki Twoslash
+
+[Twoslash](https://github.com/microsoft/TypeScript-Website/tree/v2/packages/ts-twoslasher) is a markup format for TypeScript code. Internally, Twoslash uses the TypeScript compiler to generate rich highlight info.
+
+To get a better idea of how Twoslash works, you can go over to the [Official TypeScript Documentation](https://www.typescriptlang.org/docs/handbook/typescript-in-5-minutes-func.html#type-aliases) and hover over some code examples there.
+
+You can achieve the same result by using [Shiki Twoslash](https://github.com/microsoft/TypeScript-Website/tree/v2/packages/shiki-twoslash). This package is also the one that powers the Official TypeScript Documentation.
+
+```js{}[nuxt.config.js]
+import {
+  createShikiHighlighter,
+  runTwoSlash,
+  renderCodeToHTML
+} from 'shiki-twoslash'
+
+export default {
+  modules: ['@nuxt/content'],
+
+  content: {
+    markdown: {
+      async highlighter() {
+        const highlighter = await createShikiHighlighter({
+          // Complete themes: https://github.com/shikijs/shiki/tree/master/packages/themes
+          theme: 'nord'
+        })
+        return (rawCode, lang) => {
+          const twoslashResults = runTwoSlash(rawCode, lang)
+          return renderCodeToHTML(
+            twoslashResults.code,
+            lang,
+            ['twoslash'],
+            {},
+            highlighter,
+            twoslashResults
+          )
+        }
+      }
+    }
+  }
+}
+```
+
+### Remark Plugin
+
+Nuxt Content uses [remark](https://github.com/remarkjs/remark) under the hood to process markdown documents. Creating remark plugins is a way to manipulate documents and add new features.
+
+#### List all contributors
+
+Let's say you want to list all contributors of the project in a document. You can create a plugin that fetches all contributors and injects them into the document data.
+
+- Create the plugin. This plugin fetches the contributors if `fetchContributors` is set to `true`
+
+```js [~~/plugins/contributors.js]
+const fetch = require('node-fetch')
+
+module.exports = function () {
+  return async (tree, { data }) => {
+    if (data.fetchContributors) {
+      const contributors = await fetch(
+        'https://api.github.com/repos/nuxt/content/contributors'
+      ).then(res => res.json())
+      .then(res => res.map(({ login }) => login))
+
+      data.$contributors = [...new Set(contributors)]
+    }
+    return tree
+  }
+}
+```
+
+- Register plugin in Nuxt config
+
+```js{}[nuxt.config.js]
+export default {
+  contents: {
+    markdown: {
+      remarkPlugins: [
+        '~~/plugins/contributors.js'
+      ]
+    }
+  }
+}
+```
+
+- Create a simple component to show contributors
+
+```vue{}[~~/components/List.vue]
+<template>
+  <ul>
+    <li v-for="(item, i) in items" :key="i">
+      {{ item }}
+    </li>
+  </ul>
+</template>
+
+<script>
+export default {
+  props: {
+    items: {
+      type: Array,
+      default: () => []
+    }
+  }
+}
+```
+
+- Finally use the components and mark the document to fetch the contributors
+
+```md{}[document.md]
+---
+title: Nuxt Content
+fetchContributors: true
+---
+
+## Contributors
+
+<list :items="$contributors"></list>
+
+```

--- a/docs/content-v1/pt/3.community/2.integrations.md
+++ b/docs/content-v1/pt/3.community/2.integrations.md
@@ -1,0 +1,285 @@
+---
+title: Integrations
+description: 'Learn how to use @nuxt/content with other modules.'
+category: Community
+---
+
+## @nuxtjs/feed
+
+In the case of articles, the content can be used to generate news feeds
+using [@nuxtjs/feed](https://github.com/nuxt-community/feed-module) module.
+
+<alert type="info">
+
+To use `$content` inside the `feed` option, you need to add `@nuxt/content` before `@nuxtjs/feed` in the `modules` property. 
+
+</alert>
+
+You can access your feed on: `baseUrl + baseLinkFeedArticles + file`
+
+For RSS: ```https://mywebsite.com/feed/articles/rss.xml```
+
+For JSON: ```https://mywebsite.com/feed/articles/feed.json```
+
+**Example 1**
+
+```js
+export default {
+  modules: [
+    '@nuxt/content',
+    '@nuxtjs/feed'
+  ],
+
+  feed () {
+    const baseUrlArticles = 'https://mywebsite.com/articles'
+    const baseLinkFeedArticles = '/feed/articles'
+    const feedFormats = {
+      rss: { type: 'rss2', file: 'rss.xml' },
+      json: { type: 'json1', file: 'feed.json' },
+    }
+    const { $content } = require('@nuxt/content')
+
+    const createFeedArticles = async function (feed) {
+      feed.options = {
+        title: 'My Blog',
+        description: 'I write about technology',
+        link: baseUrlArticles,
+      }
+      const articles = await $content('articles').fetch()
+
+      articles.forEach((article) => {
+        const url = `${baseUrlArticles}/${article.slug}`
+
+        feed.addItem({
+          title: article.title,
+          id: url,
+          link: url,
+          date: article.published,
+          description: article.summary,
+          content: article.summary,
+          author: article.authors,
+        })
+      })
+    }
+
+    return Object.values(feedFormats).map(({ file, type }) => ({
+      path: `${baseLinkFeedArticles}/${file}`,
+      type: type,
+      create: createFeedArticles,
+    }))
+  }
+}
+```
+
+The above approach works well for some use cases. However, if you use `npm run generate` then this approach will produce an error.
+
+Or, if you want to include the body of the article as content (including any content from components if you mix your Vue components and your markdown) then you'll need to approach this differently.
+
+One possible way to do this uses the [@nuxtjs/feed](https://github.com/nuxt-community/feed-module) documented approach and will work well with `npm run generate` and will use the existing Nuxt process to include the content. Here's how to do it.
+
+First, use the array based approach for declaring your feeds as shown in the @nuxtjs/feed documentation. The feed array consists of objects with 5 possible values.
+
+1. The `path` which is the path from your domain to the feed document.
+2. A function that will generate the feed content.
+3. The `cacheTime` which as the name suggests determines when the feed will be refreshed.
+4. The `type` which determines which type of rss feed you intend to output.
+5. The `data` which is supplied as arguments to the function (the args property in the example below)
+
+```js
+modules: [    
+    '@nuxt/content',
+    '@nuxtjs/feed'    
+  ],
+
+  feed: [
+    {
+      path: '/feed.xml',
+      async create(feed, args) => {  
+        // create the feed
+      },
+      cacheTime: 1000 * 60 * 15,
+      type: 'rss2',
+      data: [ 'some', 'info' ]
+    },
+    {
+      path: '/feed.json',
+      async create(feed, args) => {  
+        // create the feed
+      },
+      cacheTime: 1000 * 60 * 15,
+      type: 'json1',
+      data: [ 'other', 'info' ]
+    }
+  ],
+```
+
+You can make the best use of the nuxt/content api by declaring your create function separately and then supplying it to the feed array object. The create function can be declared at the top of the nuxt.config.js file, or separately in another directory and exported. The create function runs _after_ the Nuxt process has compiled the markdown and Vue components into HTML. This allows us to pull in that content and supply it to the feed. 
+
+**Example 2**
+
+```js
+// this example declares the function at the top of the nuxt.config.js file
+const fs = require('fs').promises;
+const path = require('path');
+
+let posts = [];
+
+const constructFeedItem = async (post, dir, hostname) => {  
+  //note the path used here, we are using a dummy page with an empty layout in order to not send that data along with our other content
+  const filePath = path.join(__dirname, `dist/rss/${post.slug}/index.html`); 
+  const content = await fs.readFile(filePath, 'utf8');
+  const url = `${hostname}/${dir}/${post.slug}`;
+  return {
+    title: post.title,
+    id: url,
+    link: url,
+    description: post.description,
+    content: content
+  }
+} 
+
+const create = async (feed, args) => {
+  const [filePath, ext] = args;  
+  const hostname = process.NODE_ENV === 'production' ? 'https://my-production-domain.com' : 'http://localhost:3000';
+  feed.options = {
+    title: "My Blog",
+    description: "Blog Stuff!",
+    link: `${hostname}/feed.${ext}`
+  }
+  const { $content } = require('@nuxt/content')
+  if (posts === null || posts.length === 0)
+    posts = await $content(filePath).fetch();
+
+  for (const post of posts) {
+    const feedItem = await constructFeedItem(post, filePath, hostname);
+    feed.addItem(feedItem);
+  }
+  return feed;
+}
+
+export default {
+...
+  modules: [    
+    '@nuxt/content',
+    '@nuxtjs/feed'    
+  ],
+  feed: [
+    {
+      path: '/feed.xml',
+      create,
+      cacheTime: 1000 * 60 * 15,
+      type: 'rss2',
+      data: [ 'blog', 'xml' ]
+    },
+  ],  
+...
+}
+```
+
+There are at least two drawbacks to this approach:
+
+1. Since you're reading in the entire generated page you may pick up undesired content such as from the header and footer. One way to deal with this is to create a dummy page using an empty layout so that only the content you want included in the rss feed is used.
+2. rss2 and XML work well because the HTML is automatically encoded. However, json1 and json may need additional work so that the content can be transmitted.
+
+Remember also that if you are not using mixed content in your markdown (so if you are using markdown only), then it is far easier to only include the markdown. You can retrieve the markdown using this hook in your nuxt.config.js:
+
+**Example 3**
+
+```js
+export default {
+...
+  hooks: {
+    'content:file:beforeInsert': (document) => {
+      if (document.extension === '.md') {      
+        document.bodyPlainText = document.text;
+      }
+    },
+  },
+...
+}
+```
+
+And then in your create function: 
+
+```js
+
+const constructFeedItem = (post, dir, hostname) => {  
+  const url = `${hostname}/${dir}/${post.slug}`;
+  return {
+    title: post.title,
+    id: url,
+    link: url,
+    description: post.description,
+    content: post.bodyPlainText
+  }
+} 
+
+const create = async (feed, args) => {
+  const [filePath, ext] = args;  
+  const hostname = process.NODE_ENV === 'production' ? 'https://my-production-domain.com' : 'http://localhost:3000';
+  feed.options = {
+    title: "My Blog",
+    description: "Blog Stuff!",
+    link: `${hostname}/feed.${ext}`
+  }
+  const { $content } = require('@nuxt/content')
+  if (posts === null || posts.length === 0)
+    posts = await $content(filePath).fetch();
+
+  for (const post of posts) {
+    const feedItem = await constructFeedItem(post, filePath, hostname);
+    feed.addItem(feedItem);
+  }
+  return feed;
+}
+```
+Retrieving just the markdown works great if you're using the feed to integrate with [dev.to](https://dev.to/) or [medium](https://medium.com/) since both of these sites use markdown in their editors.
+
+
+## @nuxtjs/sitemap
+
+You may want to generate a sitemap that includes links to all of your posts. You can do this similarly to how you generated the feed.
+
+**Example 1**
+
+The sitemap module should always be declared last so that routes created by other modules can be included. After declaring the module you must configure the sitemap by adding the sitemap configuration object to the nuxt.config.js. You must supply the hostname, and you can optionally include any routes that are dynamically generated from nuxt content.
+The routes property accepts an async function that returns an array of URLs.
+
+```js
+const createSitemapRoutes = async () => {
+  let routes = [];
+  const { $content } = require('@nuxt/content')
+  if (posts === null || posts.length === 0)
+    posts = await $content('blog').fetch();
+  for (const post of posts) {
+    routes.push(`blog/${post.slug}`);
+  }
+  return routes;
+}
+
+export default {
+...
+  modules: [
+    '@nuxt/content',
+    '@nuxtjs/sitemap'
+  ],
+  sitemap: {
+    hostname: 'https://my-domain-name.com',
+    gzip: true,
+    routes: createSitemapRoutes
+  },
+...
+}
+```
+
+## Forestry CMS
+
+You can integrate Nuxt Content with [Forestry](https://forestry.io) in a few steps.
+
+<alert>
+
+We recommend to take a look at this tutorial made by [Pascal Cauhépé](https://twitter.com/eQRoeil)
+
+👉 &nbsp;https://nuxt-content-and-forestry.netlify.app
+
+</alert>

--- a/docs/content-v1/pt/_dir.yml
+++ b/docs/content-v1/pt/_dir.yml
@@ -1,0 +1,3 @@
+aside:
+  root: /v1
+  level: 0

--- a/docs/content-v1/pt/_dir.yml
+++ b/docs/content-v1/pt/_dir.yml
@@ -1,3 +1,3 @@
 aside:
-  root: /v1
+  root: /pt/v1
   level: 0

--- a/docs/nuxt.config.ts
+++ b/docs/nuxt.config.ts
@@ -47,6 +47,12 @@ export default defineNuxtConfig({
         prefix: '/ru/v1',
         driver: 'fs',
         base: resolve(__dirname, 'content-v1/ru')
+      },
+      {
+        name: 'v1-pt',
+        prefix: '/pt/v1',
+        driver: 'fs',
+        base: resolve(__dirname, 'content-v1/pt')
       }
     ],
     highlight: {

--- a/docs/theme.config.ts
+++ b/docs/theme.config.ts
@@ -26,7 +26,8 @@ export default defineTheme({
       '/content-v1',
       '/fr',
       '/ja',
-      '/ru'
+      '/ru',
+      '/pt'
     ]
   },
   header: {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)

### 📚 Description

In this pull request, I start to do the modifications in the
repository to let it ready to receive the translation of the
documentation of the first version of the application to
Portuguese.

I believe that I am already known in the NuxtJS community
because I am the one behind the translation of the [NuxtJS](https://nuxtjs.org/pt/)
documentation and website to Portuguese, and today I start
the translation of the documentation of this important Nuxt Module.

@pi0 @Atinux @alexchopin @manniL 