### PR TITLE
feat(config): add toggle for `prefetch` links

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -182,7 +182,13 @@ export interface ModuleOptions {
     }
     layoutFallbacks: string[]
     injectPage: boolean
-  }
+  },
+  /**
+   * Toggle meta `prefetch` tags being added to the head when making fetch requests.
+   *
+   * @default true
+   */
+  prefetch: boolean
 }
 
 interface ContentContext extends ModuleOptions {
@@ -227,7 +233,8 @@ export default defineNuxtModule<ModuleOptions>({
     navigation: {
       fields: []
     },
-    documentDriven: false
+    documentDriven: false,
+    prefetch: true
   },
   async setup (options, nuxt) {
     const { resolve } = createResolver(import.meta.url)

--- a/src/runtime/composables/navigation.ts
+++ b/src/runtime/composables/navigation.ts
@@ -1,8 +1,8 @@
 import { hash } from 'ohash'
-import { useHead, useCookie } from '#app'
+import { useCookie } from '#app'
 import type { NavItem, QueryBuilder, QueryBuilderParams } from '../types'
 import { jsonStringify } from '../utils/json'
-import { withContentBase } from './utils'
+import { withContentBase, useContentPrefetch } from './utils'
 
 export const fetchContentNavigation = (queryBuilder?: QueryBuilder | QueryBuilderParams): Promise<Array<NavItem>> => {
   let params = queryBuilder
@@ -12,14 +12,7 @@ export const fetchContentNavigation = (queryBuilder?: QueryBuilder | QueryBuilde
 
   const apiPath = withContentBase(params ? `/navigation/${hash(params)}.json` : '/navigation')
 
-  // Add `prefetch` to `<head>` in production
-  if (!process.dev && process.server) {
-    useHead({
-      link: [
-        { rel: 'prefetch', href: apiPath }
-      ]
-    })
-  }
+  useContentPrefetch(apiPath)
 
   return $fetch(apiPath, {
     method: 'GET',

--- a/src/runtime/composables/query.ts
+++ b/src/runtime/composables/query.ts
@@ -1,10 +1,10 @@
 import { joinURL, withLeadingSlash, withoutTrailingSlash } from 'ufo'
 import { hash } from 'ohash'
-import { useHead, useCookie } from '#app'
+import { useCookie } from '#app'
 import { createQuery } from '../query/query'
 import type { ParsedContent, QueryBuilder, QueryBuilderParams } from '../types'
 import { jsonStringify } from '../utils/json'
-import { withContentBase } from './utils'
+import { withContentBase, useContentPrefetch } from './utils'
 
 /**
  * Query fetcher
@@ -26,14 +26,7 @@ export const createQueryFetch = <T = ParsedContent>(path?: string) => (query: Qu
 
   const apiPath = withContentBase(process.dev ? '/query' : `/query/${hash(params)}.json`)
 
-  // Prefetch the query
-  if (!process.dev && process.server) {
-    useHead({
-      link: [
-        { rel: 'prefetch', href: apiPath }
-      ]
-    })
-  }
+  useContentPrefetch(apiPath)
 
   return $fetch(apiPath as any, {
     method: 'GET',

--- a/src/runtime/composables/utils.ts
+++ b/src/runtime/composables/utils.ts
@@ -1,8 +1,20 @@
 import { withBase } from 'ufo'
-import { useRuntimeConfig } from '#app'
+import { useHead, useRuntimeConfig } from '#app'
 import { unwrap, flatUnwrap } from '../markdown-parser/utils/node'
 
 export const withContentBase = (url: string) => withBase(url, '/api/' + useRuntimeConfig().public.content.base)
+
+export const useContentPrefetch = (href: string) => {
+  const { prefetch } = useRuntimeConfig().content
+  // Add `prefetch` to `<head>` in production
+  if (!process.dev && process.server && prefetch) {
+    useHead({
+      link: [
+        { rel: 'prefetch', href }
+      ]
+    })
+  }
+}
 
 export const useUnwrap = () => ({
   unwrap,

--- a/test/advanced.test.ts
+++ b/test/advanced.test.ts
@@ -1,0 +1,21 @@
+import { fileURLToPath } from 'url'
+import { test, describe, expect } from 'vitest'
+import { setup, $fetch } from '@nuxt/test-utils'
+
+describe('Advanced usage', async () => {
+  await setup({
+    rootDir: fileURLToPath(new URL('./fixtures/basic', import.meta.url)),
+    server: true,
+    dev: false,
+    nuxtConfig: {
+      content: {
+        prefetch: false
+      }
+    }
+  })
+
+  test('Disable query prefetching', async () => {
+    const html = await $fetch('/')
+    expect(html).not.toContain('<link rel="prefetch" href="/api/_content/query')
+  })
+})

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -124,6 +124,11 @@ describe('Basic usage', async () => {
     expect(spyConsoleWarn).toHaveBeenCalledWith('Ignoring [content:with-\'invalid\'-char.md]. File name should not contain any of the following characters: \', ", ?, #, /')
   })
 
+  test('Query preload tag is added', async () => {
+    const html = await $fetch('/')
+    expect(html).contains('<link rel="prefetch" href="/api/_content/query/')
+  })
+
   testComponents()
 
   testContentQuery()


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

Related: https://github.com/danielroe/nuxt-zero-js/pull/8

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

When using [nuxt-zero-js](https://github.com/danielroe/nuxt-zero-js/) or if you've setup the content components to be server rendered only, you'll be in a situation where you don't need the API data pre-fetched.

Currently, there is no way to remove the pre-fetches without regex matching on the html output.

I've intentionally avoided adding doc as this is a config option that either advanced users or module authors would take advantage of.



### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
