### PR TITLE
build: do not emit `.mjs` in runtime directory

### DIFF
--- a/build.config.ts
+++ b/build.config.ts
@@ -1,11 +1,18 @@
 import { defineBuildConfig } from 'unbuild'
 
 export default defineBuildConfig({
-  entries: [
-    {
-      input: 'src/runtime/',
-      outDir: 'dist/runtime',
-      ext: 'js'
+  externals: [
+    '#build/types/layouts'
+  ],
+  hooks: {
+    'build:prepare' (ctx) {
+      ctx.options.entries = ctx.options.entries?.filter(entry => !entry.input?.includes('src/runtime'))
+      ctx.options.entries.push({
+        builder: 'mkdist',
+        input: 'src/runtime/',
+        outDir: 'dist/runtime',
+        ext: 'js'
+      })
     }
-  ]
+  }
 })

--- a/package.json
+++ b/package.json
@@ -120,10 +120,5 @@
     "hooks": {
       "after:bump": "npx changelogen@latest --no-commit --no-tag --output --r $(node -p \"require('./package.json').version\")"
     }
-  },
-  "build": {
-    "externals": [
-      "#build/types/layouts"
-    ]
   }
 }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

resolves https://github.com/nuxt/content/issues/2512

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

We probably need to fix this in nuxt/module-builder, but adding the new entrypoint didn't overwrite existing one, so both `.js` and `.mjs` files were being created.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
