### PR TITLE
feat(parser): introduce `_dir` field in contents

### DIFF
--- a/src/runtime/transformers/path-meta.ts
+++ b/src/runtime/transformers/path-meta.ts
@@ -32,12 +32,13 @@ export default defineTransformer({
     // Check first part for locale name
     const _locale = locales.includes(parts[0]) ? parts.shift() : defaultLocale
 
-    const filePath = parts.join('/')
+    const filePath = generatePath(parts.join('/'))
 
     return <ParsedContent> {
-      _path: generatePath(filePath),
-      _draft: isDraft(filePath),
-      _partial: isPartial(filePath),
+      _path: filePath,
+      _dir: filePath.split('/').slice(-2)[0],
+      _draft: isDraft(_path),
+      _partial: isPartial(_path),
       _locale,
       ...content,
       // TODO: move title to Markdown parser

--- a/test/features/transformer-path-meta.ts
+++ b/test/features/transformer-path-meta.ts
@@ -7,28 +7,32 @@ const testCases = {
     title: '',
     _draft: false,
     _partial: false,
-    _path: '/'
+    _path: '/',
+    _dir: ''
   },
   'content:3.index.draft.md': {
     __description: 'Index file with position [Draft]',
     title: '',
     _draft: true,
     _partial: false,
-    _path: '/'
+    _path: '/',
+    _dir: ''
   },
   'content:1.blog:3.index.draft.md': {
     __description: 'Blog Index file with position [Draft]',
     title: '',
     _draft: true,
     _partial: false,
-    _path: '/blog'
+    _path: '/blog',
+    _dir: ''
   },
   'content:1.blog:_4.the-post.md': {
     __description: 'Blog post file with position [Partial]',
     title: '4The Post',
     _draft: false,
     _partial: true,
-    _path: '/blog/_4.the-post'
+    _path: '/blog/_4.the-post',
+    _dir: 'blog'
   },
   ...['1.0.0', '1.1', '1', '1.x', '1.0.x', '1.0.0.x'].reduce((map, semver) => {
     map[`content:${semver}:doc.md`] = {
@@ -36,7 +40,8 @@ const testCases = {
       _draft: false,
       _partial: false,
       _path: `/${semver}/doc`,
-      _source: 'content'
+      _source: 'content',
+      _dir: semver
     }
     return map
   }, {}),
@@ -45,28 +50,32 @@ const testCases = {
     title: 'Doc',
     _draft: false,
     _partial: false,
-    _path: '/one/two/three/four/five/doc'
+    _path: '/one/two/three/four/five/doc',
+    _dir: 'five'
   },
   'content:1.one:file?param=value#hash.md': {
     __description: 'Handle special chars in file name',
     title: 'File?param=value#hash',
     _draft: false,
     _partial: false,
-    _path: '/one/fileparamvaluehash'
+    _path: '/one/fileparamvaluehash',
+    _dir: 'one'
   },
   'content:indexer.md': {
     __description: 'non-index file with index substring',
     title: 'Indexer',
     _draft: false,
     _partial: false,
-    _path: '/indexer'
+    _path: '/indexer',
+    _dir: ''
   },
   'content:indexer.draft.md': {
     __description: 'non-index file with index substring',
     title: 'Indexer',
     _draft: true,
     _partial: false,
-    _path: '/indexer'
+    _path: '/indexer',
+    _dir: ''
   }
 }
 
@@ -78,6 +87,7 @@ export const testPathMetaTransformer = () => {
           method: 'POST',
           body: { id, content: 'Index' }
         })
+console.log(transformed);
 
         const fullPath = id.replace(/:/g, '/')
         expect(transformed).toHaveProperty('_id')
@@ -108,6 +118,12 @@ export const testPathMetaTransformer = () => {
         assert(
           fullPath.startsWith(`${transformed._source}/`),
           `source is not equal, recieved: ${transformed._source}`
+        )
+
+        expect(transformed).toHaveProperty('_dir')
+        assert(
+          transformed._dir === expected._dir,
+          `directory is not equal, recieved: ${transformed._dir}`
         )
 
         expect(transformed).toHaveProperty('_path')

--- a/test/fixtures/basic/server/api/parse.ts
+++ b/test/fixtures/basic/server/api/parse.ts
@@ -1,8 +1,8 @@
-import { defineEventHandler, useBody } from 'h3'
+import { eventHandler, readBody } from 'h3'
 import { parseContent } from '#content/server'
 
-export default defineEventHandler(async (event) => {
-  const { id, content, options } = await useBody(event)
+export default eventHandler(async (event) => {
+  const { id, content, options } = await readBody(event)
 
   // @ts-ignore
   const parsedContent = await parseContent(id, content, options)


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue
resolves nuxt/content#1611
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
