### PR TITLE
fix: replace crlf line endings with lf

### DIFF
--- a/src/runtime/server/storage.ts
+++ b/src/runtime/server/storage.ts
@@ -179,7 +179,7 @@ export async function parseContent (id: string, content: string, opts: ParseCont
   )
 
   // Call hook before parsing the file
-  const file = { _id: id, body: content.replace(/\r\n|\r/g, '\n') }
+  const file = { _id: id, body: typeof content === 'string' ? content.replace(/\r\n|\r/g, '\n') : content }
   await nitroApp.hooks.callHook('content:file:beforeParse', file)
 
   const result = await transformContent(id, file.body, options)

--- a/src/runtime/server/storage.ts
+++ b/src/runtime/server/storage.ts
@@ -179,7 +179,7 @@ export async function parseContent (id: string, content: string, opts: ParseCont
   )
 
   // Call hook before parsing the file
-  const file = { _id: id, body: content }
+  const file = { _id: id, body: content.replace(/\r\n|\r/g, '\n') }
   await nitroApp.hooks.callHook('content:file:beforeParse', file)
 
   const result = await transformContent(id, file.body, options)


### PR DESCRIPTION
### 🔗 Linked issue

resolves #2000 

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Replaces CRLF (or CR) line endings with LF to prevent a `vue` hydration mismatch
`\r\n || \r => \n`

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
