### PR TITLE
fix(preview): use `sessionStorage` to keep token

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "@nuxt/module-builder": "^0.3.0",
     "@nuxt/schema": "3.4.0",
     "@nuxt/test-utils": "3.4.0",
+    "@nuxthq/studio": "^0.10.1",
     "@nuxtjs/eslint-config-typescript": "latest",
     "@types/mdurl": "^1.0.2",
     "@types/ws": "^8.5.4",

--- a/playground/shared/nuxt.config.ts
+++ b/playground/shared/nuxt.config.ts
@@ -28,7 +28,8 @@ export default defineNuxtConfig({
   ],
   modules: [
     // @ts-ignore
-    contentModule
+    contentModule,
+    '@nuxthq/studio'
   ],
   content: {
     navigation: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,6 +117,9 @@ devDependencies:
   '@nuxt/test-utils':
     specifier: 3.4.0
     version: 3.4.0(rollup@3.20.2)
+  '@nuxthq/studio':
+    specifier: ^0.10.1
+    version: 0.10.1(rollup@3.20.2)
   '@nuxtjs/eslint-config-typescript':
     specifier: latest
     version: 12.0.0(eslint@8.38.0)(typescript@5.0.4)
@@ -995,6 +998,22 @@ packages:
       - vue-tsc
     dev: true
 
+  /@nuxthq/studio@0.10.1(rollup@3.20.2):
+    resolution: {integrity: sha512-EWzk3HkE6QuiqVxqZ7jsAc/8GxSDKRO+jnTBv1wlOAvPKJNPsHrlYGP8EyR6S1NaB3pQTJ9iVBhmskAtrKIsYQ==}
+    dependencies:
+      '@nuxt/kit': 3.4.0(rollup@3.20.2)
+      defu: 6.1.2
+      nuxt-component-meta: 0.5.1(rollup@3.20.2)
+      nuxt-config-schema: 0.4.5(rollup@3.20.2)
+      socket.io-client: 4.6.1
+      ufo: 1.1.1
+    transitivePeerDependencies:
+      - bufferutil
+      - rollup
+      - supports-color
+      - utf-8-validate
+    dev: true
+
   /@nuxtjs/eslint-config-typescript@12.0.0(eslint@8.38.0)(typescript@5.0.4):
     resolution: {integrity: sha512-HJR0ho5MYuOCFjkL+eMX/VXbUwy36J12DUMVy+dj3Qz1GYHwX92Saxap3urFzr8oPkzzFiuOknDivfCeRBWakg==}
     peerDependencies:
@@ -1349,7 +1368,6 @@ packages:
 
   /@socket.io/component-emitter@3.1.0:
     resolution: {integrity: sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg==}
-    dev: false
 
   /@szmarczak/http-timer@4.0.6:
     resolution: {integrity: sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==}
@@ -1742,6 +1760,32 @@ packages:
       concordance: 5.0.4
       loupe: 2.3.6
       pretty-format: 27.5.1
+    dev: true
+
+  /@volar/language-core@1.3.0-alpha.0:
+    resolution: {integrity: sha512-W3uMzecHPcbwddPu4SJpUcPakRBK/y/BP+U0U6NiPpUX1tONLC4yCawt+QBJqtgJ+sfD6ztf5PyvPL3hQRqfOA==}
+    dependencies:
+      '@volar/source-map': 1.3.0-alpha.0
+    dev: true
+
+  /@volar/source-map@1.3.0-alpha.0:
+    resolution: {integrity: sha512-jSdizxWFvDTvkPYZnO6ew3sBZUnS0abKCbuopkc0JrIlFbznWC/fPH3iPFIMS8/IIkRxq1Jh9VVG60SmtsdaMQ==}
+    dependencies:
+      muggle-string: 0.2.2
+    dev: true
+
+  /@volar/vue-language-core@1.2.0:
+    resolution: {integrity: sha512-w7yEiaITh2WzKe6u8ZdeLKCUz43wdmY/OqAmsB/PGDvvhTcVhCJ6f0W/RprZL1IhqH8wALoWiwEh/Wer7ZviMQ==}
+    dependencies:
+      '@volar/language-core': 1.3.0-alpha.0
+      '@volar/source-map': 1.3.0-alpha.0
+      '@vue/compiler-dom': 3.2.47
+      '@vue/compiler-sfc': 3.2.47
+      '@vue/reactivity': 3.2.47
+      '@vue/shared': 3.2.47
+      minimatch: 6.2.0
+      muggle-string: 0.2.2
+      vue-template-compiler: 2.7.14
     dev: true
 
   /@vue/babel-helper-vue-transform-on@1.0.2:
@@ -2470,6 +2514,23 @@ packages:
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
     dev: true
 
+  /changelogen@0.4.1:
+    resolution: {integrity: sha512-p1dJO1Z995odIxdypzAykHIaUu+XnEvwYPSTyKJsbpL82o99sxN1G24tbecoMxTsV4PI+ZId82GJXRL2hhOeJA==}
+    hasBin: true
+    dependencies:
+      c12: 1.2.0
+      consola: 2.15.3
+      convert-gitmoji: 0.1.3
+      execa: 6.1.0
+      mri: 1.2.0
+      node-fetch-native: 1.1.0
+      pkg-types: 1.0.2
+      scule: 1.0.0
+      semver: 7.4.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /character-entities-html4@1.1.4:
     resolution: {integrity: sha512-HRcDxZuZqMx3/a+qrzxdBKBPUpxWEq9xw2OPZ3a/174ihfrQKVsFhqtthBInFy1zZ9GgZyFXOatNujm8M+El3g==}
     dev: true
@@ -2758,6 +2819,10 @@ packages:
       '@babel/types': 7.21.4
     dev: true
 
+  /convert-gitmoji@0.1.3:
+    resolution: {integrity: sha512-t5yxPyI8h8KPvRwrS/sRrfIpT2gJbmBAY0TFokyUBy3PM44RuFRpZwHdACz+GTSPLRLo3s4qsscOMLjHiXBwzw==}
+    dev: true
+
   /convert-source-map@1.9.0:
     resolution: {integrity: sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==}
 
@@ -2957,6 +3022,10 @@ packages:
     engines: {node: '>=6'}
     dependencies:
       time-zone: 1.0.0
+    dev: true
+
+  /de-indent@1.0.2:
+    resolution: {integrity: sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==}
     dev: true
 
   /debug@2.6.9:
@@ -3265,12 +3334,10 @@ packages:
       - bufferutil
       - supports-color
       - utf-8-validate
-    dev: false
 
   /engine.io-parser@5.0.6:
     resolution: {integrity: sha512-tjuoZDMAdEhVnSFleYPCtdL2GXwVTGtNjoeJd9IhIG3C1xs9uwxqRNEu5WpnDZCaozwVlK/nuQhpodhXSIMaxw==}
     engines: {node: '>=10.0.0'}
-    dev: false
 
   /enhanced-resolve@4.5.0:
     resolution: {integrity: sha512-Nv9m36S/vxpsI+Hc4/ZGRs0n9mXqSWGGq49zxb/cJfPAQMbUtttJAlNPS4AQzaBdw/pKskw5bMbekT/Y7W/Wlg==}
@@ -3846,6 +3913,21 @@ packages:
       onetime: 5.1.2
       signal-exit: 3.0.7
       strip-final-newline: 2.0.0
+
+  /execa@6.1.0:
+    resolution: {integrity: sha512-QVWlX2e50heYJcCPG0iWtf8r0xjEYfz/OYLGDYH+IyjWezzPNxz63qNFOu0l4YftGWuizFVZHHs8PrLU5p2IDA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dependencies:
+      cross-spawn: 7.0.3
+      get-stream: 6.0.1
+      human-signals: 3.0.1
+      is-stream: 3.0.0
+      merge-stream: 2.0.0
+      npm-run-path: 5.1.0
+      onetime: 6.0.0
+      signal-exit: 3.0.7
+      strip-final-newline: 3.0.0
+    dev: true
 
   /execa@7.1.1:
     resolution: {integrity: sha512-wH0eMf/UXckdUYnO21+HDztteVv05rq2GXksxT4fCGeHkBhw1DROXh40wcjMcRqDOWE7iPJ4n3M7e2+YFP+76Q==}
@@ -4583,6 +4665,11 @@ packages:
       space-separated-tokens: 2.0.2
     dev: false
 
+  /he@1.2.0:
+    resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
+    hasBin: true
+    dev: true
+
   /hookable@5.5.3:
     resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
 
@@ -4676,6 +4763,11 @@ packages:
   /human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
     engines: {node: '>=10.17.0'}
+
+  /human-signals@3.0.1:
+    resolution: {integrity: sha512-rQLskxnM/5OCldHo+wNXbpVgDn5A17CUoKX+7Sokwaknlq7CdSnphy0W39GU8dw59XiCXmFXDg4fRuckQRKewQ==}
+    engines: {node: '>=12.20.0'}
+    dev: true
 
   /human-signals@4.3.1:
     resolution: {integrity: sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==}
@@ -6107,6 +6199,13 @@ packages:
       brace-expansion: 2.0.1
     dev: true
 
+  /minimatch@6.2.0:
+    resolution: {integrity: sha512-sauLxniAmvnhhRjFwPNnJKaPFYyddAgbYdeUpHULtCT/GhzdCx/MDNy+Y40lBxTQUrMzDE8e0S43Z5uqfO0REg==}
+    engines: {node: '>=10'}
+    dependencies:
+      brace-expansion: 2.0.1
+    dev: true
+
   /minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
     dev: true
@@ -6177,6 +6276,10 @@ packages:
 
   /ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+    dev: true
+
+  /muggle-string@0.2.2:
+    resolution: {integrity: sha512-YVE1mIJ4VpUMqZObFndk9CJu6DBJR/GB13p3tXuNbwD4XExaI5EOuRl6BHeIDxIqXZVxSfAC+y6U1Z/IxCfKUg==}
     dev: true
 
   /mute-stream@1.0.0:
@@ -6420,6 +6523,32 @@ packages:
     hasBin: true
     optionalDependencies:
       fsevents: 2.3.2
+    dev: true
+
+  /nuxt-component-meta@0.5.1(rollup@3.20.2):
+    resolution: {integrity: sha512-vwx5wySyVX+QbFrNb3wLYNMPlADho8E66MO45d5i5fTlEkmhopVpQ9YXwlAvM3pLCPjupxG3R3D5rKpLDeitkw==}
+    dependencies:
+      '@nuxt/kit': 3.4.0(rollup@3.20.2)
+      scule: 1.0.0
+      typescript: 5.0.4
+      vue-component-meta: 1.2.0(typescript@5.0.4)
+    transitivePeerDependencies:
+      - rollup
+      - supports-color
+    dev: true
+
+  /nuxt-config-schema@0.4.5(rollup@3.20.2):
+    resolution: {integrity: sha512-Y5anu5puDfMJfDP7IYjXsn6Dvj262HtjZqa73jCBbFRCc5jnjrs+BEpJJmtPG32ZsqzO2+RL4oTNb3H6IfKZLQ==}
+    dependencies:
+      '@nuxt/kit': 3.4.0(rollup@3.20.2)
+      changelogen: 0.4.1
+      defu: 6.1.2
+      jiti: 1.18.2
+      pathe: 1.1.0
+      untyped: 1.3.2
+    transitivePeerDependencies:
+      - rollup
+      - supports-color
     dev: true
 
   /nuxt@3.4.0(@types/node@18.15.11)(eslint@8.38.0)(rollup@3.20.2)(typescript@5.0.4):
@@ -8140,7 +8269,6 @@ packages:
       - bufferutil
       - supports-color
       - utf-8-validate
-    dev: false
 
   /socket.io-parser@4.2.2:
     resolution: {integrity: sha512-DJtziuKypFkMMHCm2uIshOYC7QaylbtzQwiMYDuCKy3OPkjLzu4B2vAhTlqipRHHzrI0NJeBAizTK7X+6m1jVw==}
@@ -8150,7 +8278,6 @@ packages:
       debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /socks-proxy-agent@5.0.1:
     resolution: {integrity: sha512-vZdmnjb9a2Tz6WEQVIurybSwElwPxMZaIc7PzqbJTrezcKNznv6giT7J7tZDZ1BojVaa1jvO/UiUdhDVB0ACoQ==}
@@ -8675,6 +8802,10 @@ packages:
     resolution: {integrity: sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==}
     dependencies:
       is-typedarray: 1.0.0
+    dev: true
+
+  /typesafe-path@0.2.2:
+    resolution: {integrity: sha512-OJabfkAg1WLZSqJAJ0Z6Sdt3utnbzr/jh+NAHoyWHJe8CMSy79Gm085094M9nvTPy22KzTVn5Zq5mbapCI/hPA==}
     dev: true
 
   /typescript@5.0.4:
@@ -9279,6 +9410,17 @@ packages:
       ufo: 1.1.1
     dev: true
 
+  /vue-component-meta@1.2.0(typescript@5.0.4):
+    resolution: {integrity: sha512-z+/pL4txu5qCULbGHFn6vOlSR1V5gFDGWkD64Z2yLlKtYr0Wlb9oOfWTaXxpSl7R+EiX7JusbTlek0szSYeH1g==}
+    peerDependencies:
+      typescript: '*'
+    dependencies:
+      '@volar/language-core': 1.3.0-alpha.0
+      '@volar/vue-language-core': 1.2.0
+      typesafe-path: 0.2.2
+      typescript: 5.0.4
+    dev: true
+
   /vue-devtools-stub@0.1.0:
     resolution: {integrity: sha512-RutnB7X8c5hjq39NceArgXg28WZtZpGc3+J16ljMiYnFhKvd8hITxSWQSQ5bvldxMDU6gG5mkxl1MTQLXckVSQ==}
     dev: true
@@ -9354,6 +9496,13 @@ packages:
     dependencies:
       '@vue/devtools-api': 6.5.0
       vue: 3.2.47
+    dev: true
+
+  /vue-template-compiler@2.7.14:
+    resolution: {integrity: sha512-zyA5Y3ArvVG0NacJDkkzJuPQDF8RFeRlzV2vLeSnhSpieO6LK2OVbdLPi5MPPs09Ii+gMO8nY4S3iKQxBxDmWQ==}
+    dependencies:
+      de-indent: 1.0.2
+      he: 1.2.0
     dev: true
 
   /vue@3.2.47:
@@ -9532,7 +9681,6 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
-    dev: false
 
   /ws@8.13.0:
     resolution: {integrity: sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==}
@@ -9560,7 +9708,6 @@ packages:
   /xmlhttprequest-ssl@2.0.0:
     resolution: {integrity: sha512-QKxVRxiRACQcVuQEYFsI1hhkrMlrXHPegbbd1yn9UHOmRxY+si12nQYzri3vbzt8VdTTRviqcKxcyllFas5z2A==}
     engines: {node: '>=0.4.0'}
-    dev: false
 
   /xregexp@2.0.0:
     resolution: {integrity: sha512-xl/50/Cf32VsGq/1R8jJE5ajH1yMCQkpmoS10QbFZWl2Oor4H0Me64Pu2yxvsRWK3m6soJbmGfzSR7BYmDcWAA==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,7 +119,7 @@ devDependencies:
     version: 3.4.1(rollup@3.20.4)
   '@nuxthq/studio':
     specifier: ^0.10.1
-    version: 0.10.1(rollup@3.20.2)
+    version: 0.10.1(rollup@3.20.4)
   '@nuxtjs/eslint-config-typescript':
     specifier: latest
     version: 12.0.0(eslint@8.38.0)(typescript@5.0.4)
@@ -998,13 +998,13 @@ packages:
       - vue-tsc
     dev: true
 
-  /@nuxthq/studio@0.10.1(rollup@3.20.2):
+  /@nuxthq/studio@0.10.1(rollup@3.20.4):
     resolution: {integrity: sha512-EWzk3HkE6QuiqVxqZ7jsAc/8GxSDKRO+jnTBv1wlOAvPKJNPsHrlYGP8EyR6S1NaB3pQTJ9iVBhmskAtrKIsYQ==}
     dependencies:
-      '@nuxt/kit': 3.4.0(rollup@3.20.2)
+      '@nuxt/kit': 3.4.1(rollup@3.20.4)
       defu: 6.1.2
-      nuxt-component-meta: 0.5.1(rollup@3.20.2)
-      nuxt-config-schema: 0.4.5(rollup@3.20.2)
+      nuxt-component-meta: 0.5.1(rollup@3.20.4)
+      nuxt-config-schema: 0.4.5(rollup@3.20.4)
       socket.io-client: 4.6.1
       ufo: 1.1.1
     transitivePeerDependencies:
@@ -2779,6 +2779,10 @@ packages:
       unique-string: 3.0.0
       write-file-atomic: 3.0.3
       xdg-basedir: 5.1.0
+    dev: true
+
+  /consola@2.15.3:
+    resolution: {integrity: sha512-9vAdYbHj6x2fLKC4+oPH0kFzY/orMZyG2Aj+kNylHxKGJ/Ed4dpNyAQYwJOdqO4zdM7XpVHmyejQDcQHrnuXbw==}
     dev: true
 
   /consola@3.0.2:
@@ -6501,10 +6505,10 @@ packages:
       fsevents: 2.3.2
     dev: true
 
-  /nuxt-component-meta@0.5.1(rollup@3.20.2):
+  /nuxt-component-meta@0.5.1(rollup@3.20.4):
     resolution: {integrity: sha512-vwx5wySyVX+QbFrNb3wLYNMPlADho8E66MO45d5i5fTlEkmhopVpQ9YXwlAvM3pLCPjupxG3R3D5rKpLDeitkw==}
     dependencies:
-      '@nuxt/kit': 3.4.0(rollup@3.20.2)
+      '@nuxt/kit': 3.4.1(rollup@3.20.4)
       scule: 1.0.0
       typescript: 5.0.4
       vue-component-meta: 1.2.0(typescript@5.0.4)
@@ -6513,10 +6517,10 @@ packages:
       - supports-color
     dev: true
 
-  /nuxt-config-schema@0.4.5(rollup@3.20.2):
+  /nuxt-config-schema@0.4.5(rollup@3.20.4):
     resolution: {integrity: sha512-Y5anu5puDfMJfDP7IYjXsn6Dvj262HtjZqa73jCBbFRCc5jnjrs+BEpJJmtPG32ZsqzO2+RL4oTNb3H6IfKZLQ==}
     dependencies:
-      '@nuxt/kit': 3.4.0(rollup@3.20.2)
+      '@nuxt/kit': 3.4.1(rollup@3.20.4)
       changelogen: 0.4.1
       defu: 6.1.2
       jiti: 1.18.2
@@ -6854,7 +6858,7 @@ packages:
       got: 12.6.0
       registry-auth-token: 5.0.2
       registry-url: 6.0.1
-      semver: 7.3.8
+      semver: 7.4.0
     dev: true
 
   /param-case@3.0.4:
@@ -8061,7 +8065,7 @@ packages:
     resolution: {integrity: sha512-0Ju4+6A8iOnpL/Thra7dZsSlOHYAHIeMxfhWQRI1/VLcT3WDBZKKtQt/QkBOsiIN9ZpuvHE6cGZ0x4glCMmfiA==}
     engines: {node: '>=12'}
     dependencies:
-      semver: 7.3.8
+      semver: 7.4.0
     dev: true
 
   /semver@5.7.1:
@@ -9074,7 +9078,7 @@ packages:
       is-yarn-global: 0.4.1
       latest-version: 7.0.0
       pupa: 3.1.0
-      semver: 7.3.8
+      semver: 7.4.0
       semver-diff: 4.0.0
       xdg-basedir: 5.1.0
     dev: true

--- a/src/module.ts
+++ b/src/module.ts
@@ -402,6 +402,7 @@ export default defineNuxtModule<ModuleOptions>({
       { name: 'queryContent', as: 'queryContent', from: resolveRuntimeModule('./composables/query') },
       { name: 'useContentHelpers', as: 'useContentHelpers', from: resolveRuntimeModule('./composables/helpers') },
       { name: 'useContentHead', as: 'useContentHead', from: resolveRuntimeModule('./composables/head') },
+      { name: 'useContentPreview', as: 'useContentPreview', from: resolveRuntimeModule('./composables/preview') },
       { name: 'withContentBase', as: 'withContentBase', from: resolveRuntimeModule('./composables/utils') },
       { name: 'useUnwrap', as: 'useUnwrap', from: resolveRuntimeModule('./composables/utils') }
     ])

--- a/src/runtime/components/ContentRendererMarkdown.vue
+++ b/src/runtime/components/ContentRendererMarkdown.vue
@@ -7,6 +7,7 @@ import type { VNode, ConcreteComponent } from 'vue'
 import { useRuntimeConfig, useRoute } from '#app'
 import htmlTags from '../utils/html-tags'
 import type { MarkdownNode, ParsedContent, ParsedContentMeta } from '../types'
+import { useContentPreview } from '../composables/preview'
 
 type CreateElement = typeof h
 
@@ -54,6 +55,7 @@ export default defineComponent({
   },
   async setup (props) {
     const { content: { tags = {} } } = useRuntimeConfig().public
+    const debug = process.dev || useContentPreview().isEnabled()
 
     await resolveContentComponents(props.value.body, {
       tags: {
@@ -63,10 +65,10 @@ export default defineComponent({
       }
     })
 
-    return { tags }
+    return { tags, debug }
   },
   render (ctx: any) {
-    const { tags, tag, value, components } = ctx
+    const { tags, tag, value, components, debug } = ctx
 
     if (!value) {
       return null
@@ -97,7 +99,11 @@ export default defineComponent({
     // Return Vue component
     return h(
       component as any,
-      { ...meta.component?.props, ...this.$attrs },
+      {
+        ...meta.component?.props,
+        ...this.$attrs,
+        'data-content-id': debug ? value._id : undefined
+      },
       renderSlots(body, h, meta, meta)
     )
   }

--- a/src/runtime/composables/navigation.ts
+++ b/src/runtime/composables/navigation.ts
@@ -1,10 +1,11 @@
 import { hash } from 'ohash'
-import { useRuntimeConfig, useCookie } from '#app'
+import { useRuntimeConfig } from '#app'
 import type { NavItem, QueryBuilder, QueryBuilderParams } from '../types'
 import { encodeQueryParams } from '../utils/query'
 import { jsonStringify } from '../utils/json'
 import { addPrerenderPath, shouldUseClientDB, withContentBase } from './utils'
 import { queryContent } from './query'
+import { useContentPreview } from './preview'
 
 export const fetchContentNavigation = async (queryBuilder?: QueryBuilder | QueryBuilderParams): Promise<Array<NavItem>> => {
   const { content } = useRuntimeConfig().public
@@ -38,7 +39,7 @@ export const fetchContentNavigation = async (queryBuilder?: QueryBuilder | Query
       ? undefined
       : {
           _params: jsonStringify(params),
-          previewToken: useCookie('previewToken').value
+          previewToken: useContentPreview().getPreviewToken()
         }
   })
 

--- a/src/runtime/composables/preview.ts
+++ b/src/runtime/composables/preview.ts
@@ -1,0 +1,57 @@
+import { useCookie, useRoute } from '#imports'
+
+let showWarning = true
+
+export const useContentPreview = () => {
+  const getPreviewToken = () => {
+    return useCookie('previewToken').value ||
+    (process.client && sessionStorage.getItem('previewToken')) ||
+    undefined
+  }
+
+  const setPreviewToken = (token: string | undefined) => {
+    useCookie('previewToken').value = token
+
+    useRoute().query.preview = token || ''
+
+    if (process.client) {
+      if (token) {
+        sessionStorage.setItem('previewToken', token)
+      } else {
+        sessionStorage.removeItem('previewToken')
+      }
+
+      window.location.reload()
+    }
+  }
+
+  const isEnabled = () => {
+    const query = useRoute().query
+    // Disable clientDB when `?preview` is set in query, and it has falsy value
+    if (Object.prototype.hasOwnProperty.call(query, 'preview') && !query.preview) {
+      return false
+    }
+
+    // Enable clientDB when preview mode is enabled
+    if (query.preview || useCookie('previewToken').value) {
+      if (process.dev && showWarning) {
+        // eslint-disable-next-line no-console
+        console.warn('[content] Client DB enabled since a preview token is set (either in query or cookie).')
+        showWarning = false
+      }
+      return true
+    }
+
+    if (process.client && sessionStorage.getItem('previewToken')) {
+      return true
+    }
+
+    return false
+  }
+
+  return {
+    isEnabled,
+    getPreviewToken,
+    setPreviewToken
+  }
+}

--- a/src/runtime/composables/query.ts
+++ b/src/runtime/composables/query.ts
@@ -1,11 +1,12 @@
 import { joinURL, withLeadingSlash, withoutTrailingSlash } from 'ufo'
 import { hash } from 'ohash'
-import { useRuntimeConfig, useCookie } from '#app'
+import { useRuntimeConfig } from '#app'
 import { createQuery } from '../query/query'
 import type { ParsedContent, QueryBuilder, QueryBuilderParams } from '../types'
 import { encodeQueryParams } from '../utils/query'
 import { jsonStringify } from '../utils/json'
 import { addPrerenderPath, shouldUseClientDB, withContentBase } from './utils'
+import { useContentPreview } from './preview'
 
 /**
  * Query fetcher
@@ -36,7 +37,7 @@ export const createQueryFetch = <T = ParsedContent>() => async (query: QueryBuil
       ? undefined
       : {
           _params: jsonStringify(params),
-          previewToken: useCookie('previewToken').value
+          previewToken: useContentPreview().getPreviewToken()
         }
   })
 

--- a/src/runtime/composables/utils.ts
+++ b/src/runtime/composables/utils.ts
@@ -1,7 +1,8 @@
 import { withBase } from 'ufo'
-import { useRuntimeConfig, useRequestEvent, useCookie, useRoute } from '#app'
+import { useRuntimeConfig, useRequestEvent } from '#app'
 import { unwrap, flatUnwrap } from '../markdown-parser/utils/node'
 import type { useContent } from './content'
+import { useContentPreview } from './preview'
 
 export const withContentBase = (url: string) => withBase(url, useRuntimeConfig().public.content.api.baseURL)
 
@@ -34,10 +35,10 @@ export const navigationDisabled = () => {
 
 export const addPrerenderPath = (path: string) => {
   const event = useRequestEvent()
-  event.res.setHeader(
+  event.node.res.setHeader(
     'x-nitro-prerender',
     [
-      event.res.getHeader('x-nitro-prerender'),
+      event.node.res.getHeader('x-nitro-prerender'),
       path
     ].filter(Boolean).join(',')
   )
@@ -48,18 +49,5 @@ export const shouldUseClientDB = () => {
   if (process.server) { return false }
   if (experimental.clientDB) { return true }
 
-  const query = useRoute().query
-  // Disable clientDB when `?preview` is set in query, and it has falsy value
-  if (Object.prototype.hasOwnProperty.call(query, 'preview') && !query.preview) {
-    return false
-  }
-  // Enable clientDB when preview mode is enabled
-  if (query.preview || useCookie('previewToken').value) {
-    if (process.dev) {
-      console.warn('[content] Client DB enabled since a preview token is set (either in query or cookie).')
-    }
-    return true
-  }
-
-  return false
+  return useContentPreview().isEnabled()
 }

--- a/src/runtime/server/navigation.ts
+++ b/src/runtime/server/navigation.ts
@@ -9,7 +9,7 @@ type PrivateNavItem = NavItem & { path?: string }
  */
 export function createNav (contents: ParsedContentMeta[], configs: Record<string, ParsedContentMeta>) {
   // Get navigation config from runtimeConfig
-  const { navigation } = useRuntimeConfig().content
+  const { navigation } = useRuntimeConfig().public.content
 
   // Navigation fields picker
   const pickNavigationFields = (content: ParsedContentMeta) => ({


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
- Safari blocks storing/accessing cookies inside iframe. ([see](https://webkit.org/blog/8124/introducing-storage-access-api/)) With this PR, module supports session storage as secondary storage to look for preview token.
- `<ContentRendererMarkdown>` adds `data-content-id` attribute to its root element
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
