### PR TITLE
docs: fix ContentRenderer source link

### DIFF
--- a/docs/content/3.guide/2.displaying/1.rendering.md
+++ b/docs/content/3.guide/2.displaying/1.rendering.md
@@ -49,7 +49,7 @@ Head over to the [API section](/api/components/content-doc) to see the complete 
 
 ## `<ContentRenderer />`
 
-The `<ContentRenderer>` component renders the body of a Markdown document returned by [`queryContent()`](/guide/displaying/querying) in a rich-text format. It fallbacks to rendering the content in a `<pre>`{lang="html"} tag if the content is not Markdown ([:icon{name="fa-brands:github" class="inline-block w-4"} source code](https://github.com/nuxt/content/blob/main/src/runtime/components/ContentRenderer.ts)).
+The `<ContentRenderer>` component renders the body of a Markdown document returned by [`queryContent()`](/guide/displaying/querying) in a rich-text format. It fallbacks to rendering the content in a `<pre>`{lang="html"} tag if the content is not Markdown ([:icon{name="fa-brands:github" class="inline-block w-4"} source code](https://github.com/nuxt/content/blob/main/src/runtime/components/ContentRenderer.vue)).
 
 `<ContentRenderer>` accepts a `value` prop containing the data.
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
<img width="837" alt="Screenshot 2022-12-31 at 4 13 09 AM" src="https://user-images.githubusercontent.com/31113245/210131505-47814462-48a2-49bf-85e3-492b7c290640.png">

ContentRenderer `source code` used to deadlink to https://github.com/nuxt/content/blob/main/src/runtime/components/ContentRenderer.ts,
now it links to https://github.com/nuxt/content/blob/main/src/runtime/components/ContentRenderer.vue instead

