### PR TITLE
docs: fix error in ContentQuery where clause example

### DIFF
--- a/docs/content/4.api/1.components/4.content-query.md
+++ b/docs/content/4.api/1.components/4.content-query.md
@@ -62,9 +62,9 @@ The `not-found`{lang=ts} slot can be used to display a default content before re
 ```html [pages/about.vue]
 <template>
   <main>
-    <ContentQuery path="/about/authors" :where="{ type: 'csv' }" v-slot="{ authors }">
+    <ContentQuery path="/about/authors" :where="{ type: 'csv' }" v-slot="{ data }">
       <ul>
-        <li v-for="author of authors" :key="author.name">
+        <li v-for="author of data" :key="author.name">
           {{ author.name }}
         </li>
       </ul>

--- a/docs/content/4.api/1.components/4.content-query.md
+++ b/docs/content/4.api/1.components/4.content-query.md
@@ -62,7 +62,7 @@ The `not-found`{lang=ts} slot can be used to display a default content before re
 ```html [pages/about.vue]
 <template>
   <main>
-    <ContentQuery path="/about/authors" :where="{ type: 'csv' }" v-slot="{ data }">
+    <ContentQuery path="/about/authors" :where="{ type: 'csv' }" v-slot="{ authors }">
       <ul>
         <li v-for="author of authors" :key="author.name">
           {{ author.name }}


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Fixed an error in the Where clause for ContentQuery documentation. Before, ContentQuery passed `data` variable to the slot, which was not used and instead `authors` was used in its place. `data` is replaced with `authors` to fix this error.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
