### PR TITLE
fix: potential SyntaxError for generated id from markdown h1..h6

### DIFF
--- a/src/runtime/markdown-parser/compiler.ts
+++ b/src/runtime/markdown-parser/compiler.ts
@@ -22,11 +22,13 @@ export default function (this: any, _options: MarkdownOptions) {
     }
 
     // Remove double dashes and trailing dash from heading ids
+    // Insert underscore if id start with a digit
     if (node.tagName?.startsWith('h') && node.properties.id) {
       node.properties.id = node.properties.id
         .replace(/-+/g, '-')
         .replace(/-$/, '')
         .replace(/^-/, '')
+        .replace(/^(\d)/, '_$1')
     }
 
     /**


### PR DESCRIPTION
**Improve the way id are generated from markdown for h1 .. h6 tags**

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

See #1960 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Prevent a markdown id generated (for h1..h6 headings) to throw a SyntaxError when used in
`document.querySelector()` when such id start with a digit

Resolves #1960

See also:
* [stackblitz demo](https://stackblitz.com/edit/github-9negav?file=content/index.md)

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
