### PR TITLE
docs(a11y): Use list for nav example

### DIFF
--- a/docs/content/4.api/1.components/3.content-navigation.md
+++ b/docs/content/4.api/1.components/3.content-navigation.md
@@ -18,9 +18,11 @@ The `default`{lang=ts} slot can be used to render the content with `v-slot="{ na
 <template>
   <nav>
     <ContentNavigation v-slot="{ navigation }">
-      <div v-for="link of navigation" :key="link._path">
-        <NuxtLink :to="link._path">{{ link.title }}</NuxtLink>
-      </div>
+      <ul>
+        <li v-for="link of navigation" :key="link._path">
+          <NuxtLink :to="link._path">{{ link.title }}</NuxtLink>
+        </li>
+      </ul>
     </ContentNavigation>
   </nav>
 </template>


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue
I didn't see an issue for this, but I can make one if that's preferred.

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Updated the HTML in the navbar example from using `div` to using `ul`/`li`. Since many people may copy the example HTML wholesale, using a list inside the nav will start them out with better practices; as per [W3C tutorial](https://www.w3.org/WAI/tutorials/menus/structure/#menu-representation).

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
