### PR TITLE
fix: use `consola.withTag` instead of `kit.useLogger`

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,11 +8,12 @@ import httpDriver from 'unstorage/drivers/http'
 // @ts-ignore
 import githubDriver from 'unstorage/drivers/github'
 import { WebSocketServer } from 'ws'
-import { useLogger } from '@nuxt/kit'
+import { consola } from 'consola'
+
 import type { ModuleOptions, MountOptions } from './module'
 import type { MarkdownPlugin } from './runtime/types'
 
-export const logger = useLogger('@nuxt/content')
+export const logger = consola.withTag('@nuxt/content')
 
 /**
  * Internal version that represents cache format.


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
