### PR TITLE
fix: ensure `bundler` module resolution works with runtime type imports

### DIFF
--- a/build.config.ts
+++ b/build.config.ts
@@ -1,0 +1,11 @@
+import { defineBuildConfig } from 'unbuild'
+
+export default defineBuildConfig({
+  entries: [
+    {
+      input: 'src/runtime/',
+      outDir: 'dist/runtime',
+      ext: 'js'
+    }
+  ]
+})

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
       "require": "./dist/module.cjs"
     },
     "./transformers": "./dist/runtime/transformers/index.js",
-    "./transformers/*": "./dist/runtime/transformers/*.js"
+    "./transformers/*": "./dist/runtime/transformers/*.js",
+    "./dist/runtime/types": "./dist/runtime/types/index.js"
   },
   "main": "./dist/module.cjs",
   "module": "./dist/module.mjs",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     },
     "./transformers": "./dist/runtime/transformers/index.js",
     "./transformers/*": "./dist/runtime/transformers/*.js",
+    "./types": "./dist/runtime/types/index.js",
     "./dist/runtime/types": "./dist/runtime/types/index.js"
   },
   "main": "./dist/module.cjs",

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
       "import": "./dist/module.mjs",
       "require": "./dist/module.cjs"
     },
-    "./transformers": "./dist/runtime/transformers/index.mjs",
-    "./transformers/*": "./dist/runtime/transformers/*.mjs"
+    "./transformers": "./dist/runtime/transformers/index.js",
+    "./transformers/*": "./dist/runtime/transformers/*.js"
   },
   "main": "./dist/module.cjs",
   "module": "./dist/module.mjs",

--- a/src/runtime/types/api.ts
+++ b/src/runtime/types/api.ts
@@ -22,3 +22,6 @@ export interface ContentQueryWithSurround<T> {
 export interface ContentQueryWithDirConfig {
   dirConfig: Record<string, any>
 }
+
+// Ensure that a .js file is emitted too
+export {}

--- a/src/runtime/types/index.ts
+++ b/src/runtime/types/index.ts
@@ -514,3 +514,6 @@ export interface NavItem {
 
   [key: string]: any
 }
+
+// Ensure that a .js file is emitted too
+export {}

--- a/src/runtime/types/query.ts
+++ b/src/runtime/types/query.ts
@@ -347,3 +347,6 @@ export interface ContentQueryBuilder<T = ParsedContentMeta, Y = {}> {
 }
 
 export type ContentQueryFetcher<T> = (query: ContentQueryBuilder<T>) => Promise<ContentQueryResponse>
+
+// Ensure that a .js file is emitted too
+export {}


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

resolves https://github.com/nuxt/content/issues/2469

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This adds support for Bundler TypeScript module resolution. It changes extensions of runtime dir files to `.js` which should be safe as this is a `type: module` project.

I also add a subpath for `@nuxt/content/dist/runtime/types` as this is already documented. But we could also have a more ergonomic subpath for type augmentation.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
