### PR TITLE
fix(ContentList): component slot typechecking

### DIFF
--- a/src/runtime/components/ContentList.vue
+++ b/src/runtime/components/ContentList.vue
@@ -71,7 +71,7 @@ const ContentList = defineComponent({
 export default ContentList as typeof ContentList & {
   new (): {
     $slots: {
-      default: (context: { data: ParsedContent[], refresh: () => Promise<void> }) => VNode[] | undefined
+      default: (context: { list: ParsedContent[], refresh: () => Promise<void> }) => VNode[] | undefined
     }
   }
 }


### PR DESCRIPTION


<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The slot property is `list` and not `data`, so the current type is inaccurate and fails typechecking when used as:

```vue
<ContentList v-slot="{ list }">...</ContentList>
```

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
