### PR TITLE
docs(v1): link button wrapping for small screens

### DIFF
--- a/docs/components/content/V1DocsLinks.vue
+++ b/docs/components/content/V1DocsLinks.vue
@@ -5,10 +5,10 @@
       <button-link href="/v1/getting-started/introduction" :transparent="true" color="false" size="large">
         English
       </button-link>
-      <button-link href="/fr/v1/getting-started/introduction" :transparent="true" color="false" class="ml-2" size="large">
+      <button-link href="/fr/v1/getting-started/introduction" :transparent="true" color="false" size="large">
         French
       </button-link>
-      <button-link href="/ja/v1/getting-started/introduction" :transparent="true" color="false" class="ml-2" size="large">
+      <button-link href="/ja/v1/getting-started/introduction" :transparent="true" color="false" size="large">
         Japanese
       </button-link>
     </div>
@@ -23,6 +23,7 @@ css({
     padding: '2rem',
     marginBottom: '2rem',
     display: 'flex',
+    flexWrap: 'wrap',
     flexDirection: 'column',
     alignItems: 'center',
     justifyContent: 'center'

--- a/docs/components/content/V1DocsLinks.vue
+++ b/docs/components/content/V1DocsLinks.vue
@@ -11,6 +11,9 @@
       <button-link href="/ja/v1/getting-started/introduction" :transparent="true" color="false" size="large">
         Japanese
       </button-link>
+      <button-link href="/ru/v1/getting-started/introduction" :transparent="true" color="false" size="large">
+        Russian
+      </button-link>
     </div>
     <ellipsis />
   </div>

--- a/docs/components/content/V1DocsLinks.vue
+++ b/docs/components/content/V1DocsLinks.vue
@@ -26,7 +26,6 @@ css({
     padding: '2rem',
     marginBottom: '2rem',
     display: 'flex',
-    flexWrap: 'wrap',
     flexDirection: 'column',
     alignItems: 'center',
     justifyContent: 'center'
@@ -38,6 +37,7 @@ css({
   },
   '.links-wrapper': {
     display: 'flex',
+    flexWrap: 'wrap',
     gap: '2rem',
     justifyContent: 'center'
   },


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

- wrapping v1 link buttons on small screens to prevent overflow
- removing class `ml-2` as it is unused
- adding a link button to the Russian docs page

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
