### PR TITLE
fix: ignore regexes in fetchDirConfig

### DIFF
--- a/src/runtime/query/match/pipeline.ts
+++ b/src/runtime/query/match/pipeline.ts
@@ -74,11 +74,13 @@ export function createPipelineFetcher<T> (getContentsList: () => Promise<T[]>) {
     },
     function fetchDirConfig (state, params, db) {
       if (params.dirConfig) {
-        const path = (state.result[0] as any)?._path || params.where?.find(w => w._path)?._path as string
-        const dirConfig = db.find((item: any) => item._path === joinURL(path, '_dir'))
-        if (dirConfig) {
-          // @ts-ignore
-          state.dirConfig = { _path: dirConfig._path, ...withoutKeys(['_'])(dirConfig) }
+        const path = (state.result[0] as any)?._path || params.where?.find(w => w._path)?._path as (string | RegExp)
+        if (typeof path === 'string') {
+          const dirConfig = db.find((item: any) => item._path === joinURL(path, '_dir'))
+          if (dirConfig) {
+            // @ts-ignore
+            state.dirConfig = { _path: dirConfig._path, ...withoutKeys(['_'])(dirConfig) }
+          }
         }
       }
       return state


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Since #2213 (?), our build generates a lot of the following error. After digging in the nuxt content code, it seems that one of our `queryContent` call is generating a regex in `$where`, which leads to that crash.


```
 ERROR  [nuxt] [request error] [unhandled] [500] input.endsWith is not a function                                                                                        3:49:03 PM
  at withTrailingSlash (./node_modules/.pnpm/ufo@1.3.1/node_modules/ufo/dist/index.mjs:327:18)
  at joinURL (./node_modules/.pnpm/ufo@1.3.1/node_modules/ufo/dist/index.mjs:389:13)
  at ./.nuxt/prerender/chunks/nitro/nitro-prerenderer.mjs:17008:60
  at Array.find (<anonymous>)
  at fetchDirConfig (./.nuxt/prerender/chunks/nitro/nitro-prerenderer.mjs:17008:30)
  at ./.nuxt/prerender/chunks/nitro/nitro-prerenderer.mjs:17041:63
  at Array.reduce (<anonymous>)
  at ./.nuxt/prerender/chunks/nitro/nitro-prerenderer.mjs:17041:39
  at async ./.nuxt/prerender/chunks/nitro/nitro-prerenderer.mjs:17343:21
  at async Object.handler (./node_modules/.pnpm/h3@1.8.2/node_modules/h3/dist/index.mjs:1630:19)
```

```
const page = await queryContent('en')
  .where({
    pid: 'general'
  })
 .findOne();
```

Which generates:

```
{
  where: [ { pid: 'general' }, { _path: /^\/en/ } ],
  first: true,
  sort: [ { _file: 1, '$numeric': true } ],
  dirConfig: true 
}
```

I'm not sure if I need to add a regression somewhere, I didn't find any related tests and it's first time digging in this codebase :)

Thanks!

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
