### PR TITLE
docs: add examples for JSON string for inline props

### DIFF
--- a/docs/content/3.guide/1.writing/3.mdc.md
+++ b/docs/content/3.guide/1.writing/3.mdc.md
@@ -208,7 +208,7 @@ Oops! An error occurred
 ::
 ```
 
-If you want to pass arrays or objects as props to components you can pass them as JSON string and prefix the prop key with a colon automatically decode the JSON string.
+If you want to pass arrays or objects as props to components you can pass them as JSON string and prefix the prop key with a colon to automatically decode the JSON string.
 Note that in this case you should use single quotes for the value string so you can use double quotes to pass a valid JSON string:
 
 ::code-group

--- a/docs/content/3.guide/1.writing/3.mdc.md
+++ b/docs/content/3.guide/1.writing/3.mdc.md
@@ -200,6 +200,14 @@ defineProps(['type'])
   ::
 ::
 
+Multiple props can be separated with a space:
+
+```md
+::alert{type="warning" icon="exclamation-circle"}
+Oops! An error occurred
+::
+```
+
 ### YAML method
 
 The YAML method uses the `---` identifier to declare one prop per line, that can be useful for readability.

--- a/docs/content/3.guide/1.writing/3.mdc.md
+++ b/docs/content/3.guide/1.writing/3.mdc.md
@@ -208,6 +208,22 @@ Oops! An error occurred
 ::
 ```
 
+If you want to pass arrays or objects as props to components you can pass them as JSON string and prefix the prop key with a colon automatically decode the JSON string.
+Note that in this case you should use single quotes for the value string so you can use double quotes to pass a valid JSON string:
+
+::code-group
+
+  ```md [array.md]
+  ::dropdown{:items='["Nuxt", "Vue", "React"]'}
+  ::
+  ```
+
+  ```md [object.md]
+  ::chart{:options='{"responsive": true, "scales": {"y": {"beginAtZero": true}}}'}
+  ::
+  ```
+::
+
 ### YAML method
 
 The YAML method uses the `---` identifier to declare one prop per line, that can be useful for readability.

--- a/docs/content/3.guide/1.writing/3.mdc.md
+++ b/docs/content/3.guide/1.writing/3.mdc.md
@@ -219,7 +219,7 @@ Note that in this case you should use single quotes for the value string so you 
   ```
 
   ```md [number-array.md]
-  ::dropdown{:items=[1,2,3.5]}
+  ::dropdown{:items='[1,2,3.5]'}
   ::
   ```
 
@@ -229,7 +229,6 @@ Note that in this case you should use single quotes for the value string so you 
   ```
 ::
 
-Note that an array with numbers is also accepted without enquoting it with single quotes (see `number-array.md` example).
 
 ### YAML method
 

--- a/docs/content/3.guide/1.writing/3.mdc.md
+++ b/docs/content/3.guide/1.writing/3.mdc.md
@@ -218,11 +218,18 @@ Note that in this case you should use single quotes for the value string so you 
   ::
   ```
 
+  ```md [number-array.md]
+  ::dropdown{:items=[1,2,3.5]}
+  ::
+  ```
+
   ```md [object.md]
   ::chart{:options='{"responsive": true, "scales": {"y": {"beginAtZero": true}}}'}
   ::
   ```
 ::
+
+Note that an array with numbers is also accepted without enquoting it with single quotes (see `number-array.md` example).
 
 ### YAML method
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

https://github.com/nuxt/content/issues/1494, https://github.com/nuxt/content/issues/1573, https://github.com/nuxt/content/discussions/1492

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR adds examples for arrays and objects that can be passed to props as JSON string with the inline method. Additionally I added a small section with an explanation that multiple props can be passed with a space as a separator as there has been some confusion about this in multiple issues and discussions.

This was not yet documented and only mentioned by @farnabaz in the linked issue.

Also see this discussion about a similar problem: https://github.com/nuxt/content/discussions/1881

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
