### PR TITLE
feat: Add ignorePredicate to Config

### DIFF
--- a/docs/content/4.api/3.configuration.md
+++ b/docs/content/4.api/3.configuration.md
@@ -126,6 +126,23 @@ export default defineNuxtConfig({
 })
 ```
 
+## `ignorePredicate`
+
+- Type: `undefined | (string) => bool`{lang=ts}
+- Default: `undefined`{lang=ts}
+
+List of ignore pattern that will be used for excluding content from parsing and rendering.
+
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  content: {
+    ignorePredicate: (key: string) => {
+      return key.startsWith('v')
+    }
+  }
+})
+```
+
 ## `markdown`
 
 This module uses [remark](https://github.com/remarkjs/remark) and [rehype](https://github.com/remarkjs/remark-rehype) under the hood to compile markdown files into JSON AST that will be stored into the body variable.

--- a/docs/content/4.api/3.configuration.md
+++ b/docs/content/4.api/3.configuration.md
@@ -128,7 +128,7 @@ export default defineNuxtConfig({
 
 ## `ignorePredicate`
 
-- Type: `undefined | (string) => bool`{lang=ts}
+- Type: `undefined | (String) => Boolean`{lang=ts}
 - Default: `undefined`{lang=ts}
 
 List of ignore pattern that will be used for excluding content from parsing and rendering.

--- a/src/module.ts
+++ b/src/module.ts
@@ -79,6 +79,12 @@ export interface ModuleOptions {
    * @default ['\\.', '-']
    */
   ignores: Array<string>
+
+  /**
+   * A predicate used for excluding content from parsing and rendering.
+   * Parsing and rendering will be skipped when this returns false.
+   */
+  ignorePredicate?: (key: string) => boolean
   /**
    * Content module uses `remark` and `rehype` under the hood to compile markdown files.
    * You can modify this options to control its behavior.
@@ -651,6 +657,9 @@ export default defineNuxtModule<ModuleOptions>({
           typeof p === 'string' ? new RegExp(`^${p}|:${p}`) : p
         )
         keys = keys.filter((key) => {
+          if (!contentContext.ignorePredicate?.(key)) {
+            return false
+          }
           if (key.startsWith('preview:') || contentIgnores.some(prefix => prefix.test(key))) {
             return false
           }

--- a/src/runtime/server/storage.ts
+++ b/src/runtime/server/storage.ts
@@ -54,6 +54,9 @@ const invalidKeyCharacters = "'\"?#/".split('')
  * Filter predicate for ignore patterns
  */
 const contentIgnorePredicate = (key: string) => {
+  if (!contentConfig.ignorePredicate?.(key)) {
+    return false
+  }
   if (key.startsWith('preview:') || contentIgnores.some(prefix => prefix.test(key))) {
     return false
   }


### PR DESCRIPTION
### ❓ Type of change
- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Currently we allow the user to specify a `ignores` list in config which is essentially a list of regular expressions. This is useful but limited. This PR proposes an additional item, `ignorePredicate`, that allows the user to supply a custom callback function to decide if a field should be ignored.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
