### PR TITLE
fix(query): fallback to default locale if query has no filter on `_locale`

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -567,6 +567,8 @@ export default defineNuxtModule<ModuleOptions>({
     contentContext.markdown = processMarkdownOptions(contentContext.markdown)
 
     nuxt.options.runtimeConfig.public.content = defu(nuxt.options.runtimeConfig.public.content, {
+      locales: options.locales,
+      defaultLocale: contentContext.defaultLocale,
       integrity: buildIntegrity,
       clientDB: {
         isSPA: options.experimental.clientDB && nuxt.options.ssr === false
@@ -681,6 +683,10 @@ interface ModulePublicRuntimeConfig {
     isSPA: boolean
     integrity: number
   }
+
+  defaultLocale: ModuleOptions['defaultLocale']
+
+  locales: ModuleOptions['locales']
 
   tags: Record<string, string>
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -281,6 +281,9 @@ export default defineNuxtModule<ModuleOptions>({
     const { resolve } = createResolver(import.meta.url)
     const resolveRuntimeModule = (path: string) => resolveModule(path, { paths: resolve('./runtime') })
 
+    // Ensure default locale alway is the first item of locales
+    options.locales = Array.from(new Set([options.defaultLocale, ...options.locales].filter(Boolean))) as string[]
+
     // Disable cache in dev mode
     const buildIntegrity = nuxt.options.dev ? undefined : Date.now()
 

--- a/src/runtime/composables/navigation.ts
+++ b/src/runtime/composables/navigation.ts
@@ -10,6 +10,16 @@ export const fetchContentNavigation = async (queryBuilder?: QueryBuilder | Query
   // When params is an instance of QueryBuilder then we need to pick the params explicitly
   const params: QueryBuilderParams = typeof queryBuilder?.params === 'function' ? queryBuilder.params() : queryBuilder
 
+  // Filter by locale if:
+  // - locales are defined
+  // - query doesn't already have a locale filter
+  if (content.locales.length) {
+    const queryLocale = params.where?.find(w => w._locale)?._locale
+    const locale = queryLocale || content.defaultLocale
+    params.where = params.where || []
+    params.where.push({ _locale: locale })
+  }
+
   const _apiPath = params ? `/navigation/${hash(params)}` : '/navigation/'
   const apiPath = withContentBase(process.dev ? _apiPath : `${_apiPath}.${content.integrity}.json`)
 

--- a/src/runtime/composables/navigation.ts
+++ b/src/runtime/composables/navigation.ts
@@ -15,9 +15,10 @@ export const fetchContentNavigation = async (queryBuilder?: QueryBuilder | Query
   // - query doesn't already have a locale filter
   if (content.locales.length) {
     const queryLocale = params.where?.find(w => w._locale)?._locale
-    const locale = queryLocale || content.defaultLocale
-    params.where = params.where || []
-    params.where.push({ _locale: locale })
+    if (!queryLocale) {
+      params.where = params.where || []
+      params.where.push({ _locale: content.defaultLocale })
+    }
   }
 
   const _apiPath = params ? `/navigation/${hash(params)}` : '/navigation/'

--- a/src/runtime/composables/query.ts
+++ b/src/runtime/composables/query.ts
@@ -25,6 +25,15 @@ export const createQueryFetch = <T = ParsedContent>(path?: string) => async (que
     query.sort({ _file: 1, $numeric: true })
   }
 
+  // Filter by locale if:
+  // - locales are defined
+  // - query doesn't already have a locale filter
+  if (content.locales.length) {
+    const queryLocale = query.params().where?.find(w => w._locale)?._locale
+    const locale = queryLocale || content.defaultLocale
+    query.locale(locale)
+  }
+
   const params = query.params()
 
   const apiPath = withContentBase(process.dev ? '/query' : `/query/${hash(params)}.${content.integrity}.json`)

--- a/src/runtime/composables/query.ts
+++ b/src/runtime/composables/query.ts
@@ -30,8 +30,9 @@ export const createQueryFetch = <T = ParsedContent>(path?: string) => async (que
   // - query doesn't already have a locale filter
   if (content.locales.length) {
     const queryLocale = query.params().where?.find(w => w._locale)?._locale
-    const locale = queryLocale || content.defaultLocale
-    query.locale(locale)
+    if (!queryLocale) {
+      query.locale(content.defaultLocale)
+    }
   }
 
   const params = query.params()

--- a/src/runtime/server/storage.ts
+++ b/src/runtime/server/storage.ts
@@ -199,6 +199,15 @@ export const createServerQueryFetch = <T = ParsedContent>(event: H3Event, path?:
     query.sort({ _file: 1, $numeric: true })
   }
 
+  // Filter by locale if:
+  // - locales are defined
+  // - query doesn't already have a locale filter
+  if (contentConfig.locales.length) {
+    const queryLocale = query.params().where?.find(w => w._locale)?._locale
+    const locale = queryLocale || contentConfig.defaultLocale
+    query.locale(locale)
+  }
+
   return createPipelineFetcher<T>(() => getIndexedContentsList<T>(event, query))(query)
 }
 

--- a/src/runtime/server/storage.ts
+++ b/src/runtime/server/storage.ts
@@ -204,8 +204,9 @@ export const createServerQueryFetch = <T = ParsedContent>(event: H3Event, path?:
   // - query doesn't already have a locale filter
   if (contentConfig.locales.length) {
     const queryLocale = query.params().where?.find(w => w._locale)?._locale
-    const locale = queryLocale || contentConfig.defaultLocale
-    query.locale(locale)
+    if (!queryLocale) {
+      query.locale(contentConfig.defaultLocale)
+    }
   }
 
   return createPipelineFetcher<T>(() => getIndexedContentsList<T>(event, query))(query)

--- a/src/runtime/transformers/markdown.ts
+++ b/src/runtime/transformers/markdown.ts
@@ -23,7 +23,7 @@ export default defineTransformer({
 })
 
 async function importPlugins (plugins: Record<string, false | MarkdownPlugin> = {}) {
-  const resolvedPlugins = {}
+  const resolvedPlugins: Record<string, false | MarkdownPlugin & { instance: any }> = {}
   for (const [name, plugin] of Object.entries(plugins)) {
     if (plugin) {
       resolvedPlugins[name] = {

--- a/test/__snapshots__/basic.test.ts.snap
+++ b/test/__snapshots__/basic.test.ts.snap
@@ -1,5 +1,43 @@
 // Vitest Snapshot v1
 
+exports[`Basic usage > Content Queries > Get contents index > basic-index-body 1`] = `
+{
+  "children": [
+    {
+      "children": [
+        {
+          "type": "text",
+          "value": "Index",
+        },
+      ],
+      "props": {
+        "id": "index",
+      },
+      "tag": "h1",
+      "type": "element",
+    },
+    {
+      "children": [
+        {
+          "type": "text",
+          "value": "Hello World",
+        },
+      ],
+      "props": {},
+      "tag": "p",
+      "type": "element",
+    },
+  ],
+  "toc": {
+    "depth": 2,
+    "links": [],
+    "searchDepth": 2,
+    "title": "",
+  },
+  "type": "root",
+}
+`;
+
 exports[`Basic usage > Get contents index > basic-index-body 1`] = `
 {
   "children": [

--- a/test/__snapshots__/custom-api-base.test.ts.snap
+++ b/test/__snapshots__/custom-api-base.test.ts.snap
@@ -1,5 +1,43 @@
 // Vitest Snapshot v1
 
+exports[`Custom api baseURL > Content Queries > Get contents index > basic-index-body 1`] = `
+{
+  "children": [
+    {
+      "children": [
+        {
+          "type": "text",
+          "value": "Index",
+        },
+      ],
+      "props": {
+        "id": "index",
+      },
+      "tag": "h1",
+      "type": "element",
+    },
+    {
+      "children": [
+        {
+          "type": "text",
+          "value": "Hello World",
+        },
+      ],
+      "props": {},
+      "tag": "p",
+      "type": "element",
+    },
+  ],
+  "toc": {
+    "depth": 2,
+    "links": [],
+    "searchDepth": 2,
+    "title": "",
+  },
+  "type": "root",
+}
+`;
+
 exports[`Custom api baseURL > Get contents index > basic-index-body 1`] = `
 {
   "children": [

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -1,7 +1,6 @@
 import { fileURLToPath } from 'url'
-import { assert, test, describe, expect, vi } from 'vitest'
+import { test, describe, expect, vi } from 'vitest'
 import { setup, $fetch } from '@nuxt/test-utils'
-import { hash } from 'ohash'
 import { testMarkdownParser } from './features/parser-markdown'
 import { testPathMetaTransformer } from './features/transformer-path-meta'
 import { testYamlParser } from './features/parser-yaml'
@@ -28,92 +27,9 @@ describe('Basic usage', async () => {
     server: true
   })
 
-  const QUERY_ENDPOINT = '/api/_content/query'
-  const fetchDocument = (_id: string) => {
-    const params = { first: true, where: { _id } }
-    const qid = hash(params)
-    return $fetch(`${QUERY_ENDPOINT}/${qid}`, {
-      params: { _params: JSON.stringify(params) }
-    })
-  }
-
-  test('List contents', async () => {
-    const params = { only: '_id' }
-    const qid = hash(params)
-    const docs = await $fetch(`${QUERY_ENDPOINT}/${qid}`, {
-      params: { _params: JSON.stringify(params) }
-    })
-
-    const ids = docs.map(doc => doc._id)
-
-    assert(ids.length > 0)
-    assert(ids.includes('content:index.md'))
-
-    // Ignored files should be listed
-    assert(ids.includes('content:.dot-ignored.md') === false, 'Ignored files with `.` should not be listed')
-    assert(ids.includes('content:-dash-ignored.md') === false, 'Ignored files with `-` should not be listed')
-
-    assert(ids.includes('fa-ir:fa:hello.md') === true, 'Files with `fa-ir` prefix should be listed')
-  })
-
-  test('Get contents index', async () => {
-    const index = await fetchDocument('content:index.md')
-
-    expect(index).toHaveProperty('body')
-
-    expect(index.body).toMatchSnapshot('basic-index-body')
-  })
-
-  test('Get ignored contents', async () => {
-    const ignored = await fetchDocument('content:.dot-ignored.md').catch(_err => null)
-
-    expect(ignored).toBeNull()
-  })
-
-  test('Search contents using `locale` helper', async () => {
-    const fa = await $fetch('/locale-fa')
-
-    expect(fa).toContain('fa-ir:fa:hello.md')
-    expect(fa).not.toContain('content:index.md')
-
-    const en = await $fetch('/locale-en')
-
-    expect(en).not.toContain('fa-ir:fa:hello.md')
-    expect(en).toContain('content:index.md')
-  })
-
-  test('Use default locale for unscoped contents', async () => {
-    const index = await fetchDocument('content:index.md')
-
-    expect(index).toMatchObject({
-      _locale: 'en'
-    })
-  })
-
   test('Multi part path', async () => {
     const html = await $fetch('/features/multi-part-path')
     expect(html).contains('Persian')
-  })
-
-  test('Empty slot', async () => {
-    const html = await $fetch('/features/empty-slot')
-    expect(html).contains('Nullish Document!!!')
-    expect(html).contains('Empty Child!!!')
-  })
-
-  test('<ContentDoc> head management (if same path)', async () => {
-    const html = await $fetch('/head')
-    expect(html).contains('<title>Head overwritten</title>')
-    expect(html).contains('<meta property="og:image" content="https://picsum.photos/200/300">')
-    expect(html).contains('<meta name="description" content="Description overwritten">')
-    expect(html).contains('<meta property="og:image" content="https://picsum.photos/200/300">')
-  })
-
-  test('<ContentDoc> head management (not same path)', async () => {
-    const html = await $fetch('/bypass-head')
-    expect(html).not.contains('<title>Head overwritten</title>')
-    expect(html).not.contains('<meta property="og:image" content="https://picsum.photos/200/300">')
-    expect(html).not.contains('<meta name="description" content="Description overwritten"><meta property="og:image" content="https://picsum.photos/200/300">')
   })
 
   test('Partials specials chars', async () => {

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -18,6 +18,7 @@ import { testHighlighter } from './features/highlighter'
 import { testMarkdownRenderer } from './features/renderer-markdown'
 import { testParserOptions } from './features/parser-options'
 import { testComponents } from './features/components'
+import { testLocales } from './features/locales'
 
 const spyConsoleWarn = vi.spyOn(global.console, 'warn')
 
@@ -130,6 +131,8 @@ describe('Basic usage', async () => {
     expect(spyConsoleWarn).toHaveBeenCalled()
     expect(spyConsoleWarn).toHaveBeenCalledWith('Ignoring [content:with-\'invalid\'-char.md]. File name should not contain any of the following characters: \', ", ?, #, /')
   })
+
+  testLocales()
 
   testComponents()
 

--- a/test/custom-api-base.test.ts
+++ b/test/custom-api-base.test.ts
@@ -1,7 +1,6 @@
 import { fileURLToPath } from 'url'
-import { assert, test, describe, expect, vi } from 'vitest'
+import { test, describe, expect, vi } from 'vitest'
 import { setup, $fetch } from '@nuxt/test-utils'
-import { hash } from 'ohash'
 import { testMarkdownParser } from './features/parser-markdown'
 import { testPathMetaTransformer } from './features/transformer-path-meta'
 import { testYamlParser } from './features/parser-yaml'
@@ -18,6 +17,7 @@ import { testHighlighter } from './features/highlighter'
 import { testMarkdownRenderer } from './features/renderer-markdown'
 import { testParserOptions } from './features/parser-options'
 import { testComponents } from './features/components'
+import { testLocales } from './features/locales'
 
 const spyConsoleWarn = vi.spyOn(global.console, 'warn')
 const apiBaseURL = '/my-content-api'
@@ -36,92 +36,9 @@ describe('Custom api baseURL', async () => {
     }
   })
 
-  const QUERY_ENDPOINT = `${apiBaseURL}/query`
-  const fetchDocument = (_id: string) => {
-    const params = { first: true, where: { _id } }
-    const qid = hash(params)
-    return $fetch(`${QUERY_ENDPOINT}/${qid}`, {
-      params: { _params: JSON.stringify(params) }
-    })
-  }
-
-  test('List contents', async () => {
-    const params = { only: '_id' }
-    const qid = hash(params)
-    const docs = await $fetch(`${QUERY_ENDPOINT}/${qid}`, {
-      params: { _params: JSON.stringify(params) }
-    })
-
-    const ids = docs.map(doc => doc._id)
-
-    assert(ids.length > 0)
-    assert(ids.includes('content:index.md'))
-
-    // Ignored files should be listed
-    assert(ids.includes('content:.dot-ignored.md') === false, 'Ignored files with `.` should not be listed')
-    assert(ids.includes('content:-dash-ignored.md') === false, 'Ignored files with `-` should not be listed')
-
-    assert(ids.includes('fa-ir:fa:hello.md') === true, 'Files with `fa-ir` prefix should be listed')
-  })
-
-  test('Get contents index', async () => {
-    const index = await fetchDocument('content:index.md')
-
-    expect(index).toHaveProperty('body')
-
-    expect(index.body).toMatchSnapshot('basic-index-body')
-  })
-
-  test('Get ignored contents', async () => {
-    const ignored = await fetchDocument('content:.dot-ignored.md').catch(_err => null)
-
-    expect(ignored).toBeNull()
-  })
-
-  test('Search contents using `locale` helper', async () => {
-    const fa = await $fetch('/locale-fa')
-
-    expect(fa).toContain('fa-ir:fa:hello.md')
-    expect(fa).not.toContain('content:index.md')
-
-    const en = await $fetch('/locale-en')
-
-    expect(en).not.toContain('fa-ir:fa:hello.md')
-    expect(en).toContain('content:index.md')
-  })
-
-  test('Use default locale for unscoped contents', async () => {
-    const index = await fetchDocument('content:index.md')
-
-    expect(index).toMatchObject({
-      _locale: 'en'
-    })
-  })
-
   test('Multi part path', async () => {
     const html = await $fetch('/features/multi-part-path')
     expect(html).contains('Persian')
-  })
-
-  test('Empty slot', async () => {
-    const html = await $fetch('/features/empty-slot')
-    expect(html).contains('Nullish Document!!!')
-    expect(html).contains('Empty Child!!!')
-  })
-
-  test('<ContentDoc> head management (if same path)', async () => {
-    const html = await $fetch('/head')
-    expect(html).contains('<title>Head overwritten</title>')
-    expect(html).contains('<meta property="og:image" content="https://picsum.photos/200/300">')
-    expect(html).contains('<meta name="description" content="Description overwritten">')
-    expect(html).contains('<meta property="og:image" content="https://picsum.photos/200/300">')
-  })
-
-  test('<ContentDoc> head management (not same path)', async () => {
-    const html = await $fetch('/bypass-head')
-    expect(html).not.contains('<title>Head overwritten</title>')
-    expect(html).not.contains('<meta property="og:image" content="https://picsum.photos/200/300">')
-    expect(html).not.contains('<meta name="description" content="Description overwritten"><meta property="og:image" content="https://picsum.photos/200/300">')
   })
 
   test('Partials specials chars', async () => {
@@ -139,6 +56,8 @@ describe('Custom api baseURL', async () => {
     expect(spyConsoleWarn).toHaveBeenCalled()
     expect(spyConsoleWarn).toHaveBeenCalledWith('Ignoring [content:with-\'invalid\'-char.md]. File name should not contain any of the following characters: \', ", ?, #, /')
   })
+
+  testLocales()
 
   testComponents()
 

--- a/test/features/locales.ts
+++ b/test/features/locales.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'vitest'
+import { describe, expect, test, assert } from 'vitest'
 import { $fetch, useTestContext } from '@nuxt/test-utils'
 
 export const testLocales = () => {
@@ -9,7 +9,32 @@ export const testLocales = () => {
     test('Path with multiple locales', async () => {
       const params = { where: [{ _path: '/translated' }] }
       const content = await $fetch(`${apiBaseUrl}/query`, { params: { _params: JSON.stringify(params) } })
-      expect(content.length === 2)
+      assert(content.length === 1)
+      assert(content[0]._locale === 'en')
+    })
+
+    test('Search contents using `locale` helper', async () => {
+      const fa = await $fetch('/locale-fa')
+
+      expect(fa).toContain('fa-ir:fa:hello.md')
+      expect(fa).not.toContain('content:index.md')
+
+      const en = await $fetch('/locale-en')
+
+      expect(en).not.toContain('fa-ir:fa:hello.md')
+      expect(en).toContain('content:index.md')
+    })
+
+    test('Use default locale for unscoped contents', async () => {
+      const index = await $fetch(`${apiBaseUrl}/query`, {
+        params: {
+          _params: JSON.stringify({ first: true, where: { _id: 'content:index.md' } })
+        }
+      })
+
+      expect(index).toMatchObject({
+        _locale: 'en'
+      })
     })
   })
 }

--- a/test/features/locales.ts
+++ b/test/features/locales.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from 'vitest'
+import { $fetch, useTestContext } from '@nuxt/test-utils'
+
+export const testLocales = () => {
+  // @ts-ignore
+  const apiBaseUrl = useTestContext().options.nuxtConfig.content?.api?.baseURL || '/api/_content'
+
+  describe('Locales', () => {
+    test('Path with multiple locales', async () => {
+      const params = { where: [{ _path: '/translated' }] }
+      const content = await $fetch(`${apiBaseUrl}/query`, { params: { _params: JSON.stringify(params) } })
+      expect(content.length === 2)
+    })
+  })
+}

--- a/test/features/renderer-markdown.ts
+++ b/test/features/renderer-markdown.ts
@@ -67,5 +67,26 @@ export const testMarkdownRenderer = () => {
       const html = await $fetch('/features/slotted-content-renderer')
       expect(html).contains('The default slot is overridden')
     })
+
+    test('Empty slot', async () => {
+      const html = await $fetch('/features/empty-slot')
+      expect(html).contains('Nullish Document!!!')
+      expect(html).contains('Empty Child!!!')
+    })
+
+    test('<ContentDoc> head management (if same path)', async () => {
+      const html = await $fetch('/head')
+      expect(html).contains('<title>Head overwritten</title>')
+      expect(html).contains('<meta property="og:image" content="https://picsum.photos/200/300">')
+      expect(html).contains('<meta name="description" content="Description overwritten">')
+      expect(html).contains('<meta property="og:image" content="https://picsum.photos/200/300">')
+    })
+
+    test('<ContentDoc> head management (not same path)', async () => {
+      const html = await $fetch('/bypass-head')
+      expect(html).not.contains('<title>Head overwritten</title>')
+      expect(html).not.contains('<meta property="og:image" content="https://picsum.photos/200/300">')
+      expect(html).not.contains('<meta name="description" content="Description overwritten"><meta property="og:image" content="https://picsum.photos/200/300">')
+    })
   })
 }

--- a/test/fixtures/basic/content-fa/translated.md
+++ b/test/fixtures/basic/content-fa/translated.md
@@ -1,0 +1,1 @@
+# Translated to Farsi

--- a/test/fixtures/basic/content/translated.md
+++ b/test/fixtures/basic/content/translated.md
@@ -1,0 +1,1 @@
+# Translate Me

--- a/test/fixtures/basic/nuxt.config.ts
+++ b/test/fixtures/basic/nuxt.config.ts
@@ -23,7 +23,8 @@ export default defineNuxtConfig({
   },
   modules: [contentModule],
   content: {
-    locales: ['en', 'fa'],
+    locales: ['fa', 'en'],
+    defaultLocale: 'en',
     sources: [
       {
         name: 'fa-ir',


### PR DESCRIPTION
Contents with same `_path` and different locales should exist in the Index

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue
resolves #1737

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
