### PR TITLE
chore: remove unused argument

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -595,7 +595,7 @@ export default defineNuxtModule<ModuleOptions>({
     addTemplate({
       filename: 'content-components.mjs',
       getContents ({ options }) {
-        const components = options.getComponents(options.mode).filter((c: any) => !c.island).flatMap((c: any) => {
+        const components = options.getComponents().filter((c: any) => !c.island).flatMap((c: any) => {
           const exp = c.export === 'default' ? 'c.default || c' : `c['${c.export}']`
           const isClient = c.mode === 'client'
           const definitions: string[] = []


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

discovered in https://github.com/nuxt/nuxt/actions/runs/7472932540?pr=25109

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

It looks like `options.getComponents` doesn't accept an argument (L608). This removes the unused argument...

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
