### PR TITLE
docs: add warning about windows development

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ Nuxt 2 is supported with Content v1, documentation is on <https://content.nuxtjs
 - Prepare using `pnpm prepare`
 - Prepare using `pnpm build`
 - Try playground using `pnpm dev`
+- Test using `pnpm test`
+
+**Note:** This repository uses bash scripts for development and testing. If you are on Windows, you can use [WSL](https://learn.microsoft.com/en-us/windows/wsl/install) or [Git Bash](https://gitforwindows.org/).
 
 ## License
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Hello, I added a note in the README to warn about Windows usage to developpe this module. I'm a Windows user and the first time I contribute to this repo, it was painful to try to understand bash scripts and to reproduce them manually. I completely switch to WSL and it's so much more convenient

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
