### PR TITLE
fix: allow ] in filename code block

### DIFF
--- a/docs/content/2.get-started.md
+++ b/docs/content/2.get-started.md
@@ -123,7 +123,7 @@ The module automatically loads and parses them.
 
 To render content pages, add a [catch-all route](https://nuxt.com/docs/guide/directory-structure/pages/#catch-all-route) using the `ContentDoc` component:
 
-```vue [pages/[...slug].vue]
+```vue [pages/[...slug\\].vue]
 <template>
   <main>
     <ContentDoc />

--- a/docs/content/3.guide/2.displaying/1.rendering.md
+++ b/docs/content/3.guide/2.displaying/1.rendering.md
@@ -19,7 +19,7 @@ The fetching endpoint defaults to the current route (`$route.path`). An explicit
 
 Create a [catch all route](https://nuxt.com/docs/guide/directory-structure/pages/#catch-all-route) named `pages/[...slug].vue` and add the component:
 
-```vue [pages/[...slug].vue]
+```vue [pages/[...slug\\].vue]
 <template>
   <main>
     <ContentDoc />

--- a/docs/content/4.api/1.components/1.content-doc.md
+++ b/docs/content/4.api/1.components/1.content-doc.md
@@ -73,7 +73,7 @@ The `empty`{lang=ts} slot can be used to display a default content before render
 
 ### Default
 
-```html [pages/[...slug.vue\\]]
+```html [pages/[...slug\\].vue]
 <template>
   <main>
     <!-- Similar to <ContentDoc :path="$route.path" /> -->

--- a/docs/content/4.api/1.components/1.content-doc.md
+++ b/docs/content/4.api/1.components/1.content-doc.md
@@ -73,7 +73,7 @@ The `empty`{lang=ts} slot can be used to display a default content before render
 
 ### Default
 
-```html [pages/[...slug.vue]]
+```html [pages/[...slug.vue\\]]
 <template>
   <main>
     <!-- Similar to <ContentDoc :path="$route.path" /> -->

--- a/docs/content/4.api/1.components/2.content-renderer.md
+++ b/docs/content/4.api/1.components/2.content-renderer.md
@@ -27,7 +27,7 @@ Other types will currently be passed to default slot via `v-slot="{ data }"` or 
 
 The `default`{lang=ts} slot can be used to render the content via `v-slot="{ data }"` syntax.
 
-```html [pages/[...slug.vue]]
+```html [pages/[...slug.vue\\]]
 <script setup lang="ts">
 const { data } = await useAsyncData('page-data', () => queryContent('/hello').findOne())
 </script>
@@ -44,7 +44,7 @@ const { data } = await useAsyncData('page-data', () => queryContent('/hello').fi
 
 The `empty`{lang=ts} slot can be used to display a default content when the document is empty:
 
-```html [pages/[...slug.vue]]
+```html [pages/[...slug.vue\\]]
 <script setup lang="ts">
 const { data } = await useAsyncData('page-data', () => queryContent('/hello').findOne())
 </script>
@@ -63,7 +63,7 @@ const { data } = await useAsyncData('page-data', () => queryContent('/hello').fi
 ::alert{type="info"}
 Note that when you use default slot and `<ContentRendererMarkdown>` in your template you need to pass `components` to `<ContentRendererMarkdown>`.
 
-```html [pages/[...slug].vue]
+```html [pages/[...slug\\].vue]
 <script setup lang="ts">
 const { data } = await useAsyncData('page-data', () => queryContent('/hello').findOne())
 

--- a/docs/content/4.api/1.components/2.content-renderer.md
+++ b/docs/content/4.api/1.components/2.content-renderer.md
@@ -27,7 +27,7 @@ Other types will currently be passed to default slot via `v-slot="{ data }"` or 
 
 The `default`{lang=ts} slot can be used to render the content via `v-slot="{ data }"` syntax.
 
-```html [pages/[...slug.vue\\]]
+```html [pages/[...slug\\].vue]
 <script setup lang="ts">
 const { data } = await useAsyncData('page-data', () => queryContent('/hello').findOne())
 </script>
@@ -44,7 +44,7 @@ const { data } = await useAsyncData('page-data', () => queryContent('/hello').fi
 
 The `empty`{lang=ts} slot can be used to display a default content when the document is empty:
 
-```html [pages/[...slug.vue\\]]
+```html [pages/[...slug\\].vue]
 <script setup lang="ts">
 const { data } = await useAsyncData('page-data', () => queryContent('/hello').findOne())
 </script>

--- a/docs/content/4.api/1.components/4.content-query.md
+++ b/docs/content/4.api/1.components/4.content-query.md
@@ -39,7 +39,7 @@ The `<ContentQuery>`{lang=html} component fetches a document and gives access to
 
 The `default`{lang=ts} slot can be used to render the content via `v-slot="{ data }"`{lang=html} syntax.
 
-```html [pages/[...slug.vue]]
+```html [pages/[...slug.vue\\]]
 <!-- Similar to <ContentDoc :path="$route.path" /> -->
 <template>
   <main>
@@ -63,7 +63,7 @@ The `not-found`{lang=ts} slot can be used to display a default content before re
 <template>
   <main>
     <ContentQuery path="/about/authors" :where="{ type: 'csv' }">
-      <template #default="{ data }"> 
+      <template #default="{ data }">
         <ul>
           <li v-for="author of data" :key="author.name">
             {{ author.name }}

--- a/docs/content/4.api/1.components/4.content-query.md
+++ b/docs/content/4.api/1.components/4.content-query.md
@@ -39,7 +39,7 @@ The `<ContentQuery>`{lang=html} component fetches a document and gives access to
 
 The `default`{lang=ts} slot can be used to render the content via `v-slot="{ data }"`{lang=html} syntax.
 
-```html [pages/[...slug.vue\\]]
+```html [pages/[...slug\\].vue]
 <!-- Similar to <ContentDoc :path="$route.path" /> -->
 <template>
   <main>

--- a/docs/content/4.api/1.components/7.prose.md
+++ b/docs/content/4.api/1.components/7.prose.md
@@ -71,9 +71,9 @@ Component properties will be:
 Check out the [highlight options](/api/configuration#highlight) for more about the syntax highlighting.
 
 ::alert{type="warning"}
-One limitation is you can't put `[` or `]` in the meta info. Otherwise, it will break the parsing.
+If you want to use `]` in the filename, you need to escape it with 2 backslashes: `\\]`. This is necessary since JS will automatically escape the backslash in a string so `\\]` will be resolved as `\]`.
 
-This is due to how code block header to allow `[` and `]` in the filename.
+Internally, a regex is used to extract filename.
 ::
 
 ## `ProseCodeInline`

--- a/docs/content/4.api/1.components/7.prose.md
+++ b/docs/content/4.api/1.components/7.prose.md
@@ -70,6 +70,12 @@ Component properties will be:
 
 Check out the [highlight options](/api/configuration#highlight) for more about the syntax highlighting.
 
+::alert{type="warning"}
+One limitation is you can't put `[` or `]` in the meta info. Otherwise, it will break the parsing.
+
+This is due to how code block header to allow `[` and `]` in the filename.
+::
+
 ## `ProseCodeInline`
 
 [:icon{name="fa-brands:github" class="inline -mt-1 w-6"} Source](https://github.com/nuxt/content/tree/main/src/runtime/components/Prose/ProseCodeInline.vue)

--- a/docs/content/4.api/1.components/7.prose.md
+++ b/docs/content/4.api/1.components/7.prose.md
@@ -71,9 +71,7 @@ Component properties will be:
 Check out the [highlight options](/api/configuration#highlight) for more about the syntax highlighting.
 
 ::alert{type="warning"}
-If you want to use `]` in the filename, you need to escape it with 2 backslashes: `\\]`. This is necessary since JS will automatically escape the backslash in a string so `\\]` will be resolved as `\]`.
-
-Internally, a regex is used to extract filename.
+If you want to use `]` in the filename, you need to escape it with 2 backslashes: `\\]`. This is necessary since JS will automatically escape the backslash in a string so `\]` will be resolved as `]` breaking our regex.
 ::
 
 ## `ProseCodeInline`

--- a/docs/content/4.api/2.composables/4.use-document-driven.md
+++ b/docs/content/4.api/2.composables/4.use-document-driven.md
@@ -34,7 +34,7 @@ const {
 
 Rendering the current page becomes a bliss with this composable:
 
-```vue [pages/[...slug].vue]
+```vue [pages/[...slug\\].vue]
 <script setup lang="ts">
 const { page } = useContent()
 </script>

--- a/docs/content/6.blog/1.announcing-v2.md
+++ b/docs/content/6.blog/1.announcing-v2.md
@@ -15,7 +15,7 @@ authors:
   - name: "Ahad Birang"
     avatarUrl: https://pbs.twimg.com/profile_images/780374165136244736/x5HfdWA1_400x400.jpg
     link: https://twitter.com/a_birang
-  - name: "Clément Ollivier" 
+  - name: "Clément Ollivier"
     avatarUrl: https://pbs.twimg.com/profile_images/1370286658432724996/ZMSDzzIi_400x400.jpg
     link: https://twitter.com/clemcodes
 tags:
@@ -63,7 +63,7 @@ https://content.nuxtjs.org
 
 Create a `pages/[...slug].vue` file with the [`<ContentDoc>`](/guide/displaying/rendering) component inside:
 
-```vue [pages/[...slug].vue]
+```vue [pages/[...slug\\].vue]
 <template>
   <ContentDoc />
 </template>

--- a/playground/basic/components/content/ProseCode.vue
+++ b/playground/basic/components/content/ProseCode.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-const props = defineProps<{
+defineProps<{
     code: string,
     language?: string,
     filename?: string,

--- a/playground/basic/components/content/ProseCode.vue
+++ b/playground/basic/components/content/ProseCode.vue
@@ -6,8 +6,6 @@ const props = defineProps<{
     highlights: number[],
     meta?: string
   }>()
-
-console.log(props)
 </script>
 
 <template>

--- a/playground/basic/components/content/ProseCode.vue
+++ b/playground/basic/components/content/ProseCode.vue
@@ -1,11 +1,13 @@
 <script lang="ts" setup>
-defineProps<{
+const props = defineProps<{
     code: string,
     language?: string,
     filename?: string,
     highlights: number[],
     meta?: string
   }>()
+
+console.log(props)
 </script>
 
 <template>

--- a/playground/basic/components/content/ProseCode.vue
+++ b/playground/basic/components/content/ProseCode.vue
@@ -9,7 +9,22 @@ defineProps<{
 </script>
 
 <template>
-  <span v-if="filename"> {{ filename }} </span>
+  <div v-if="language">
+    language <br>
+    {{ language }}
+  </div>
+  <div v-if="filename">
+    filename <br>
+    {{ filename }}
+  </div>
+  <div v-if="highlights">
+    highlights <br>
+    {{ highlights }}
+  </div>
+  <div v-if="meta">
+    meta <br>
+    {{ meta }}
+  </div>
   <slot />
 </template>
 

--- a/playground/basic/components/content/ProseCode.vue
+++ b/playground/basic/components/content/ProseCode.vue
@@ -1,0 +1,21 @@
+<script lang="ts" setup>
+defineProps<{
+    code: string,
+    language?: string,
+    filename?: string,
+    highlights: number[],
+    meta?: string
+  }>()
+</script>
+
+<template>
+  <span v-if="filename"> {{ filename }} </span>
+  <slot />
+</template>
+
+<style>
+pre code .line {
+  display: block;
+  min-height: 1rem;
+}
+</style>

--- a/playground/basic/content/1.real-content/content.md
+++ b/playground/basic/content/1.real-content/content.md
@@ -35,7 +35,7 @@ export default defineNuxtConfig({
 
 Render any document content.
 
-```vue [pages/[...slug].vue]
+```vue [pages/[...slug\\].vue]
 <script setup>
 const route = useRoute()
 const { data } = await useAsyncData(`doc-${route.path}`, () => queryContent(route.path).findOne())

--- a/playground/basic/content/2.features/3.mdc-highlighter.md
+++ b/playground/basic/content/2.features/3.mdc-highlighter.md
@@ -4,7 +4,7 @@ title: title
 array:
 - item
 - itemKey: itemValue
-object: 
+object:
  name: object
  version: 1
 string: "string"

--- a/playground/basic/content/2.features/8.custom-prose.md
+++ b/playground/basic/content/2.features/8.custom-prose.md
@@ -1,4 +1,46 @@
-```vue [[...page].vue]
+```vue [[...page].vue]{1} title="Custom Prose"
+<template>
+  <div>
+    <h1>Custom Prose</h1>
+  </div>
+</template>
+```
+```vue [[...page].vue] title="Custom Prose"
+<template>
+  <div>
+    <h1>Custom Prose</h1>
+  </div>
+</template>
+```
+```vue [[...page].vue]{1}
+<template>
+  <div>
+    <h1>Custom Prose</h1>
+  </div>
+</template>
+```
+```vue title="Custom Prose"
+<template>
+  <div>
+    <h1>Custom Prose</h1>
+  </div>
+</template>
+```
+```vue [file.js] {2-4}title="Custom Prose"
+<template>
+  <div>
+    <h1>Custom Prose</h1>
+  </div>
+</template>
+```
+```[[...page].vue] {4-6,7} other code block info
+<template>
+  <div>
+    <h1>Custom Prose</h1>
+  </div>
+</template>
+```
+```[] {4-6,7} other code block info
 <template>
   <div>
     <h1>Custom Prose</h1>

--- a/playground/basic/content/2.features/8.custom-prose.md
+++ b/playground/basic/content/2.features/8.custom-prose.md
@@ -1,0 +1,7 @@
+```vue [[...page].vue]
+<template>
+  <div>
+    <h1>Custom Prose</h1>
+  </div>
+</template>
+```

--- a/playground/basic/content/2.features/8.custom-prose.md
+++ b/playground/basic/content/2.features/8.custom-prose.md
@@ -33,7 +33,7 @@
   </div>
 </template>
 ```
-```[[...page\\].vue] {4-6,7} other code block info
+```ts[[...page\\].vue] {4-6,7} other code block info
 <template>
   <div>
     <h1>Custom Prose</h1>

--- a/playground/basic/content/2.features/8.custom-prose.md
+++ b/playground/basic/content/2.features/8.custom-prose.md
@@ -1,18 +1,18 @@
-```vue [[...page].vue]{1} title="Custom Prose"
+```vue [[...page\\].vue]{1} title="Custom Prose"
 <template>
   <div>
     <h1>Custom Prose</h1>
   </div>
 </template>
 ```
-```vue [[...page].vue] title="Custom Prose"
+```vue [[...page\\].vue] title="Custom Prose"
 <template>
   <div>
     <h1>Custom Prose</h1>
   </div>
 </template>
 ```
-```vue [[...page].vue]{1}
+```vue [[...page\\].vue]{1}
 <template>
   <div>
     <h1>Custom Prose</h1>
@@ -33,7 +33,7 @@
   </div>
 </template>
 ```
-```[[...page].vue] {4-6,7} other code block info
+```[[...page\\].vue] {4-6,7} other code block info
 <template>
   <div>
     <h1>Custom Prose</h1>

--- a/src/runtime/markdown-parser/handler/utils.ts
+++ b/src/runtime/markdown-parser/handler/utils.ts
@@ -28,9 +28,9 @@ export function parseThematicBlock (lang: string) {
     .trim()
 
   return {
-    language: languageMatches?.[0] ?? undefined,
-    highlights: parseHighlightedLines(highlightTokensMatches?.[1] ?? undefined),
-    filename: filenameMatches?.[1] ?? undefined,
+    language: languageMatches?.[0] || undefined,
+    highlights: parseHighlightedLines(highlightTokensMatches?.[1] || undefined),
+    filename: filenameMatches?.[1] || undefined,
     meta
   }
 }

--- a/src/runtime/markdown-parser/handler/utils.ts
+++ b/src/runtime/markdown-parser/handler/utils.ts
@@ -18,15 +18,19 @@ export function parseThematicBlock (lang: string) {
     }
   }
 
-  const language = lang.replace(/[{|[](.+)/, '').match(/^[^ \t]+(?=[ \t]|$)/)
-  const highlightTokens = lang.match(/{([^}]*)}/)
-  const filenameTokens = lang.match(/\[(.*)\]/) /** Allow ']' in filename. @see https://regex101.com/r/Hm0t5m/1 */
-  const meta = lang.replace(/^\w*\s*(\[[^\]]*\]|\{[^}]*\})?\s*(\[[^\]]*\]|\{[^}]*\})?\s*/, '')
+  const languageMatches = lang.replace(/[{|[](.+)/, '').match(/^[^ \t]+(?=[ \t]|$)/)
+  const highlightTokensMatches = lang.match(/{([^}]*)}/)
+  const filenameMatches = lang.match(/\[((\S)*)\]/) /** Allow ']' in filename. */
+  const meta = lang
+    .replace(languageMatches?.[0] ?? '', '')
+    .replace(highlightTokensMatches?.[0] ?? '', '')
+    .replace(filenameMatches?.[0] ?? '', '')
+    .trim()
 
   return {
-    language: language ? language[0] : undefined,
-    highlights: parseHighlightedLines(highlightTokens && highlightTokens[1]),
-    filename: Array.isArray(filenameTokens) && filenameTokens[1] ? filenameTokens[1] : undefined,
+    language: languageMatches?.[0],
+    highlights: parseHighlightedLines(highlightTokensMatches?.[1]),
+    filename: filenameMatches?.[1],
     meta
   }
 }

--- a/src/runtime/markdown-parser/handler/utils.ts
+++ b/src/runtime/markdown-parser/handler/utils.ts
@@ -20,7 +20,8 @@ export function parseThematicBlock (lang: string) {
 
   const languageMatches = lang.replace(/[{|[](.+)/, '').match(/^[^ \t]+(?=[ \t]|$)/)
   const highlightTokensMatches = lang.match(/{([^}]*)}/)
-  const filenameMatches = lang.match(\[((\\]|[^\]])*)\]/)
+  const filenameMatches = lang.match(/\[((\\]|[^\]])*)\]/)
+
   const meta = lang
     .replace(languageMatches?.[0] ?? '', '')
     .replace(highlightTokensMatches?.[0] ?? '', '')
@@ -29,8 +30,8 @@ export function parseThematicBlock (lang: string) {
 
   return {
     language: languageMatches?.[0] || undefined,
-    highlights: parseHighlightedLines(highlightTokensMatches?.[1].replace(/\\]/g, ']') || undefined),
-    filename: filenameMatches?.[1] || undefined,
+    highlights: parseHighlightedLines(highlightTokensMatches?.[1] || undefined),
+    filename: filenameMatches?.[1].replace(/\\]/g, ']') || undefined,
     meta
   }
 }

--- a/src/runtime/markdown-parser/handler/utils.ts
+++ b/src/runtime/markdown-parser/handler/utils.ts
@@ -28,9 +28,9 @@ export function parseThematicBlock (lang: string) {
     .trim()
 
   return {
-    language: languageMatches?.[0],
-    highlights: parseHighlightedLines(highlightTokensMatches?.[1]),
-    filename: filenameMatches?.[1],
+    language: languageMatches?.[0] ?? undefined,
+    highlights: parseHighlightedLines(highlightTokensMatches?.[1] ?? undefined),
+    filename: filenameMatches?.[1] ?? undefined,
     meta
   }
 }

--- a/src/runtime/markdown-parser/handler/utils.ts
+++ b/src/runtime/markdown-parser/handler/utils.ts
@@ -29,7 +29,7 @@ export function parseThematicBlock (lang: string) {
 
   return {
     language: languageMatches?.[0] || undefined,
-    highlights: parseHighlightedLines(highlightTokensMatches?.[1] || undefined),
+    highlights: parseHighlightedLines(highlightTokensMatches?.[1].replace(/\\]/g, ']') || undefined),
     filename: filenameMatches?.[1] || undefined,
     meta
   }

--- a/src/runtime/markdown-parser/handler/utils.ts
+++ b/src/runtime/markdown-parser/handler/utils.ts
@@ -20,7 +20,7 @@ export function parseThematicBlock (lang: string) {
 
   const language = lang.replace(/[{|[](.+)/, '').match(/^[^ \t]+(?=[ \t]|$)/)
   const highlightTokens = lang.match(/{([^}]*)}/)
-  const filenameTokens = lang.match(/\[([^\]]*)\]/)
+  const filenameTokens = lang.match(/\[(.*)\]/) /** Allow ']' in filename. @see https://regex101.com/r/Hm0t5m/1 */
   const meta = lang.replace(/^\w*\s*(\[[^\]]*\]|\{[^}]*\})?\s*(\[[^\]]*\]|\{[^}]*\})?\s*/, '')
 
   return {

--- a/src/runtime/markdown-parser/handler/utils.ts
+++ b/src/runtime/markdown-parser/handler/utils.ts
@@ -20,7 +20,7 @@ export function parseThematicBlock (lang: string) {
 
   const languageMatches = lang.replace(/[{|[](.+)/, '').match(/^[^ \t]+(?=[ \t]|$)/)
   const highlightTokensMatches = lang.match(/{([^}]*)}/)
-  const filenameMatches = lang.match(/\[((\S)*)\]/) /** Allow ']' in filename. */
+  const filenameMatches = lang.match(\[((\\]|[^\]])*)\]/)
   const meta = lang
     .replace(languageMatches?.[0] ?? '', '')
     .replace(highlightTokensMatches?.[0] ?? '', '')

--- a/test/features/parser-markdown.ts
+++ b/test/features/parser-markdown.ts
@@ -115,13 +115,13 @@ export const testMarkdownParser = () => {
         expect(props.highlights).toEqual([4, 5, 6, 7])
       })
 
-      test('Extract filename with "[" or "]"', async () => {
+      test('Extract filename with "]" using a "\\" to escape it', async () => {
         const parsed = await $fetch('/api/parse', {
           method: 'POST',
           body: {
             id: 'content:index.md',
             content: [
-              '```ts[[...page].vue] {4-6,7} other code block info',
+              '```ts[[...page\\].vue] {4-6,7} other code block info',
               'let code = undefined;',
               'return code;',
               '```'
@@ -146,7 +146,7 @@ export const testMarkdownParser = () => {
           body: {
             id: 'content:index.md',
             content: [
-              '```[[...page].vue] {4-6,7} other code block info',
+              '```[[...page\\].vue] {4-6,7} other code block info',
               'let code = undefined;',
               'return code;',
               '```'
@@ -160,31 +160,6 @@ export const testMarkdownParser = () => {
         const props = parsed.body.children[0].props
         expect(props).toHaveProperty('meta')
         expect(props.meta).toBe('other code block info')
-        expect(props.language).toBe(undefined)
-        expect(props.filename).toBe('[...page].vue')
-        expect(props.highlights).toEqual([4, 5, 6, 7])
-      })
-
-      test.fails('Extract filename with "[" or "]" with "[" in meta', async () => {
-        const parsed = await $fetch('/api/parse', {
-          method: 'POST',
-          body: {
-            id: 'content:index.md',
-            content: [
-              '```ts[[...page].vue] {4-6,7} meta=[]',
-              'let code = undefined;',
-              'return code;',
-              '```'
-            ].join('\n')
-          }
-        })
-
-        expect(parsed).toHaveProperty('body')
-        expect(parsed.body).toHaveProperty('children[0].tag', 'code')
-        expect(parsed.body).toHaveProperty('children[0].props')
-        const props = parsed.body.children[0].props
-        expect(props).toHaveProperty('meta')
-        expect(props.meta).toBe('[]')
         expect(props.language).toBe(undefined)
         expect(props.filename).toBe('[...page].vue')
         expect(props.highlights).toEqual([4, 5, 6, 7])

--- a/test/features/parser-markdown.ts
+++ b/test/features/parser-markdown.ts
@@ -121,8 +121,7 @@ export const testMarkdownParser = () => {
           body: {
             id: 'content:index.md',
             content: [
-              // eslint-disable-next-line no-useless-escape
-              '```ts[[...page\].vue] {4-6,7} other code block info',
+              '```ts[[...page\\].vue] {4-6,7} other code block info',
               'let code = undefined;',
               'return code;',
               '```'
@@ -147,8 +146,8 @@ export const testMarkdownParser = () => {
           body: {
             id: 'content:index.md',
             content: [
-              // eslint-disable-next-line no-useless-escape
-              '```[[...page\].vue] {4-6,7} other code block info',
+
+              '```[[...page\\].vue] {4-6,7} other code block info',
               'let code = undefined;',
               'return code;',
               '```'

--- a/test/features/parser-markdown.ts
+++ b/test/features/parser-markdown.ts
@@ -121,7 +121,8 @@ export const testMarkdownParser = () => {
           body: {
             id: 'content:index.md',
             content: [
-              '```ts[[...page\\].vue] {4-6,7} other code block info',
+              // eslint-disable-next-line no-useless-escape
+              '```ts[[...page\].vue] {4-6,7} other code block info',
               'let code = undefined;',
               'return code;',
               '```'
@@ -146,7 +147,8 @@ export const testMarkdownParser = () => {
           body: {
             id: 'content:index.md',
             content: [
-              '```[[...page\\].vue] {4-6,7} other code block info',
+              // eslint-disable-next-line no-useless-escape
+              '```[[...page\].vue] {4-6,7} other code block info',
               'let code = undefined;',
               'return code;',
               '```'

--- a/test/features/parser-markdown.ts
+++ b/test/features/parser-markdown.ts
@@ -114,6 +114,81 @@ export const testMarkdownParser = () => {
         expect(props.filename).toBe(undefined)
         expect(props.highlights).toEqual([4, 5, 6, 7])
       })
+
+      test('Extract filename with "[" or "]"', async () => {
+        const parsed = await $fetch('/api/parse', {
+          method: 'POST',
+          body: {
+            id: 'content:index.md',
+            content: [
+              '```ts[[...page].vue] {4-6,7} other code block info',
+              'let code = undefined;',
+              'return code;',
+              '```'
+            ].join('\n')
+          }
+        })
+
+        expect(parsed).toHaveProperty('body')
+        expect(parsed.body).toHaveProperty('children[0].tag', 'code')
+        expect(parsed.body).toHaveProperty('children[0].props')
+        const props = parsed.body.children[0].props
+        expect(props).toHaveProperty('meta')
+        expect(props.meta).toBe('other code block info')
+        expect(props.language).toBe('ts')
+        expect(props.filename).toBe('[...page].vue')
+        expect(props.highlights).toEqual([4, 5, 6, 7])
+      })
+
+      test('Extract filename with "[" or "]" in the name without language in code block', async () => {
+        const parsed = await $fetch('/api/parse', {
+          method: 'POST',
+          body: {
+            id: 'content:index.md',
+            content: [
+              '```[[...page].vue] {4-6,7} other code block info',
+              'let code = undefined;',
+              'return code;',
+              '```'
+            ].join('\n')
+          }
+        })
+
+        expect(parsed).toHaveProperty('body')
+        expect(parsed.body).toHaveProperty('children[0].tag', 'code')
+        expect(parsed.body).toHaveProperty('children[0].props')
+        const props = parsed.body.children[0].props
+        expect(props).toHaveProperty('meta')
+        expect(props.meta).toBe('other code block info')
+        expect(props.language).toBe(undefined)
+        expect(props.filename).toBe('[...page].vue')
+        expect(props.highlights).toEqual([4, 5, 6, 7])
+      })
+
+      test.fails('Extract filename with "[" or "]" with "[" in meta', async () => {
+        const parsed = await $fetch('/api/parse', {
+          method: 'POST',
+          body: {
+            id: 'content:index.md',
+            content: [
+              '```ts[[...page].vue] {4-6,7} meta=[]',
+              'let code = undefined;',
+              'return code;',
+              '```'
+            ].join('\n')
+          }
+        })
+
+        expect(parsed).toHaveProperty('body')
+        expect(parsed.body).toHaveProperty('children[0].tag', 'code')
+        expect(parsed.body).toHaveProperty('children[0].props')
+        const props = parsed.body.children[0].props
+        expect(props).toHaveProperty('meta')
+        expect(props.meta).toBe('[]')
+        expect(props.language).toBe(undefined)
+        expect(props.filename).toBe('[...page].vue')
+        expect(props.highlights).toEqual([4, 5, 6, 7])
+      })
     })
 
     describe('Frontmatter', () => {

--- a/test/features/parser-markdown.ts
+++ b/test/features/parser-markdown.ts
@@ -114,57 +114,6 @@ export const testMarkdownParser = () => {
         expect(props.filename).toBe(undefined)
         expect(props.highlights).toEqual([4, 5, 6, 7])
       })
-
-      test('Extract filename with "]" using a "\\" to escape it', async () => {
-        const parsed = await $fetch('/api/parse', {
-          method: 'POST',
-          body: {
-            id: 'content:index.md',
-            content: [
-              '```ts[[...page\\].vue] {4-6,7} other code block info',
-              'let code = undefined;',
-              'return code;',
-              '```'
-            ].join('\n')
-          }
-        })
-
-        expect(parsed).toHaveProperty('body')
-        expect(parsed.body).toHaveProperty('children[0].tag', 'code')
-        expect(parsed.body).toHaveProperty('children[0].props')
-        const props = parsed.body.children[0].props
-        expect(props).toHaveProperty('meta')
-        expect(props.meta).toBe('other code block info')
-        expect(props.language).toBe('ts')
-        expect(props.filename).toBe('[...page].vue')
-        expect(props.highlights).toEqual([4, 5, 6, 7])
-      })
-
-      test('Extract filename with "[" or "]" in the name without language in code block', async () => {
-        const parsed = await $fetch('/api/parse', {
-          method: 'POST',
-          body: {
-            id: 'content:index.md',
-            content: [
-
-              '```[[...page\\].vue] {4-6,7} other code block info',
-              'let code = undefined;',
-              'return code;',
-              '```'
-            ].join('\n')
-          }
-        })
-
-        expect(parsed).toHaveProperty('body')
-        expect(parsed.body).toHaveProperty('children[0].tag', 'code')
-        expect(parsed.body).toHaveProperty('children[0].props')
-        const props = parsed.body.children[0].props
-        expect(props).toHaveProperty('meta')
-        expect(props.meta).toBe('other code block info')
-        expect(props.language).toBe(undefined)
-        expect(props.filename).toBe('[...page].vue')
-        expect(props.highlights).toEqual([4, 5, 6, 7])
-      })
     })
 
     describe('Frontmatter', () => {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
fix #2166 

For a code block, if filename was `[...page].vue`, regex was stoping at `[...page`. This PR fix it.


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
