### PR TITLE
fix(types): use const type parameter for QueryBuilder.only

### DIFF
--- a/src/runtime/types/query.ts
+++ b/src/runtime/types/query.ts
@@ -280,8 +280,8 @@ export interface ContentQueryBuilder<T = ParsedContentMeta, Y = {}> {
   /**
    * Select a subset of fields
    */
-  only<K extends keyof T | string>(keys: K): ContentQueryBuilder<Pick<T, K>, Y>
-  only<K extends (keyof T | string)[]>(keys: K): ContentQueryBuilder<Pick<T, K[number]>, Y>
+  only<const K extends keyof T | string>(keys: K): ContentQueryBuilder<Pick<T, K>, Y>
+  only<const K extends (keyof T | string)[]>(keys: K): ContentQueryBuilder<Pick<T, K[number]>, Y>
 
   /**
    * Remove a subset of fields


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue
#2545 
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
Resolves #2545 
This PR enables having better types when using the .only() function and uses the const type parameter feature that was introduced in Typescript 5.0

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
