### PR TITLE
fix(`<ContentDoc>`): render blink in SSG

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -570,14 +570,14 @@ export default defineNuxtModule<ModuleOptions>({
         // Disable cache in dev mode
         integrity: nuxt.options.dev ? undefined : Date.now()
       },
-      navigation: contentContext.navigation,
+      navigation: contentContext.navigation as any,
       base: options.base,
       // Tags will use in markdown renderer for component replacement
       tags: contentContext.markdown.tags as any,
       highlight: options.highlight as any,
       wsUrl: '',
       // Document-driven configuration
-      documentDriven: options.documentDriven as ModuleOptions['documentDriven'],
+      documentDriven: options.documentDriven as any,
       // Anchor link generation config
       anchorLinks: options.markdown.anchorLinks
     })

--- a/src/runtime/components/ContentDoc.vue
+++ b/src/runtime/components/ContentDoc.vue
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { PropType, defineComponent, h, useSlots } from 'vue'
+import { withTrailingSlash } from 'ufo'
 import type { QueryBuilderParams } from '../types'
 import ContentRenderer from './ContentRenderer'
 import ContentQuery from './ContentQuery'
@@ -42,7 +43,7 @@ export default defineComponent({
     path: {
       type: String,
       required: false,
-      default: () => useRoute().path
+      default: undefined
     },
 
     /**
@@ -78,7 +79,11 @@ export default defineComponent({
     const { tag, excerpt, path, query, head } = ctx
 
     // Merge local `path` props and apply `findOne` query default.
-    const contentQueryProps = Object.assign(query || {}, { path, find: 'one' })
+    const contentQueryProps = {
+      ...query || {},
+      path: path || query?.path || withTrailingSlash(useRoute().path),
+      find: 'one'
+    }
 
     const emptyNode = (slot: string, data: any) => h('pre', null, JSON.stringify({ message: 'You should use slots with <ContentDoc>', slot, data }, null, 2))
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue
resolves nuxt/content#1583

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
In SSG on client hydration `useRoute().path` contains additional slash at the end of path which cause cache miss in `asyncData`.
`ContentDoc` is responsible for fetching single content, so we can safely remove this trailing slash.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
