### PR TITLE
docs: Clarify global components vs auto-imports

### DIFF
--- a/docs/content/3.guide/1.writing/3.mdc.md
+++ b/docs/content/3.guide/1.writing/3.mdc.md
@@ -14,7 +14,7 @@ Install the [MDC VS Code extension](https://marketplace.visualstudio.com/items?i
 
 Block components are components that accept Markdown content or another component as a slot.
 
-Any component in the `components/content/` directory or [made available globally](https://nuxt.com/docs/guide/directory-structure/components) in your application can be used in Markdown files.
+Any component in the `components/content/` directory or [made available globally](https://nuxt.com/docs/guide/directory-structure/components#dynamic-components) in your application can be used in Markdown files. While Nuxt auto-imports all components in your `components` directory, by default, only those in `components/global/` are available globally.
 
 The component must contain either:
 

--- a/docs/content/3.guide/1.writing/8.vue-component.md
+++ b/docs/content/3.guide/1.writing/8.vue-component.md
@@ -20,4 +20,4 @@ All global components in your Nuxt app will be available to use in your markdown
 
 While Nuxt auto-imports components in the `components` directory, this doesn't make them globally available. By default, only components in `components/global/` are global.
 
-For more information about global components, visit [Nuxt 3 docs](https://nuxt.com/docs/guide/directory-structure/components).
+For more information about global components, visit [Nuxt 3 docs](https://nuxt.com/docs/guide/directory-structure/components#dynamic-components).

--- a/docs/content/3.guide/1.writing/8.vue-component.md
+++ b/docs/content/3.guide/1.writing/8.vue-component.md
@@ -18,4 +18,6 @@ Every component created inside the `components/content` directory will be availa
 
 All global components in your Nuxt app will be available to use in your markdown files.
 
+While Nuxt auto-imports components in the `components` directory, this doesn't make them globally available. By default, only components in `components/global/` are global.
+
 For more information about global components, visit [Nuxt 3 docs](https://nuxt.com/docs/guide/directory-structure/components).


### PR DESCRIPTION
### 🔗 Linked issue

Helps with #2256

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ x ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Clarifies the different between Nuxt auto-importing a component and whether it's globally available. Beginners to Nuxt may expect that if Nuxt can auto-import component in the `components` directory, that means it is globally available. This PR also changes the links to Nuxt documentation to the specific section on Dynamic Components that refers to global components. 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ x ] I have linked an issue or discussion.
- [ x ] I have updated the documentation accordingly.
