### PR TITLE
docs: broken link on Markdown API page

### DIFF
--- a/docs/content/4.api/1.components/5.markdown.md
+++ b/docs/content/4.api/1.components/5.markdown.md
@@ -3,7 +3,7 @@
 The fastest way to inject Markdown into your Vue components.
 
 ::alert{type=danger}
-**NOTE**: As of Content@2.1.0 this component is deprecated and replaced by [`<ContentSlot>`](./content-slot).
+**NOTE**: As of Content@2.1.0 this component is deprecated and replaced by [`<ContentSlot>`](../content-slot).
 ::
 
 The `<Markdown>`{lang=html} component makes it easier to use Markdown syntax in your Vue components.

--- a/docs/content/4.api/1.components/5.markdown.md
+++ b/docs/content/4.api/1.components/5.markdown.md
@@ -3,7 +3,7 @@
 The fastest way to inject Markdown into your Vue components.
 
 ::alert{type=danger}
-**NOTE**: As of Content@2.1.0 this component is deprecated and replaced by [`<ContentSlot>`](../content-slot).
+**NOTE**: As of Content@2.1.0 this component is deprecated and replaced by [`<ContentSlot>`](/api/components/content-slot).
 ::
 
 The `<Markdown>`{lang=html} component makes it easier to use Markdown syntax in your Vue components.


### PR DESCRIPTION
The ContentSlot links to a broken link.

Just curious to jump in the parent folder (..) to get the correct link.

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue
No issue raised.

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Adding a dot to the link to get the correct link.
https://deploy-preview-1588--nuxt-content.netlify.app/api/components/markdown