### PR TITLE
perf(ProseA): wrap ProseA with ClentOnly to aviod vue warn

### DIFF
--- a/src/runtime/components/Prose/ProseA.vue
+++ b/src/runtime/components/Prose/ProseA.vue
@@ -12,7 +12,9 @@ defineProps({
 </script>
 
 <template>
-  <NuxtLink :href="href">
-    <slot />
-  </NuxtLink>
+  <ClientOnly>
+    <NuxtLink :href="href">
+      <slot />
+    </NuxtLink>
+  </ClientOnly>
 </template>


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Production

when write link in md header, there is a [vue warn]:
`[Vue warn]: Hydration children mismatch in <h2>: server rendered element contains more child nodes than client vdom. ` or `[Vue warn]: Hydration node mismatch`,
which I resolve by wrap **ProseA** sfc with **ClientOnly**

there is a demo repo: 
https://stackblitz.com/edit/nuxt-starter-fiejbj?file=content/index.md

I'm not quite sure if this is corrected，please check it 😊

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
