### PR TITLE
docs: guidance on using local images

### DIFF
--- a/docs/content/3.guide/1.writing/2.markdown.md
+++ b/docs/content/3.guide/1.writing/2.markdown.md
@@ -109,3 +109,25 @@ Code highlighting works both on [`ProseCode`](/api/components/prose#prosecode) a
 ::alert{type=info}
 [Read the API reference to configure or entirely disable syntax highlighting.](/api/configuration#highlight)
 ::
+
+## Images
+
+You can add images to your `public` directory:
+
+```
+my-project/
+  content/
+    index.md
+  public/
+    img/
+      image.png
+  nuxt.config.ts
+  package.json
+  tsconfig.json
+```
+
+And then use them in your markdown files in the `content` directory as such:
+
+```md[content/index.md]
+![my image](/img/image.png)
+```


### PR DESCRIPTION
### 🔗 Linked issue
#1610 

### ❓ Type of change
- [X] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
I added a section in the documentation to explain how to use local images inside the markdown file.

There's no mention of how to use local images in the documentation. 

It might confuse beginners who wish to use local images in their content.

Resolves #1610 

### 📝 Checklist
- [X] I have linked an issue or discussion.
- [X] I have updated the documentation accordingly.
