### PR TITLE
fix: sanitize highlighted text

### DIFF
--- a/src/runtime/transformers/shiki/highlighter.ts
+++ b/src/runtime/transformers/shiki/highlighter.ts
@@ -177,7 +177,7 @@ export const useShikiHighlighter = createSingleton((opts?: Exclude<ModuleOptions
 
     function renderNode (node: any) {
       if (node.type === 'text') {
-        return node.value
+        return node.value.replace(/</g, '&lt;').replace(/>/g, '&gt;')
       }
       const children = node.children.map(renderNode).join('')
       return `<${node.tag} class="${node.props.class}">${children}</${node.tag}>`


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Previously we were producing code like this:

```html
<span class=\"ct-2c497b\"><</span>
```

which breaks the dom tree - or worse, renders the highlighted code directly as HTML elements.

Looking through the codebase it seems likely that this fix might need to be applied elsewhere too and it would be worth a quick look.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
