### PR TITLE
docs(composables): fix close tag ContentRenderer

### DIFF
--- a/docs/content/4.api/2.composables/4.use-document-driven.md
+++ b/docs/content/4.api/2.composables/4.use-document-driven.md
@@ -40,7 +40,7 @@ const { page } = useContent()
 </script>
 
 <template>
-  <ContentRenderer :key="page._id" :value="page">
+  <ContentRenderer :key="page._id" :value="page" />
 </template>
 ```
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

By copying the following code from the documentation

```vue
<script setup lang="ts">
const { page } = useContent()
</script>

<template>
  <ContentRenderer :key="page._id" :value="page">
</template>
```

It was giving me an error, it turns out that the ContentRenderer component did not have the closing tag, so I proceeded to update it in the documentation

