### PR TITLE
fix(link): Remove hash before checking if ending by '.md'

### DIFF
--- a/src/runtime/markdown-parser/handler/link.ts
+++ b/src/runtime/markdown-parser/handler/link.ts
@@ -29,8 +29,10 @@ export default function link (h: H, node: Node) {
 }
 
 function normalizeLink (link: string) {
-  if (link.endsWith('.md') && (isRelative(link) || (!/^https?/.test(link) && !link.startsWith('/')))) {
-    return generatePath(link.replace(/\.md$/, ''), { forceLeadingSlash: false })
+  const match = link.match(/#.+$/)
+  const hash = match ? match[0] : ''
+  if (link.replace(/#.+$/, '').endsWith('.md') && (isRelative(link) || (!/^https?/.test(link) && !link.startsWith('/')))) {
+    return (generatePath(link.replace('.md' + hash, ''), { forceLeadingSlash: false }) + hash)
   } else {
     return link
   }

--- a/test/features/parser-markdown.ts
+++ b/test/features/parser-markdown.ts
@@ -183,7 +183,8 @@ export const testMarkdownParser = () => {
             '[link1](./../01.foo.md)',
             '[link1](../01.foo.md)',
             '[link1](../../01.foo.md)',
-            '[link1](../../01.foo#bar.md)',
+            '[link1](../../01.foo.md#bar)',
+            '[link1](../../01.foo/file.md#bar)',
             '[link1](../../01.foo.draft.md)',
             '[link1](../../_foo.draft.md)'
           ].join('\n')
@@ -200,7 +201,8 @@ export const testMarkdownParser = () => {
       expect(nodes.shift().props.href).toEqual('./../foo')
       expect(nodes.shift().props.href).toEqual('../foo')
       expect(nodes.shift().props.href).toEqual('../../foo')
-      expect(nodes.shift().props.href).toEqual('../../foobar')
+      expect(nodes.shift().props.href).toEqual('../../foo#bar')
+      expect(nodes.shift().props.href).toEqual('../../foo/file#bar')
       expect(nodes.shift().props.href).toEqual('../../foo')
       expect(nodes.shift().props.href).toEqual('../../_foo')
     })


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

Does not know if it's a bug fix or an enhancement.

### 📚 Description

The PR consists of allowing hash in a relative title.

Example of an URL used in our md files : 
`../docs/04.developer-guide/04.inputs.md#set-inputs-with-curl`

Without the hash part, this works fine and the URL is well interpreted, but we notice that having a hash will break the functionality.

In fact, the method `normalizeLink()` works only with relative files that end with `.md`, so we added hash handling in this function, which is just a regex that removes hash, and set it back before returning.


### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly. -> Did not find any documentation about this.
