### PR TITLE
docs: remove outdated description

### DIFF
--- a/docs/content/3.guide/2.displaying/1.rendering.md
+++ b/docs/content/3.guide/2.displaying/1.rendering.md
@@ -39,8 +39,6 @@ You can use the `<ContentDoc>` component to render a specific document by specif
 </template>
 ```
 
-Note that no head management will be done when the `path` is specified.
-
 Take a look at the [Hello world](/examples/essentials/hello-world) example to see it in action.
 
 ::alert{type="info"}


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
`<ContentDoc />` will perform head management regardless of whether the path parameter is passed in, unless the `head` prop is specified as `false`.
Update old documents according to the correct behaviour.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
