### PR TITLE
docs: add locale to content-docs and content-list

### DIFF
--- a/docs/content/4.api/1.components/1.content-doc.md
+++ b/docs/content/4.api/1.components/1.content-doc.md
@@ -25,6 +25,9 @@ It uses `<ContentRenderer>`{lang=html} and `<ContentQuery>`{lang=html} under the
 - `head`{lang=ts}: Toggles the usage of [`useContentHead`](/api/composables/use-content-head).
   - Type: `Boolean`{lang=ts}
   - Default: `true`{lang=ts}
+- `locale`{lang=ts}: Filter contents based on a locale.
+  - Type: `String`{lang=ts}
+  - Default: `undefined`{lang=ts}
 
 ## Slots
 

--- a/docs/content/4.api/1.components/2.content-list.md
+++ b/docs/content/4.api/1.components/2.content-list.md
@@ -16,6 +16,9 @@ An explicit `path`{lang=ts} can be given to the component.
 - `query`{lang=ts}: A query builder params object to be passed to `<ContentQuery />` component.
   - Type: `QueryBuilderParams`{lang=ts}
   - Default: `undefined`{lang=ts}
+- `locale`{lang=ts}: Filter contents based on a locale.
+  - Type: `String`{lang=ts}
+  - Default: `undefined`{lang=ts}
 
 ## Slots
 
@@ -53,8 +56,13 @@ An explicit `path`{lang=ts} can be given to the component.
 
 ```html [pages/index.vue]
 <script setup lang="ts">
-import type { QueryBuilderParams } from '@nuxt/content/dist/runtime/types'
-const query: QueryBuilderParams = { path: '/articles', where: { layout: 'article' }, limit: 5, sort: { date: -1 } }
+  import type { QueryBuilderParams } from "@nuxt/content/dist/runtime/types";
+  const query: QueryBuilderParams = {
+    path: "/articles",
+    where: { layout: "article" },
+    limit: 5,
+    sort: { date: -1 },
+  };
 </script>
 
 <template>


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue
#1737 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

```:locale``` was not documented to be used within ContentList, and ContentDoc but they works just fine and required for multilingual content.
#1737 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
