### PR TITLE
feat(markdown): don't create excerpt if there is no <!--more-->

### DIFF
--- a/docs/content/3.guide/1.writing/2.markdown.md
+++ b/docs/content/3.guide/1.writing/2.markdown.md
@@ -87,6 +87,8 @@ Full amount of content beyond the more divider.
 
 Description property will contain the excerpt content unless defined within the Front Matter props.
 
+If there is no `<!--more-->` divider in the text then excerpt is undefined.
+
 Example variables will be injected into the document:
 
 ```json

--- a/src/runtime/markdown-parser/index.ts
+++ b/src/runtime/markdown-parser/index.ts
@@ -105,5 +105,4 @@ function useExcerpt (content: string, delimiter = /<!--\s*?more\s*?-->/i) {
   if (idx !== -1) {
     return content.slice(0, idx)
   }
-  return content
 }

--- a/test/features/parser-markdown-excerpt.ts
+++ b/test/features/parser-markdown-excerpt.ts
@@ -57,5 +57,22 @@ export const testMarkdownParserExcerpt = () => {
         }
       `)
     })
+
+    test('When no <!--more--> then excerpt is undefined', async () => {
+      const parsed = await $fetch('/api/parse', {
+        method: 'POST',
+        body: {
+          id: 'content:index.md',
+          content: [
+            '# Index',
+            'First paragraph',
+            '',
+            'Second paragraph'
+          ].join('\n')
+        }
+      })
+
+      expect(parsed.excerpt).not.toBeDefined()
+    })
   })
 }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
If there is no `<!-- more -->` divider in the text then the excerpt is a copy of full content.

This change adds new boolean variable `excerptIsBody` into the document next to `excerpt`.

- It can help to improve performance and don't process the excerpt (just make a copy of body).
- It can help to don't show link to full text if there is nothing to read more. 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
