### PR TITLE
feat: introduce `component-resolver` transformer

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -9,7 +9,7 @@ import {
   addTemplate,
   extendViteConfig
 } from '@nuxt/kit'
-import { genImport, genSafeVariableName } from 'knitwork'
+import { genDynamicImport, genImport, genSafeVariableName } from 'knitwork'
 import type { ListenOptions } from 'listhen'
 // eslint-disable-next-line import/no-named-as-default
 import defu from 'defu'
@@ -20,6 +20,7 @@ import { listen } from 'listhen'
 import type { WatchEvent } from 'unstorage'
 import { createStorage } from 'unstorage'
 import { joinURL, withLeadingSlash, withTrailingSlash } from 'ufo'
+import type { Component } from '@nuxt/schema'
 import { name, version } from '../package.json'
 import {
   CACHE_VERSION,
@@ -411,6 +412,40 @@ export default defineNuxtModule<ModuleOptions>({
       pathPrefix: false,
       prefix: '',
       global: true
+    })
+
+    const componsntsContext = { components: [] as Component[] }
+    nuxt.hook('components:extend', (newComponents) => {
+      componsntsContext.components = newComponents.filter((c) => {
+        if (c.pascalName.startsWith('Prose') || c.pascalName === 'NuxtLink') {
+          return true
+        }
+
+        if (
+          c.filePath.includes('@nuxt/content/dist') ||
+          c.filePath.includes('nuxt/dist/app') ||
+          c.filePath.includes('NuxtWelcome')
+        ) {
+          return false
+        }
+
+        return true
+      })
+    })
+    addTemplate({
+      filename: 'content-components.mjs',
+      getContents ({ options }) {
+        const components = options.getComponents(options.mode).filter((c: any) => !c.island).flatMap((c: any) => {
+          const exp = c.export === 'default' ? 'c.default || c' : `c['${c.export}']`
+          const isClient = c.mode === 'client'
+          const definitions = []
+
+          definitions.push(`export const ${c.pascalName} = ${genDynamicImport(c.filePath)}.then(c => ${isClient ? `createClientOnly(${exp})` : exp})`)
+          return definitions
+        })
+        return components.join('\n')
+      },
+      options: { getComponents: () => componsntsContext.components }
     })
 
     const typesPath = addTemplate({

--- a/src/module.ts
+++ b/src/module.ts
@@ -414,9 +414,9 @@ export default defineNuxtModule<ModuleOptions>({
       global: true
     })
 
-    const componsntsContext = { components: [] as Component[] }
+    const componentsContext = { components: [] as Component[] }
     nuxt.hook('components:extend', (newComponents) => {
-      componsntsContext.components = newComponents.filter((c) => {
+      componentsContext.components = newComponents.filter((c) => {
         if (c.pascalName.startsWith('Prose') || c.pascalName === 'NuxtLink') {
           return true
         }
@@ -445,7 +445,7 @@ export default defineNuxtModule<ModuleOptions>({
         })
         return components.join('\n')
       },
-      options: { getComponents: () => componsntsContext.components }
+      options: { getComponents: () => componentsContext.components }
     })
 
     const typesPath = addTemplate({

--- a/src/runtime/transformers/component-resolver.ts
+++ b/src/runtime/transformers/component-resolver.ts
@@ -1,0 +1,51 @@
+import { pascalCase } from 'scule'
+import { ParsedContent } from '../types'
+import htmlTags from '../utils/html-tags'
+import { defineTransformer } from './utils'
+
+async function resolveContentComponents (body: ParsedContent['body'], meta: Record<string, string>) {
+  const components = Array.from(new Set(loadComponents(body, meta)))
+  // @ts-ignore
+  const manifest = await import('#build/content-components').catch(() => ({}))
+  const resolvedComponentsEntries = await Promise.all(components.map(async ([t, c]) => {
+    const componentImporter = manifest[pascalCase(c)]
+    if (componentImporter) {
+      return [t, await componentImporter()]
+    }
+    return [t, c]
+  }))
+
+  return Object.fromEntries(resolvedComponentsEntries)
+  function loadComponents (node: any, tags: Record<string, string>) {
+    if (node.type === 'text' || node.tag === 'binding') {
+      return []
+    }
+    const renderTag: string = (typeof node.props?.__ignoreMap === 'undefined' && tags[node.tag!]) || node.tag!
+    const components: Array<Array<string>> = []
+    if (node.type !== 'root' && !htmlTags.includes(renderTag as any)) {
+      components.push([node.tag, renderTag])
+    }
+    for (const child of (node.children || [])) {
+      components.push(...loadComponents(child, tags))
+    }
+    return components
+  }
+}
+export default defineTransformer({
+  name: 'component-resolver',
+  extensions: ['.*'],
+  async transform (content, options = {}) {
+    if (process.server) {
+      // This transformer is only needed on client side to resolve components
+      return content
+    }
+
+    const _components = await resolveContentComponents(content.body, {
+      ...(options?.tags || {}),
+      ...(content._components || {})
+    })
+
+    content._components = _components
+    return content
+  }
+})

--- a/src/runtime/transformers/component-resolver.ts
+++ b/src/runtime/transformers/component-resolver.ts
@@ -9,7 +9,7 @@ async function resolveContentComponents (body: ParsedContent['body'], meta: Reco
   const manifest = await import('#build/content-components').catch(() => ({}))
   const resolvedComponentsEntries = await Promise.all(components.map(async ([t, c]) => {
     const componentImporter = manifest[pascalCase(c)]
-    if (componentImporter) {
+    if (typeof componentImporter === 'function') {
       return [t, await componentImporter()]
     }
     return [t, c]


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Introducing new transformer for client side usage to pre import dynamic components that used in markdown during parse.

Background:
Using dynamic component in Markdown, causes a blink in client side rendering. This behavior exists because `Suspense` shows an empty fallback while `MarkdownRendere` tries to load dynamic components. With preloading components in parse time, we can avoid this blink and layout should and force Suspense to not show the fallback state.

Additionally, with this feature, we will be able to load non-global component.



### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
