### PR TITLE
fix: add regex to match ContentSlot in Pug templates

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -136,11 +136,11 @@ export interface ModuleOptions {
      * @default {}
      */
     anchorLinks?: boolean | {
-     /**
-       * Sets the maximal depth for anchor link generation
-       *
-       * @default 4
-       */
+      /**
+        * Sets the maximal depth for anchor link generation
+        *
+        * @default 4
+        */
       depth?: number,
       /**
        * Excludes headings from link generation when they are in the depth range.
@@ -305,7 +305,7 @@ export default defineNuxtModule<ModuleOptions>({
       advanceQuery: false
     }
   },
-  async setup (options, nuxt) {
+  async setup(options, nuxt) {
     const { resolve, resolvePath } = createResolver(import.meta.url)
     const resolveRuntimeModule = (path: string) => resolve('./runtime', path)
     // Ensure default locale alway is the first item of locales
@@ -333,12 +333,13 @@ export default defineNuxtModule<ModuleOptions>({
       config.plugins?.push({
         name: 'content-slot',
         enforce: 'pre',
-        transform (code) {
+        transform(code) {
           if (code.includes('ContentSlot')) {
             code = code.replace(/<ContentSlot (.*)(:use=['"](\$slots.)?([a-zA-Z0-9_-]*)['"]|use=['"]([a-zA-Z0-9_-]*)['"])/g, '<MDCSlot $1 name="$4"')
             code = code.replace(/<\/ContentSlot>/g, '</MDCSlot>')
             code = code.replace(/<ContentSlot/g, '<MDCSlot')
             code = code.replace(/(['"])ContentSlot['"]/g, '$1MDCSlot$1')
+            code = code.replace(/ContentSlot\(([^\(]*)(:use=['"](\$slots.)?([a-zA-Z0-9_-]*)['"]|use=['"]([a-zA-Z0-9_-]*)['"])([^\)]*)/g, 'MDCSlot($1name="$4"$6')
             return {
               code,
               map: { mappings: '' }
@@ -472,7 +473,7 @@ export default defineNuxtModule<ModuleOptions>({
     })
     addTemplate({
       filename: 'content-components.mjs',
-      getContents ({ options }) {
+      getContents({ options }) {
         const components = options.getComponents(options.mode).filter((c: any) => !c.island).flatMap((c: any) => {
           const exp = c.export === 'default' ? 'c.default || c' : `c['${c.export}']`
           const isClient = c.mode === 'client'
@@ -530,10 +531,10 @@ export default defineNuxtModule<ModuleOptions>({
             route: `${options.api.baseURL}/navigation/:qid/**:params`,
             handler: resolveRuntimeModule('./server/api/navigation')
           }, {
-            method: 'get',
-            route: `${options.api.baseURL}/navigation/:qid`,
-            handler: resolveRuntimeModule('./server/api/navigation')
-          },
+          method: 'get',
+          route: `${options.api.baseURL}/navigation/:qid`,
+          handler: resolveRuntimeModule('./server/api/navigation')
+        },
           {
             method: 'get',
             route: `${options.api.baseURL}/navigation`,
@@ -723,7 +724,7 @@ export default defineNuxtModule<ModuleOptions>({
       addVitePlugin({
         enforce: 'post',
         name: 'nuxt:content:tailwindcss',
-        handleHotUpdate (ctx) {
+        handleHotUpdate(ctx) {
           if (!contentSources.some(cs => ctx.file.startsWith(cs))) {
             return
           }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue
#2343 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
Added a regex line to match ContentSlot in Pug template. Resolves #2343 
### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
