### PR TITLE
fix: enable cache only for clientDb

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -239,7 +239,7 @@ export interface ModuleOptions {
 
     /**
      * Control content cach generation.
-     * 
+     *
      * This option might be removed in the next major version.
      */
     cacheContents?: boolean

--- a/src/module.ts
+++ b/src/module.ts
@@ -424,15 +424,22 @@ export default defineNuxtModule<ModuleOptions>({
           method: 'get',
           route: `${options.api.baseURL}/query`,
           handler: resolveRuntimeModule('./server/api/query')
-        },
-        {
+        }
+      )
+
+      if (options.experimental?.clientDB) {
+        nitroConfig.handlers.push({
           method: 'get',
           route: nuxt.options.dev
             ? `${options.api.baseURL}/cache.json`
             : `${options.api.baseURL}/cache.${buildIntegrity}.json`,
           handler: resolveRuntimeModule('./server/api/cache')
+        })
+
+        if (!nuxt.options.dev) {
+          nitroConfig.prerender.routes.unshift(`${options.api.baseURL}/cache.${buildIntegrity}.json`)
         }
-      )
+      }
 
       if (options.experimental?.search) {
         const route = nuxt.options.dev
@@ -451,10 +458,6 @@ export default defineNuxtModule<ModuleOptions>({
           // Use text/plain to avoid Nitro render an index.html
           headers: options.experimental.search.indexed ? { 'Content-Type': 'text/plain' } : { 'Content-Type': 'application/json' }
         }
-      }
-
-      if (!nuxt.options.dev) {
-        nitroConfig.prerender.routes.unshift(`${options.api.baseURL}/cache.${buildIntegrity}.json`)
       }
 
       // Register source storages

--- a/src/runtime/server/api/cache.ts
+++ b/src/runtime/server/api/cache.ts
@@ -9,7 +9,7 @@ export default defineEventHandler(async (event) => {
   const { content } = useRuntimeConfig()
   const now = Date.now()
   // Fetch all content
-  const contents = await serverQueryContent(event).find()
+  let contents = await serverQueryContent(event).find()
 
   // Generate Index
   await getContentIndex(event)
@@ -20,7 +20,7 @@ export default defineEventHandler(async (event) => {
   return {
     generatedAt: now,
     generateTime: Date.now() - now,
-    contents,
+    contents: content.experimental.cacheContents ? contents : [] as any,
     navigation
   }
 })

--- a/src/runtime/server/api/cache.ts
+++ b/src/runtime/server/api/cache.ts
@@ -9,7 +9,7 @@ export default defineEventHandler(async (event) => {
   const { content } = useRuntimeConfig()
   const now = Date.now()
   // Fetch all content
-  let contents = await serverQueryContent(event).find()
+  const contents = await serverQueryContent(event).find()
 
   // Generate Index
   await getContentIndex(event)


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

fix #2415

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
Enable the `/api/cache.json` endpoint only for the clientDb feature. Otherwise, it's unnecessary and can be a real pain (build perf and deployment) for huge website.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
