### PR TITLE
fix: uppercase in path

### DIFF
--- a/docs/content/4.api/3.configuration.md
+++ b/docs/content/4.api/3.configuration.md
@@ -416,4 +416,4 @@ Toggles the document-driven mode.
 - Type: `Boolean`{lang=ts}
 - Default: `false`{lang=ts}
 
-Whether to respect the case of the file path when generating the route. Defaults to `false`, which means the route will be generated in lowercase. If set to `true`, the route will be generated with the same case as the file path.
+Whether to respect the case of the file path when generating the route. Defaults to `false`, which means the route will be generated in lowercase. For example, `content/en-US/foo.md` will resolve to the `en-us/foo` path. This may not be what you expect.If set to `true`, the route will be generated with the same case as the file path. `content/en-US/foo.md` will resolve to the `en-US/foo` path.

--- a/docs/content/4.api/3.configuration.md
+++ b/docs/content/4.api/3.configuration.md
@@ -411,9 +411,9 @@ Toggles the document-driven mode.
 | `injectPage`      |      `boolean`      | Inject `[...slug].vue` pre-configured page                     |
 | `trailingSlash`   |      `boolean`      | Add a slash at the end of  `canonical` and `og:url`            |
 
-## `keepUppercase`
+## `respectPathCase`
 
 - Type: `Boolean`{lang=ts}
 - Default: `false`{lang=ts}
 
-Whether to keep uppercase characters in the generated routes.
+Whether to respect the case of the file path when generating the route. Defaults to `false`, which means the route will be generated in lowercase. If set to `true`, the route will be generated with the same case as the file path.

--- a/docs/content/4.api/3.configuration.md
+++ b/docs/content/4.api/3.configuration.md
@@ -410,3 +410,10 @@ Toggles the document-driven mode.
 | `layoutFallbacks` |     `string[]`      | A list of `globals` key to use to find a layout fallback.      |
 | `injectPage`      |      `boolean`      | Inject `[...slug].vue` pre-configured page                     |
 | `trailingSlash`   |      `boolean`      | Add a slash at the end of  `canonical` and `og:url`            |
+
+## `keepUppercase`
+
+- Type: `Boolean`{lang=ts}
+- Default: `false`{lang=ts}
+
+Whether to keep uppercase characters in the generated routes.

--- a/src/module.ts
+++ b/src/module.ts
@@ -223,6 +223,7 @@ export interface ModuleOptions {
   experimental: {
     clientDB: boolean
     stripQueryParameters: boolean
+    keepUppercase: boolean
   }
 }
 
@@ -283,7 +284,8 @@ export default defineNuxtModule<ModuleOptions>({
     documentDriven: false,
     experimental: {
       clientDB: false,
-      stripQueryParameters: false
+      stripQueryParameters: false,
+      keepUppercase: false
     }
   },
   async setup (options, nuxt) {
@@ -603,7 +605,8 @@ export default defineNuxtModule<ModuleOptions>({
       integrity: buildIntegrity,
       experimental: {
         stripQueryParameters: options.experimental.stripQueryParameters,
-        clientDB: options.experimental.clientDB && nuxt.options.ssr === false
+        clientDB: options.experimental.clientDB && nuxt.options.ssr === false,
+        keepUppercase: options.experimental.keepUppercase ?? false
       },
       api: {
         baseURL: options.api.baseURL
@@ -728,6 +731,7 @@ interface ModulePublicRuntimeConfig {
   experimental: {
     stripQueryParameters: boolean
     clientDB: boolean
+    keepUppercase: boolean
   }
 
   defaultLocale: ModuleOptions['defaultLocale']

--- a/src/module.ts
+++ b/src/module.ts
@@ -225,7 +225,7 @@ export interface ModuleOptions {
    *
    * @default false
    */
-  keepUppercase: boolean
+  respectPathCase: boolean
   experimental: {
     clientDB: boolean
     stripQueryParameters: boolean
@@ -287,7 +287,7 @@ export default defineNuxtModule<ModuleOptions>({
       fields: []
     },
     documentDriven: false,
-    keepUppercase: false,
+    respectPathCase: false,
     experimental: {
       clientDB: false,
       stripQueryParameters: false
@@ -612,7 +612,7 @@ export default defineNuxtModule<ModuleOptions>({
         stripQueryParameters: options.experimental.stripQueryParameters,
         clientDB: options.experimental.clientDB && nuxt.options.ssr === false
       },
-      keepUppercase: options.keepUppercase ?? false,
+      respectPathCase: options.respectPathCase ?? false,
       api: {
         baseURL: options.api.baseURL
       },
@@ -737,7 +737,7 @@ interface ModulePublicRuntimeConfig {
     stripQueryParameters: boolean
     clientDB: boolean
   }
-  keepUppercase: boolean
+  respectPathCase: boolean
 
   defaultLocale: ModuleOptions['defaultLocale']
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -220,10 +220,15 @@ export interface ModuleOptions {
     injectPage?: boolean
     trailingSlash?: boolean
   },
+  /**
+   * Enable to keep uppercase characters in the generated routes.
+   *
+   * @default false
+   */
+  keepUppercase: boolean
   experimental: {
     clientDB: boolean
     stripQueryParameters: boolean
-    keepUppercase: boolean
   }
 }
 
@@ -282,10 +287,10 @@ export default defineNuxtModule<ModuleOptions>({
       fields: []
     },
     documentDriven: false,
+    keepUppercase: false,
     experimental: {
       clientDB: false,
-      stripQueryParameters: false,
-      keepUppercase: false
+      stripQueryParameters: false
     }
   },
   async setup (options, nuxt) {
@@ -605,9 +610,9 @@ export default defineNuxtModule<ModuleOptions>({
       integrity: buildIntegrity,
       experimental: {
         stripQueryParameters: options.experimental.stripQueryParameters,
-        clientDB: options.experimental.clientDB && nuxt.options.ssr === false,
-        keepUppercase: options.experimental.keepUppercase ?? false
+        clientDB: options.experimental.clientDB && nuxt.options.ssr === false
       },
+      keepUppercase: options.keepUppercase ?? false,
       api: {
         baseURL: options.api.baseURL
       },
@@ -731,8 +736,8 @@ interface ModulePublicRuntimeConfig {
   experimental: {
     stripQueryParameters: boolean
     clientDB: boolean
-    keepUppercase: boolean
   }
+  keepUppercase: boolean
 
   defaultLocale: ModuleOptions['defaultLocale']
 

--- a/src/runtime/server/storage.ts
+++ b/src/runtime/server/storage.ts
@@ -26,6 +26,7 @@ interface ParseContentOptions {
   pathMeta?: {
     locales?: ModuleOptions['locales']
     defaultLocale?: ModuleOptions['defaultLocale']
+    respectPathCase?: ModuleOptions['respectPathCase']
   }
   // Allow passing options for custom transformers
   [key: string]: any
@@ -173,7 +174,8 @@ export async function parseContent (id: string, content: string, opts: ParseCont
       transformers: customTransformers,
       pathMeta: {
         defaultLocale: contentConfig.defaultLocale,
-        locales: contentConfig.locales
+        locales: contentConfig.locales,
+        respectPathCase: contentConfig.respectPathCase
       }
     }
   )

--- a/src/runtime/transformers/path-meta.ts
+++ b/src/runtime/transformers/path-meta.ts
@@ -67,7 +67,8 @@ const isPartial = (path: string): boolean => path.split(/[:/]/).some(part => par
  * @returns generated slug
  */
 export const generatePath = (path: string, { forceLeadingSlash = true } = {}): string => {
-  path = path.split('/').map(part => slugify(refineUrlPart(part), { lower: true })).join('/')
+  const { content } = useRuntimeConfig().public
+  path = path.split('/').map(part => slugify(refineUrlPart(part), { lower: !content.experimental.keepUppercase })).join('/')
   return forceLeadingSlash ? withLeadingSlash(withoutTrailingSlash(path)) : path
 }
 

--- a/src/runtime/transformers/path-meta.ts
+++ b/src/runtime/transformers/path-meta.ts
@@ -68,7 +68,7 @@ const isPartial = (path: string): boolean => path.split(/[:/]/).some(part => par
  */
 export const generatePath = (path: string, { forceLeadingSlash = true } = {}): string => {
   const { content } = useRuntimeConfig().public
-  path = path.split('/').map(part => slugify(refineUrlPart(part), { lower: !content.keepUppercase })).join('/')
+  path = path.split('/').map(part => slugify(refineUrlPart(part), { lower: !content.respectPathCase })).join('/')
   return forceLeadingSlash ? withLeadingSlash(withoutTrailingSlash(path)) : path
 }
 

--- a/src/runtime/transformers/path-meta.ts
+++ b/src/runtime/transformers/path-meta.ts
@@ -25,14 +25,12 @@ export default defineTransformer({
   name: 'path-meta',
   extensions: ['.*'],
   transform (content, options: any = {}) {
-    const { locales = [], defaultLocale = 'en' } = options
+    const { locales = [], defaultLocale = 'en', respectPathCase = false } = options
     const { _source, _file, _path, _extension } = describeId(content._id)
     const parts = _path.split('/')
-
     // Check first part for locale name
     const _locale = locales.includes(parts[0]) ? parts.shift() : defaultLocale
-
-    const filePath = generatePath(parts.join('/'))
+    const filePath = generatePath(parts.join('/'), { respectPathCase })
 
     return <ParsedContent> {
       _path: filePath,
@@ -66,9 +64,8 @@ const isPartial = (path: string): boolean => path.split(/[:/]/).some(part => par
  * @param path file full path
  * @returns generated slug
  */
-export const generatePath = (path: string, { forceLeadingSlash = true } = {}): string => {
-  const { content } = useRuntimeConfig().public
-  path = path.split('/').map(part => slugify(refineUrlPart(part), { lower: !content.respectPathCase })).join('/')
+export const generatePath = (path: string, { forceLeadingSlash = true, respectPathCase = false } = {}): string => {
+  path = path.split('/').map(part => slugify(refineUrlPart(part), { lower: !respectPathCase })).join('/')
   return forceLeadingSlash ? withLeadingSlash(withoutTrailingSlash(path)) : path
 }
 

--- a/src/runtime/transformers/path-meta.ts
+++ b/src/runtime/transformers/path-meta.ts
@@ -68,7 +68,7 @@ const isPartial = (path: string): boolean => path.split(/[:/]/).some(part => par
  */
 export const generatePath = (path: string, { forceLeadingSlash = true } = {}): string => {
   const { content } = useRuntimeConfig().public
-  path = path.split('/').map(part => slugify(refineUrlPart(part), { lower: !content.experimental.keepUppercase })).join('/')
+  path = path.split('/').map(part => slugify(refineUrlPart(part), { lower: !content.keepUppercase })).join('/')
   return forceLeadingSlash ? withLeadingSlash(withoutTrailingSlash(path)) : path
 }
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

close #2162 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Currently, if we construct a path like /zh-CN/foo.md, the corresponding document cannot be found. This is because the path is automatically converted to lowercase. I think the existence of such a path is reasonable and should not be converted. I don't understand why this is done, so in order not to introduce destructive changes, I added a flag named keepUppercase to allow uppercase letters in the path.

I wasn't sure where this flag should be placed, so I tentatively put it under the experimental options.

Resolves #2162 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
