### PR TITLE
fix: Custom drivers failed on build

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -662,7 +662,7 @@ export default defineNuxtModule<ModuleOptions>({
           base: resolve(nuxt.options.buildDir, 'content-cache')
         }
         for (const [key, source] of Object.entries(sources)) {
-          storage.mount(key, getMountDriver(source))
+          storage.mount(key, await getMountDriver(source))
         }
         let keys = await storage.getKeys('content:source')
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -58,15 +58,14 @@ const unstorageDrivers = {
 /**
  * Resolve driver of a mount.
  */
-export function getMountDriver (mount: MountOptions) {
+export async function getMountDriver (mount: MountOptions) {
   const dirverName = mount.driver as keyof typeof unstorageDrivers
   if (unstorageDrivers[dirverName]) {
     return unstorageDrivers[dirverName](mount as any)
   }
 
   try {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    return require(mount.driver).default(mount as any)
+    return (await import(mount.driver)).default(mount as any)
   } catch (e) {
     // eslint-disable-next-line no-console
     console.error("Couldn't load driver", mount.driver)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,7 @@
 {
+  "compilerOptions": {
+    "lib": [ "es2015" ]
+  },
   "extends": "./playground/basic/.nuxt/tsconfig.json",
   "exclude": [
     "test",


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

Issue #2096 (Custom drivers failed to build)

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Resolves #2096 so that Nuxt Content builds with support for custom drivers:
 * modified `getMountDriver()` in `src/utils.ts` to "change the require [statement] to a dynamic import()".
 * modified `setup()` in `src/module.ts` to await `getMountDriver()`.
 * modified `tsconfig.json` to avoid TS2705 error: "A dynamic import call in ES5/ES3 requires the Promise constructor. Make sure you have a declaration for the Promise constructor or include ES2015 in your --lib option."


<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
