### PR TITLE
fix: access `experimental` config from `public` key

### DIFF
--- a/src/runtime/composables/utils.ts
+++ b/src/runtime/composables/utils.ts
@@ -44,7 +44,7 @@ export const addPrerenderPath = (path: string) => {
 }
 
 export const shouldUseClientDB = () => {
-  const { experimental } = useRuntimeConfig().content
+  const { experimental } = useRuntimeConfig().public.content
   if (process.server) { return false }
   if (experimental.clientDB) { return true }
 


### PR DESCRIPTION
### 🔗 Linked issue



### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

We recently deprecated a Nuxt 2 compatibility feature (https://github.com/nuxt/nuxt/pull/20082) and it seems that `@nuxt/content` was still using this feature.

(We plan to remove it entirely by v3.5.)

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
