### PR TITLE
fix: allow empty string in $`contains`

### DIFF
--- a/playground/basic/content/1.real-content/post.md
+++ b/playground/basic/content/1.real-content/post.md
@@ -1,0 +1,8 @@
+---
+title: Post 1
+authors: [ "alice", "bob" ]
+---
+
+# Post 1
+
+This is the first post written by Alice and Bob used to try `$contains` filter.

--- a/playground/basic/pages/custom-query.vue
+++ b/playground/basic/pages/custom-query.vue
@@ -1,0 +1,9 @@
+<script lang="ts" setup>
+const { data } = await useAsyncData('posts', () => queryContent('/real-content/post').where({ authors: { $contains: 'super' } }).find())
+</script>
+
+<template>
+  <div>
+    {{ data }}
+  </div>
+</template>

--- a/src/runtime/query/match/utils.ts
+++ b/src/runtime/query/match/utils.ts
@@ -99,7 +99,9 @@ export const assertArray = (value: any, message = 'Expected an array') => {
 }
 
 /**
- * Ensure result is an array
+ * Ensure result is an array.
  */
-export const ensureArray = <T>(value: T) =>
-(Array.isArray(value) ? value : value ? [value] : []) as T extends Array<any> ? T : T[]
+export const ensureArray = <T>(value: T) => {
+  if (value === '') { return [''] } // Special case for empty string which is a valid value in an array
+  return (Array.isArray(value) ? value : value ? [value] : []) as T extends Array<any> ? T : T[]
+}


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

fix #2158

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Hello,

I'm not sure if the fix must be in the `ensureArray` function or in the `$contains` function (`src/runtime/query/match`).

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
