### PR TITLE
doc: link Nuxt Simple Sitemap for full featured sitemaps

### DIFF
--- a/docs/content/6.recipes/3.sitemap.md
+++ b/docs/content/6.recipes/3.sitemap.md
@@ -3,7 +3,11 @@ title: 'Sitemap'
 description: 'A sitemap file is useful for helping Google to better index your website, ensuring that the content you write can be visible in search results.'
 ---
 
-# Library
+Need a complete Sitemap solution? Check out [Nuxt Simple Sitemap](https://nuxtseo.com/sitemap/integrations/content), it integrates with Nuxt Content's document-driven mode and frontmatter.
+
+Otherwise, feel free to implement your own with the below guide.
+
+## Add dependencies
 
 This can be created by utilising the `sitemap` library, which can be installed as follows:
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

I believe this guide was made when there was no sitemap solution for Nuxt 3, now that there is and it integrates with Nuxt Content, I think it should be linked.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
