### PR TITLE
fix: Return 404 when file not found by the content API

### DIFF
--- a/src/runtime/server/api/query.ts
+++ b/src/runtime/server/api/query.ts
@@ -13,7 +13,7 @@ export default defineEventHandler(async (event) => {
     const path = content?._path || query.where?.find(w => w._path)?._path as string
     if (path) {
       const _dir = await serverQueryContent(event).where({ _path: join(path, '_dir') }).without('_').findOne()
-      if (_dir && !Array.isArray(_dir)) {
+      if (_dir && !Array.isArray(_dir) && content) {
         return {
           _path: path,
           ...(content || {}),


### PR DESCRIPTION
### 🔗 Linked issue
Resolves #1780 

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When a user uses the [path explicitly](https://content.nuxtjs.org/api/components/content-doc/#explicit-path) and the file does not exist, it should throw a 404. But instead, that `if (!content)` block doesn't execute at all since the method does a return inside the `if(path)` block, returning a 'success' response even if the `content` variable is undefined.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly. (N/A)
