### PR TITLE
fix(headings): don't generate link if `id` is missing

### DIFF
--- a/src/runtime/components/Prose/ProseH1.vue
+++ b/src/runtime/components/Prose/ProseH1.vue
@@ -1,6 +1,6 @@
 <template>
   <h1 :id="id">
-    <a v-if="generate" :href="`#${id}`">
+    <a v-if="generate && id" :href="`#${id}`">
       <slot />
     </a>
     <slot v-else />
@@ -9,7 +9,7 @@
 
 <script setup lang="ts">
 import { useRuntimeConfig } from '#imports'
-defineProps<{ id: string }>()
+defineProps<{ id?: string }>()
 const heading = 1
 const { anchorLinks } = useRuntimeConfig().public.content
 const generate = anchorLinks?.depth >= heading && !anchorLinks?.exclude.includes(heading)

--- a/src/runtime/components/Prose/ProseH1.vue
+++ b/src/runtime/components/Prose/ProseH1.vue
@@ -1,6 +1,6 @@
 <template>
   <h1 :id="id">
-    <a v-if="generate && id" :href="`#${id}`">
+    <a v-if="id && generate" :href="`#${id}`">
       <slot />
     </a>
     <slot v-else />

--- a/src/runtime/components/Prose/ProseH2.vue
+++ b/src/runtime/components/Prose/ProseH2.vue
@@ -1,6 +1,6 @@
 <template>
   <h2 :id="id">
-    <a v-if="generate" :href="`#${id}`">
+    <a v-if="generate && id" :href="`#${id}`">
       <slot />
     </a>
     <slot v-else />
@@ -9,7 +9,7 @@
 
 <script setup lang="ts">
 import { useRuntimeConfig } from '#imports'
-defineProps<{ id: string }>()
+defineProps<{ id?: string }>()
 const heading = 2
 const { anchorLinks } = useRuntimeConfig().public.content
 const generate = anchorLinks?.depth >= heading && !anchorLinks?.exclude.includes(heading)

--- a/src/runtime/components/Prose/ProseH2.vue
+++ b/src/runtime/components/Prose/ProseH2.vue
@@ -1,6 +1,6 @@
 <template>
   <h2 :id="id">
-    <a v-if="generate && id" :href="`#${id}`">
+    <a v-if="id && generate" :href="`#${id}`">
       <slot />
     </a>
     <slot v-else />

--- a/src/runtime/components/Prose/ProseH3.vue
+++ b/src/runtime/components/Prose/ProseH3.vue
@@ -1,6 +1,6 @@
 <template>
   <h3 :id="id">
-    <a v-if="generate" :href="`#${id}`">
+    <a v-if="generate && id" :href="`#${id}`">
       <slot />
     </a>
     <slot v-else />
@@ -9,7 +9,7 @@
 
 <script setup lang="ts">
 import { useRuntimeConfig } from '#imports'
-defineProps<{ id: string }>()
+defineProps<{ id?: string }>()
 const heading = 3
 const { anchorLinks } = useRuntimeConfig().public.content
 const generate = anchorLinks?.depth >= heading && !anchorLinks?.exclude.includes(heading)

--- a/src/runtime/components/Prose/ProseH3.vue
+++ b/src/runtime/components/Prose/ProseH3.vue
@@ -1,6 +1,6 @@
 <template>
   <h3 :id="id">
-    <a v-if="generate && id" :href="`#${id}`">
+    <a v-if="id && generate" :href="`#${id}`">
       <slot />
     </a>
     <slot v-else />

--- a/src/runtime/components/Prose/ProseH4.vue
+++ b/src/runtime/components/Prose/ProseH4.vue
@@ -1,6 +1,6 @@
 <template>
   <h4 :id="id">
-    <a v-if="generate && id" :href="`#${id}`">
+    <a v-if="id && generate" :href="`#${id}`">
       <slot />
     </a>
     <slot v-else />

--- a/src/runtime/components/Prose/ProseH4.vue
+++ b/src/runtime/components/Prose/ProseH4.vue
@@ -1,6 +1,6 @@
 <template>
   <h4 :id="id">
-    <a v-if="generate" :href="`#${id}`">
+    <a v-if="generate && id" :href="`#${id}`">
       <slot />
     </a>
     <slot v-else />
@@ -9,7 +9,7 @@
 
 <script setup lang="ts">
 import { useRuntimeConfig } from '#imports'
-defineProps<{ id: string }>()
+defineProps<{ id?: string }>()
 const heading = 4
 const { anchorLinks } = useRuntimeConfig().public.content
 const generate = anchorLinks?.depth >= heading && !anchorLinks?.exclude.includes(heading)

--- a/src/runtime/components/Prose/ProseH5.vue
+++ b/src/runtime/components/Prose/ProseH5.vue
@@ -1,6 +1,6 @@
 <template>
   <h5 :id="id">
-    <a v-if="generate && id" :href="`#${id}`">
+    <a v-if="id && generate" :href="`#${id}`">
       <slot />
     </a>
     <slot v-else />

--- a/src/runtime/components/Prose/ProseH5.vue
+++ b/src/runtime/components/Prose/ProseH5.vue
@@ -1,6 +1,6 @@
 <template>
   <h5 :id="id">
-    <a v-if="generate" :href="`#${id}`">
+    <a v-if="generate && id" :href="`#${id}`">
       <slot />
     </a>
     <slot v-else />
@@ -9,7 +9,7 @@
 
 <script setup lang="ts">
 import { useRuntimeConfig } from '#imports'
-defineProps<{ id: string }>()
+defineProps<{ id?: string }>()
 const heading = 5
 const { anchorLinks } = useRuntimeConfig().public.content
 const generate = anchorLinks?.depth >= heading && !anchorLinks?.exclude.includes(heading)

--- a/src/runtime/components/Prose/ProseH6.vue
+++ b/src/runtime/components/Prose/ProseH6.vue
@@ -1,6 +1,6 @@
 <template>
   <h6 :id="id">
-    <a v-if="generate && id" :href="`#${id}`">
+    <a v-if="id && generate" :href="`#${id}`">
       <slot />
     </a>
     <slot v-else />

--- a/src/runtime/components/Prose/ProseH6.vue
+++ b/src/runtime/components/Prose/ProseH6.vue
@@ -1,6 +1,6 @@
 <template>
   <h6 :id="id">
-    <a v-if="generate" :href="`#${id}`">
+    <a v-if="generate && id" :href="`#${id}`">
       <slot />
     </a>
     <slot v-else />
@@ -9,7 +9,7 @@
 
 <script setup lang="ts">
 import { useRuntimeConfig } from '#imports'
-defineProps<{ id: string }>()
+defineProps<{ id?: string }>()
 const heading = 6
 const { anchorLinks } = useRuntimeConfig().public.content
 const generate = anchorLinks?.depth >= heading && !anchorLinks?.exclude.includes(heading)


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

#1864

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Adding checks if anchor-id is present in headings, if `id` is not defined, the link isn't generated

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
