### PR TITLE
fix: set property instead of name for og metadata

### DIFF
--- a/src/runtime/composables/head.ts
+++ b/src/runtime/composables/head.ts
@@ -28,7 +28,7 @@ export const useContentHead = (
       head.title = title
       if (process.server && !head.meta.some(m => m.property === 'og:title')) {
         head.meta.push({
-          name: 'og:title',
+          property: 'og:title',
           content: title as string
         })
       }
@@ -47,7 +47,7 @@ export const useContentHead = (
       const url = config.public.content.trailingSlash ? withTrailingSlash(_url) : withoutTrailingSlash(_url)
       if (!head.meta.some(m => m.property === 'og:url')) {
         head.meta.push({
-          name: 'og:url',
+          property: 'og:url',
           content: url
         })
       }
@@ -72,7 +72,7 @@ export const useContentHead = (
     }
     if (process.server && description && !head.meta.some(m => m.property === 'og:description')) {
       head.meta.push({
-        name: 'og:description',
+        property: 'og:description',
         content: description
       })
     }


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #1980 

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Replaced `name` attribute by `property` for og meta tags
Resolves #1980

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
