### PR TITLE
fix(code block): use <div> for Firefox code block line breaks

### DIFF
--- a/src/runtime/transformers/shiki/highlighter.ts
+++ b/src/runtime/transformers/shiki/highlighter.ts
@@ -143,7 +143,7 @@ export const useShikiHighlighter = createSingleton((opts?: Exclude<ModuleOptions
 
     return lines.map((line, lineIndex) => ({
       type: 'element',
-      tag: 'span',
+      tag: 'div',
       props: { class: ['line', highlights.includes(lineIndex + 1) ? 'highlight' : ''].join(' ').trim() },
       children: line.map(tokenSpan)
     }))


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

#1883

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Using `div`s for highlighted code blocks (instead of `span`s) to preserve line breaks when copying selection in **Firefox**.
`Inline code`s aren't affected, because those only use the children of the first "line" as content.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
