### PR TITLE
fix(code-block): pass language as class name

### DIFF
--- a/src/runtime/markdown-parser/handler/code.ts
+++ b/src/runtime/markdown-parser/handler/code.ts
@@ -23,7 +23,8 @@ export default (h: H, node: Node) => {
       filename,
       highlights,
       meta: node.meta,
-      code
+      code,
+      className: [`language-${language}`]
     },
     [h(node, 'pre', {}, [h(node, 'code', { __ignoreMap: '' }, [u('text', code)])])]
   )


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

some syntax highlighters and other packages which transform markdown codeblocks (e.g. mermaid) expect the language of the code block to be passed via class attribute. this fixed that.

for context: i ran into this issue trying to add [`rehype-mermaidjs`](https://github.com/remcohaszing/rehype-mermaidjs) to `rehypePlugins`.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
