### PR TITLE
docs: update slots example for the content-query component

### DIFF
--- a/docs/content/4.api/1.components/4.content-query.md
+++ b/docs/content/4.api/1.components/4.content-query.md
@@ -43,7 +43,7 @@ The `default`{lang=ts} slot can be used to render the content via `v-slot="{ dat
 <!-- Similar to <ContentDoc :path="$route.path" /> -->
 <template>
   <main>
-    <ContentQuery :path="$route.path" v-slot="{ data }">
+    <ContentQuery :path="$route.path" find="one" v-slot="{ data }">
       <ContentRenderer :value="data" />
     </ContentQuery>
   </main>


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

fix #2173

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Without `find="one"`, the query return an array. So the condition, https://github.com/nuxt/content/blob/main/src/runtime/components/ContentRenderer.vue#L73, can not be true in the `ContentRenderer` component. I update the example to easily copy-paste code.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
