### PR TITLE
feat(markdown): keep meta from fenced code block

### DIFF
--- a/docs/content/4.api/1.components/7.prose.md
+++ b/docs/content/4.api/1.components/7.prose.md
@@ -45,7 +45,7 @@ To overwrite a prose component, create a component with the same name in your pr
 ::code-group
 
   ```markdown [Code]
-    ```javascript
+    ```javascript[file.js]{4-6,7} meta-info=val
     export default () => {
       console.log('Code block')
     }
@@ -54,7 +54,7 @@ To overwrite a prose component, create a component with the same name in your pr
 
   ::code-block{label="Preview"}
 
-  ```javascript
+  ```javascript[file.js]{4-6,7}
   export default () => {
     console.log('Code block')
   }
@@ -63,6 +63,17 @@ To overwrite a prose component, create a component with the same name in your pr
   ::
 
 ::
+
+Component properties will be:
+```json
+{
+  code: "export default () => {\n    console.log('Code block')\n}"
+  language: "javascript"
+  filename: "file.js"
+  highlights: [4, 5, 6, 7]
+  meta: "meta-info=val"
+}
+```
 
 Check out the [highlight options](/api/configuration#highlight) for more about the syntax highlighting.
 

--- a/src/runtime/components/Prose/ProseCode.vue
+++ b/src/runtime/components/Prose/ProseCode.vue
@@ -18,6 +18,10 @@ export default defineComponent({
     highlights: {
       type: Array as () => number[],
       default: () => []
+    },
+    meta: {
+      type: String,
+      default: null
     }
   }
 })

--- a/src/runtime/markdown-parser/handler/code.ts
+++ b/src/runtime/markdown-parser/handler/code.ts
@@ -15,6 +15,7 @@ export default (h: H, node: any) => {
       language,
       filename,
       highlights,
+      meta: node.meta,
       code
     },
     [h(node, 'pre', {}, [h(node, 'code', { __ignoreMap: '' }, [u('text', code)])])]

--- a/test/features/parser-markdown.ts
+++ b/test/features/parser-markdown.ts
@@ -45,10 +45,10 @@ export const testMarkdownParser = () => {
         body: {
           id: 'content:index.md',
           content: [
-          '``` ts [file.ts]{4-6,7} other code block info',
-          'let code = undefined;',
-          'return code;',
-          '```'
+            '```ts [file.ts]{4-6,7} other code block info',
+            'let code = undefined;',
+            'return code;',
+            '```'
           ].join('\n')
         }
       })

--- a/test/features/parser-markdown.ts
+++ b/test/features/parser-markdown.ts
@@ -39,6 +39,31 @@ export const testMarkdownParser = () => {
       expect(parsed.body).toHaveProperty('children[0].children[0].tag', 'code-inline')
     })
 
+    test('Keep meta from fenced code block', async () => {
+      const parsed = await $fetch('/api/parse', {
+        method: 'POST',
+        body: {
+          id: 'content:index.md',
+          content: [
+          '``` ts [file.ts]{4-6,7} other code block info',
+          'let code = undefined;',
+          'return code;',
+          '```'
+          ].join('\n')
+        }
+      })
+
+      expect(parsed).toHaveProperty('body')
+      expect(parsed.body).toHaveProperty('children[0].tag', 'code')
+      expect(parsed.body).toHaveProperty('children[0].props')
+      const props = parsed.body.children[0].props
+      expect(props).toHaveProperty('meta')
+      expect(props.meta).toBe('[file.ts]{4-6,7} other code block info')
+      expect(props.language).toBe('ts')
+      expect(props.filename).toBe('file.ts')
+      expect(props.highlights).toEqual([4, 5, 6, 7])
+    })
+
     test('comment', async () => {
       const parsed = await $fetch('/api/parse', {
         method: 'POST',


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Don't drop a info from fenced code
````markdown
```javascript[file.js]{4-6,7} meta-info=val
export default () => {
  console.log('Code block')
}
```
````
So `meta-info=val` will be accessible from the document tree after parsing. Property `meta` will be next to `language`, `filename`, `highlights`.
It can help to do other modifications with remark plugins, transformers, or ProseCode component.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
