### PR TITLE
docs: add example of additional sorting options for queryContent

### DIFF
--- a/docs/content/4.api/2.composables/1.query-content.md
+++ b/docs/content/4.api/2.composables/1.query-content.md
@@ -87,7 +87,7 @@ const articles = await queryContent('articles')
 For example, to sort a list of people from youngest to oldest:
 ```ts
 const people = await queryContent('people')
-  .sort({ age: 1, $numeric: 1 })
+  .sort({ age: 1, $numeric: true })
   .find()
 ```
 

--- a/docs/content/4.api/2.composables/1.query-content.md
+++ b/docs/content/4.api/2.composables/1.query-content.md
@@ -78,11 +78,18 @@ const articles = await queryContent('articles')
 
 ```
 
-> `sort()`{lang="ts"} method does **case-sensitive** sort by default. There is some magical options you can pass to sort options to change sort behavior, like sorting **case-insensitive**.
+> `sort()`{lang="ts"} method does **case-sensitive, alphabetical** sort by default. There is some magical options you can pass to sort options to change sort behavior, like sorting **case-insensitive** or **numerically rather than alphabetically**.
 >
 > - `$sensitivity`{lang=ts}: Change case sensitivity. Like using `$sensitivity: 'base'`{lang=ts} for case-insensitive sort
 > - `$numeric`{lang=ts}: Boolean whether numeric collation should be used, such that `"1" < "2" < "10"`.
 > - `$caseFirst`{lang=ts}: Whether upper case or lower case should sort first.
+
+For example, to sort a list of people from youngest to oldest:
+```ts
+const people = await queryContent('people')
+  .sort({ age: 1, $numeric: 1 })
+  .find()
+```
 
 These options are given to [Intl.Collator()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Collator/Collator#parameters).
 


### PR DESCRIPTION
Suggesting an example to add to demonstrate how to use the additional sorting options for queryContent(). The previous wording was not clear

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
