### PR TITLE
docs(mdc): fix {attribute} examples

### DIFF
--- a/docs/content/3.guide/1.writing/3.mdc.md
+++ b/docs/content/3.guide/1.writing/3.mdc.md
@@ -320,6 +320,8 @@ To create inline spans in your text you can use the `[]` identifier.
 
 Attributes are useful for highlighting and modifying part of paragraph. The syntax is nearly similar to inline components and markdown links syntax.
 
+Possible values ​​are all named attributes, classes with the notation `.class-name` and an ID with `#id-name`.
+
 ::code-group
   ```md [Code]
   Hello [World]{style="color: var(--color-primary-500)"}!
@@ -330,7 +332,7 @@ Attributes are useful for highlighting and modifying part of paragraph. The synt
   ::
 ::
 
-Other than `spans` the attribute syntax will work on images, links, `code`, **bold** and _italic_ texts.
+In addition to mdc components and `spans`, attribute syntax will work on images, links, inline `code`, **bold** and _italic_ text.
 
 ::code-group
   ```md [Code]

--- a/docs/content/3.guide/1.writing/3.mdc.md
+++ b/docs/content/3.guide/1.writing/3.mdc.md
@@ -308,7 +308,7 @@ To create inline spans in your text you can use the `[]` identifier.
 
 ::code-group
   ```md [Code]
-  Hello [World]{.bg-blue-500}!
+  Hello [World]{.bg-primary-500}!
   ```
 
   ::code-block{label="Preview"}

--- a/docs/content/3.guide/1.writing/3.mdc.md
+++ b/docs/content/3.guide/1.writing/3.mdc.md
@@ -308,7 +308,7 @@ To create inline spans in your text you can use the `[]` identifier.
 
 ::code-group
   ```md [Code]
-  Hello [World]{.bg-primary-500}!
+  Hello [World]{style="background-color: var(--color-primary-500)"}!
   ```
 
   ::code-block{label="Preview"}
@@ -322,7 +322,7 @@ Attributes are useful for highlighting and modifying part of paragraph. The synt
 
 ::code-group
   ```md [Code]
-  Hello [World]{.text-primary-500}!
+  Hello [World]{style="color: var(--color-primary-500)"}!
   ```
 
   ::code-block{label="Preview"}
@@ -334,18 +334,18 @@ Other than `spans` the attribute syntax will work on images, links, `code`, **bo
 
 ::code-group
   ```md [Code]
-  Attributes works on:
+  Attributes work on:
 
-  - ![](/icon.png){.inline.m-0.bg-primary-800} image,
-  - [link](#attributes){.bg-primary-400}, `code`{.text-red-500},
-  - _italic_{.bg-primary-500} and **bold**{.bg-primary-500} texts.
+  - ![](/favicon.ico){style="display: inline; margin: 0; background-color: var(--color-primary-800);"} image,
+  - [link](#attributes){style="background-color: var(--color-primary-400);"}, `code`{style="color: var(--color-primary-500);"},
+  - _italic_{style="background-color: var(--color-primary-500);"} and **bold**{style="background-color: var(--color-primary-500);"} texts.
   ```
 
   ::code-block{label="Preview"}
-  Attributes works on:
+  Attributes work on:
 
   - ![](/favicon.ico){style="display: inline; margin: 0; background-color: var(--color-primary-800);"} image,
-  - [link](#attributes){style="background-color: var(--color-primary-400);"}, `code`{style="color: var(--color-red-500);"},
+  - [link](#attributes){style="background-color: var(--color-primary-400);"}, `code`{style="color: var(--color-primary-500);"},
   - _italic_{style="background-color: var(--color-primary-500);"} and **bold**{style="background-color: var(--color-primary-500);"} texts.
   ::
 ::

--- a/docs/content/3.guide/1.writing/3.mdc.md
+++ b/docs/content/3.guide/1.writing/3.mdc.md
@@ -324,11 +324,11 @@ Possible values ​​are all named attributes, classes with the notation `.clas
 
 ::code-group
   ```md [Code]
-  Hello [World]{style="color: var(--color-primary-500)"}!
+  Hello [World]{style="color: var(--color-primary-500)" .custom-class #custom-id}!
   ```
 
   ::code-block{label="Preview"}
-  Hello [World]{style="color: var(--color-primary-500)"}!
+  Hello [World]{style="color: var(--color-primary-500)" .custom-class #custom-id}!
   ::
 ::
 

--- a/docs/content/3.guide/1.writing/3.mdc.md
+++ b/docs/content/3.guide/1.writing/3.mdc.md
@@ -312,7 +312,7 @@ To create inline spans in your text you can use the `[]` identifier.
   ```
 
   ::code-block{label="Preview"}
-  Hello [World]{.bg-primary-500}!
+  Hello [World]{style="background-color: var(--color-primary-500)"}!
   ::
 ::
 
@@ -326,7 +326,7 @@ Attributes are useful for highlighting and modifying part of paragraph. The synt
   ```
 
   ::code-block{label="Preview"}
-  Hello [World]{.text-primary-500}!
+  Hello [World]{style="color: var(--color-primary-500)"}!
   ::
 ::
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

As Tailwind isn't used by Docus anymore, the class names aren't providing styling by themselves. I added the corresponding style tags to fix this.
This has also been [changed for lines 347-349](https://github.com/nuxt/content/commit/1823c0defcc836ebfdfc0f1bf9be1e8ac19f0cc7#diff-486c5f2e2433a70cd8bace1d6253fd758d7ef340bb21fa57dcf135ec9eca2801R347-R349) in a previous PR #1982.

I am not sure, if it is good to do this, because the class name styling won't work if someone tries doing it with Docus.
Maybe a warning or info should be added, that the styling with classes just works with e.g. Tailwind?
I mean... the props are assigned, just the styling would be missing.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
