### PR TITLE
docs: fix page overflow

### DIFF
--- a/docs/pages/index.vue
+++ b/docs/pages/index.vue
@@ -336,6 +336,7 @@ const { format: formatNumber } = Intl.NumberFormat('en-GB', { notation: 'compact
 .gradient {
   position: absolute;
   top: 25vh;
+  left: 0;
   width: 100%;
   height: 30vh;
   background: radial-gradient(50% 50% at 50% 50%, #00DC82 0%, rgba(0, 220, 130, 0) 100%);


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

The [new docs](https://content.nuxt.com) (#2310) have a gradient on the home page which is `positioned absolute` and overflows to the right of the page, as it takes 100% width.

(Checked with `Firefox 117.0.1` and `Chromium 116.0.5845.187` on Linux)

![Screenshot 2023-09-21 at 21-10-19 Nuxt Content made easy for Vue Developers](https://github.com/nuxt/content/assets/44443899/19694afb-6627-4680-8069-fc16bd106dcc)


Possible changes are
- setting the parent element to `hide overflow(-x)`
  -> gradient shifted slightly right
- or to add a `left: 0` to the absolutely positioned element
  -> gradient centered

---

I decided to use `left: 0` which looks like this:

![Screenshot 2023-09-21 at 21-11-01 Nuxt Content made easy for Vue Developers](https://github.com/nuxt/content/assets/44443899/0d795234-e938-4e3f-b9b5-13b64254be75)


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
