### PR TITLE
fix(anchorLinks): add useRuntimeConfig imports

### DIFF
--- a/src/runtime/components/Prose/ProseH1.vue
+++ b/src/runtime/components/Prose/ProseH1.vue
@@ -8,6 +8,7 @@
 </template>
 
 <script setup lang="ts">
+import { useRuntimeConfig } from '#imports'
 defineProps<{ id: string }>()
 const heading = 1
 const { anchorLinks } = useRuntimeConfig().public.content

--- a/src/runtime/components/Prose/ProseH2.vue
+++ b/src/runtime/components/Prose/ProseH2.vue
@@ -8,6 +8,7 @@
 </template>
 
 <script setup lang="ts">
+import { useRuntimeConfig } from '#imports'
 defineProps<{ id: string }>()
 const heading = 2
 const { anchorLinks } = useRuntimeConfig().public.content

--- a/src/runtime/components/Prose/ProseH3.vue
+++ b/src/runtime/components/Prose/ProseH3.vue
@@ -8,6 +8,7 @@
 </template>
 
 <script setup lang="ts">
+import { useRuntimeConfig } from '#imports'
 defineProps<{ id: string }>()
 const heading = 3
 const { anchorLinks } = useRuntimeConfig().public.content

--- a/src/runtime/components/Prose/ProseH4.vue
+++ b/src/runtime/components/Prose/ProseH4.vue
@@ -8,6 +8,7 @@
 </template>
 
 <script setup lang="ts">
+import { useRuntimeConfig } from '#imports'
 defineProps<{ id: string }>()
 const heading = 4
 const { anchorLinks } = useRuntimeConfig().public.content

--- a/src/runtime/components/Prose/ProseH5.vue
+++ b/src/runtime/components/Prose/ProseH5.vue
@@ -8,6 +8,7 @@
 </template>
 
 <script setup lang="ts">
+import { useRuntimeConfig } from '#imports'
 defineProps<{ id: string }>()
 const heading = 5
 const { anchorLinks } = useRuntimeConfig().public.content

--- a/src/runtime/components/Prose/ProseH6.vue
+++ b/src/runtime/components/Prose/ProseH6.vue
@@ -8,6 +8,7 @@
 </template>
 
 <script setup lang="ts">
+import { useRuntimeConfig } from '#imports'
 defineProps<{ id: string }>()
 const heading = 6
 const { anchorLinks } = useRuntimeConfig().public.content


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

My new local projects always get the following error in edge channel:

```
500
useRuntimeConfig is not defined
```

<details>
<summary>View full log</summary>

Webpage:

```
500

useRuntimeConfig is not defined

at _sfc_main.setup (./node_modules/@nuxt/content/dist/runtime/components/Prose/ProseH1.js:39:23)
at callWithErrorHandling (./node_modules/@vue/runtime-core/dist/runtime-core.cjs.js:157:22)
at setupStatefulComponent (./node_modules/@vue/runtime-core/dist/runtime-core.cjs.js:7135:29)
at setupComponent (./node_modules/@vue/runtime-core/dist/runtime-core.cjs.js:7090:11)
at renderComponentVNode (./node_modules/@vue/server-renderer/dist/server-renderer.cjs.js:172:17)
at renderVNode (./node_modules/@vue/server-renderer/dist/server-renderer.cjs.js:299:22)
at renderComponentSubTree (./node_modules/@vue/server-renderer/dist/server-renderer.cjs.js:263:13)
at renderComponentVNode (./node_modules/@vue/server-renderer/dist/server-renderer.cjs.js:188:16)
at renderVNode (./node_modules/@vue/server-renderer/dist/server-renderer.cjs.js:299:22)
```

Console:

```
[Vue warn]: Unhandled error during execution of setup function 
  at <ProseH1 id="nuxt-content" >
```

</details>

This is obviously caused by the new anchorLinks option (--> the config checking in the heading prose components), so I added the necessary import.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
