### PR TITLE
fix(query): ensure default values always apply to query params

### DIFF
--- a/src/runtime/composables/navigation.ts
+++ b/src/runtime/composables/navigation.ts
@@ -8,19 +8,13 @@ import { addPrerenderPath, shouldUseClientDB, withContentBase } from './utils'
 export const fetchContentNavigation = async (queryBuilder?: QueryBuilder | QueryBuilderParams): Promise<Array<NavItem>> => {
   const { content } = useRuntimeConfig().public
 
-  // When params is an instance of QueryBuilder then we need to pick the params explicitly
-  const params: QueryBuilderParams = typeof queryBuilder?.params === 'function' ? queryBuilder.params() : queryBuilder || {}
-
-  // Filter by locale if:
-  // - locales are defined
-  // - query doesn't already have a locale filter
-  if (content.locales.length) {
-    const queryLocale = params.where?.find(w => w._locale)?._locale
-    if (!queryLocale) {
-      params.where = params.where || []
-      params.where.push({ _locale: content.defaultLocale })
-    }
+  // Ensure that queryBuilder is an instance of QueryBuilder
+  if (typeof queryBuilder?.params !== 'function') {
+    queryBuilder = queryContent(queryBuilder as QueryBuilderParams)
   }
+
+  // Get query params from queryBuilder instance to ensure default values are applied
+  const params: QueryBuilderParams = queryBuilder.params()
 
   const apiPath = content.experimental.stripQueryParameters
     ? withContentBase(`/navigation/${process.dev ? '_' : `${hash(params)}.${content.integrity}`}/${encodeQueryParams(params)}.json`)


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue
resolves #1558
resolves #1399

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
This PR removes the limitation of `queryContent` and now we are able to use it like:
```vue
<template>
  <div>
    <ContentNavigation v-slot="{ navigation }" :query="querpath">
     <!-- navigation object of blog contents -->
      <pre>{{ navigation }}</pre>
    </ContentNavigation>
  </div>
</template>

<script setup>
const querpath = queryContent('blog');
</script>
```
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
