### PR TITLE
docs: reorder document-driven page slots components description

### DIFF
--- a/docs/content/3.guide/1.writing/7.document-driven.md
+++ b/docs/content/3.guide/1.writing/7.document-driven.md
@@ -62,6 +62,8 @@ To do so, you only have to create a component with the same name in your project
 
 - `<DocumentDrivenNotFound />`{lang=html}
 
+This component will be shown when no page has been found for the current URL.
+
 ```html [components/DocumentDrivenNotFound.vue]
 <template>
   <h1>Page not found</h1>
@@ -77,8 +79,6 @@ This component will be shown when there is no content for the current page, but 
   <h1>This page is empty</h1>
 </template>
 ```
-
-This component will be shown when no page has been found for the current URL.
 
 ## Layout binding
 


### PR DESCRIPTION
### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Update document-driven page in documentation to reorder description to their respective page slots components (specifically `<DocumentDrivenNotFound />`: "This component will be shown when no page has been found for the current URL.").

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
