### PR TITLE
docs: fix incorrect naming & link path in Component/Prose 

### DIFF
--- a/docs/content/1.get-started/2.configuration.md
+++ b/docs/content/1.get-started/2.configuration.md
@@ -174,7 +174,7 @@ Toggles the [document-driven mode](/document-driven/introduction).
 
 - Type: `false | object`
 
-Nuxt Content uses [Shikiji](https://github.com/antfu/shikiji) to provide syntax highlighting for [`ProseCode`](/components/prose#prosecode) and [`ProseCodeInline`](/components/prose#prosecodeinline).
+Nuxt Content uses [Shikiji](https://github.com/antfu/shikiji) to provide syntax highlighting for [`ProsePre`](/components/prose#prosepre) and [`ProseCodeInline`](/components/prose#prosecodeinline).
 
 | Option    |                     Type                     | Description                                                                                                         |
 | --------- | :------------------------------------------: | :------------------------------------------------------------------------------------------------------------------ |

--- a/docs/content/2.usage/2.markdown.md
+++ b/docs/content/2.usage/2.markdown.md
@@ -75,7 +75,7 @@ Example variables will be injected into the document:
 
 Nuxt Content uses [Shikiji](https://github.com/antfu/shikiji), that colors tokens with VSCode themes.
 
-Code highlighting works both on [`ProseCode`](/components/prose#prosecode) and [`ProseCodeInline`](/components/prose#prosecodeinline).
+Code highlighting works both on [`ProsePre`](/components/prose#prosepre) and [`ProseCodeInline`](/components/prose#prosecodeinline).
 
 Each line of a code block gets its line number in the `line` attribute so lines can be labeled or individually styled.
 
@@ -475,7 +475,7 @@ customVariable: 'Custom Value'
 
 ```
 
-### Example 2: Define in external with `<ContentRendererMarkdown>` 
+### Example 2: Define in external with `<ContentRendererMarkdown>`
 
 ```html
 <template>

--- a/docs/content/4.components/7.prose.md
+++ b/docs/content/4.components/7.prose.md
@@ -37,9 +37,9 @@ To overwrite a prose component, create a component with the same name in your pr
   ::
 ::
 
-## `ProseCode`
+## `ProsePre`
 
-[:icon{name="fa-brands:github" class="inline -mt-1 w-6"} Source](https://github.com/nuxt-modules/mdc/blob/main/src/runtime/components/prose/ProseCode.vue)
+[:icon{name="fa-brands:github" class="inline -mt-1 w-6"} Source](https://github.com/nuxt-modules/mdc/blob/main/src/runtime/components/prose/ProsePre.vue)
 
 ::code-group
   ```md [Code]
@@ -79,7 +79,7 @@ If you want to use `]` in the filename, you need to escape it with 2 backslashes
 
 ## `ProseCodeInline`
 
-[:icon{name="fa-brands:github" class="inline -mt-1 w-6"} Source](https://github.com/nuxt-modules/mdc/blob/main/src/runtime/components/prose/ProseCodeInline.vue)
+[:icon{name="fa-brands:github" class="inline -mt-1 w-6"} Source](https://github.com/nuxt-modules/mdc/blob/main/src/runtime/components/prose/ProseCode.vue)
 
 `code inline`.
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
According to https://github.com/nuxt/content/blob/main/src/module.ts#L343
We replace `ProseCode.vue` define into `ProseCodeInline.vue`
And using `ProsePre.vue` to wrap `ProseCode.vue`

So, if i want to use custom prose component, I have to named `ProsePre.vue` in order to replace the code block in `.md`

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
