### PR TITLE
docs(document-driven): fix typo

### DIFF
--- a/docs/content/3.guide/1.writing/7.document-driven.md
+++ b/docs/content/3.guide/1.writing/7.document-driven.md
@@ -111,7 +111,7 @@ This option will search for a `theme` key in `globals`, then search for a `layou
 
 ## Global variables
 
-Queries are been made from a [route middlewares](https://v3.nuxtjs.org/guide/directory-structure/middleware#middleware-directory) and are resolved before your page renders.
+Queries are being made from a [route middleware](https://v3.nuxtjs.org/guide/directory-structure/middleware#middleware-directory) and are resolved before your page renders.
 
 This gives access to the [`useContent()`](/api/composables/use-document-driven) composable **anywhere in your app** with the following variables:
 - `page`

--- a/docs/content/3.guide/1.writing/7.document-driven.md
+++ b/docs/content/3.guide/1.writing/7.document-driven.md
@@ -111,7 +111,7 @@ This option will search for a `theme` key in `globals`, then search for a `layou
 
 ## Global variables
 
-Queries are be made from a [route middlewares](https://v3.nuxtjs.org/guide/directory-structure/middleware#middleware-directory) and are resolved before your page renders.
+Queries are been made from a [route middlewares](https://v3.nuxtjs.org/guide/directory-structure/middleware#middleware-directory) and are resolved before your page renders.
 
 This gives access to the [`useContent()`](/api/composables/use-document-driven) composable **anywhere in your app** with the following variables:
 - `page`


### PR DESCRIPTION
Fixed typo in line 114 `Queries are be made` to `Queries are been made`

