### PR TITLE
fix: refresh content-index on nitro start

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -691,6 +691,9 @@ export default defineNuxtModule<ModuleOptions>({
       // Register ws url
       nitro.options.runtimeConfig.public.content.wsUrl = url.replace('http', 'ws')
 
+      // Remove content Index to force fresh index when nitro start (after a pull or a change without started Nuxt)
+      await nitro.storage.removeItem('cache:content:content-index.json')
+
       // Watch contents
       await nitro.storage.watch(async (event: WatchEvent, key: string) => {
         // Ignore events that are not related to content


### PR DESCRIPTION

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

fix #1869


### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Here the situation:
- You start your nuxt dev server
- `.nuxt` is generated with a `content-cache` folder and a `content-index.json`
- You stop your nuxt dev server
- You add files in content or you modifie the architecture
- You restart your nuxt dev server but because your `content-index.json` is already there, index is not refreshed (https://github.com/nuxt/content/blob/main/src/runtime/server/content-index.ts#L9)

This situation also occure when you pull from remote with new files in the content folder with a stopped dev server.

Here, I remove the `content-index.json` file every time nitro restart to be sure that a fresh index is generated before the user restart to code.

I was thinking about using a hash but I didn't find good data to hash and this could require to check each time the user hit save. With this method (removing index when nitro start), index is re-caculated only once.


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
