### PR TITLE
feat: add result hooks

### DIFF
--- a/docs/content/3.composables/1.query-content.md
+++ b/docs/content/3.composables/1.query-content.md
@@ -243,3 +243,40 @@ const count = await queryContent('articles')
 // Returns
 5 // number of articles
 ```
+
+## `resultHook(hook)`
+
+- `hook`
+  - Type: `(content: T) => HT`
+  - **Required**
+
+Add a hook for to be executed on the results of the content query.
+
+This hook is useful for simple transforms of returned content or validation of returned data with libraries such as `zod`.
+
+```ts
+// Some example front-matter on a content page
+const articleSchema = z.object({
+  navigation: z.object({
+    nextBtn: z.string()
+  })
+})
+
+// Validate each returned article
+const articles = await queryContent('articles')
+  .resultHook(c => articleSchema.parse(c))
+  .find()
+```
+
+You can also use `resultHook(hook)` to augment the returned content with new fields.
+
+```ts
+// Count of articles
+const articles = await queryContent('articles')
+  .resultHook(c => {
+    ...c,
+    newField: 'some-data'
+  })
+  .find()
+```
+

--- a/src/runtime/query/query.ts
+++ b/src/runtime/query/query.ts
@@ -32,14 +32,14 @@ export function createQuery <T = ParsedContent> (fetcher: ContentQueryFetcher<T>
 
   const resolveResultHooks = (result: any) => {
     let res = result
-    for (let h of resultHooks) {
+    for (const h of resultHooks) {
       res = h(res)
     }
     return res
   }
 
   const resolveResult = (result: any) => {
-    let ret: any
+    let ret = result
     if (opts.legacy) {
       if (result?.surround) {
         return result.surround
@@ -68,7 +68,7 @@ export function createQuery <T = ParsedContent> (fetcher: ContentQueryFetcher<T>
       return resolveResultHooks(ret)
     }
 
-    return result
+    return ret
   }
 
   const query: any = {

--- a/src/runtime/types/index.d.ts
+++ b/src/runtime/types/index.d.ts
@@ -492,6 +492,11 @@ export interface QueryBuilder<T = ParsedContentMeta> {
   locale(locale: string): QueryBuilder<T>
 
   /**
+   * Add result hook to returned content
+   */
+  resultHook<HT>(hook: (content: T) => HT): QueryBuilder<HT>
+
+  /**
    * Retrieve query builder params
    * @internal
    */

--- a/test/features/query/query.test.ts
+++ b/test/features/query/query.test.ts
@@ -329,4 +329,17 @@ describe('Database Provider', () => {
       expect(item._deleted).toBeUndefined()
     })
   })
+
+  test('Result Hook transform return', async () => {
+    const query = createQuery(pipelineFetcher, { legacy: true })
+      .where({ id: { $in: [1, 2] } })
+      .resultHook((c) => { return { transformedPath: c._path, exampleExtraField: 'hello' } })
+    const result = await query.find()
+
+    result.forEach((item: any) => {
+      expect(Object.keys(item)).toMatchObject(['transformedPath', 'exampleExtraField'])
+      assert(item.exampleExtraField === 'hello')
+      expect(item.id).toBeUndefined()
+    })
+  })
 })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

#1057

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

I have introduced a new feature result hooks. This feature is detailed in [#1057](https://github.com/nuxt/content/issues/1057#issuecomment-1821285848).

The primary aim of this feature is to allow for augmentations to the returned type to be performed within the query builder pipeline. This allows users to use libraries like `zod` to assert that the schema of the returned content is valid and expected.

I feel this feature will add a more type safe way to query content and throw errors for unexpected content structure earlier in the pipeline.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
