### PR TITLE
fix(docs): 7.search-content.md typo

### DIFF
--- a/docs/content/3.composables/7.search-content.md
+++ b/docs/content/3.composables/7.search-content.md
@@ -34,4 +34,4 @@ Only available when using the simple search, aka non-indexed search.
 
 ## UseFetchOptions
 
-An option is provided to customize the behavior of the `useFetch` composable used internally to only fetch the search content on client and lazy. This could avoid fetching the content on SSR and adding content to the `_payload.josn` file improving the performance of your app since `_payload` is loaded for hydration.
+An option is provided to customize the behavior of the `useFetch` composable used internally to only fetch the search content on client and lazy. This could avoid fetching the content on SSR and adding content to the `_payload.json` file improving the performance of your app since `_payload` is loaded for hydration.


### PR DESCRIPTION
_payload.josn should be _payload.json

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Fixed a typo in 7.search-content.md, _payload.josn should be _payload.json

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
