### PR TITLE
perf(content-list): cache contents list during generation and per-request

### DIFF
--- a/src/runtime/server/storage.ts
+++ b/src/runtime/server/storage.ts
@@ -38,7 +38,7 @@ export const cacheStorage: Storage = prefixStorage(useStorage(), 'cache:content'
 export const cacheParsedStorage: Storage = prefixStorage(useStorage(), 'cache:content:parsed')
 
 const isProduction = process.env.NODE_ENV === 'production'
-const isPrerendering = process.argv?.includes('generate')
+const isPrerendering = import.meta.prerender
 
 const contentConfig = useRuntimeConfig().content
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue
resolves #2449
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The bottleneck in the pre-rendering phase is getting contents list from file system. By caching the list in the pre-render process, the generation time will drop significantly.

This change reduce the generation time in Content docs from 15s to 5s on my machine

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
