### PR TITLE
fix: split `getContent` to chunks in `getIndexedContentsList` (#2354)

### DIFF
--- a/src/runtime/server/content-index.ts
+++ b/src/runtime/server/content-index.ts
@@ -42,7 +42,7 @@ export async function getIndexedContentsList<T = ParsedContent> (event: H3Event,
     const keyChunks = [...chunksFromArray(keys, 10)]
 
     const contents = []
-    for (const chunk of keyChunks) {
+    for await (const chunk of keyChunks) {
       const result = await Promise.all(chunk.map(key => getContent(event, key)))
       contents.push(...result)
     }

--- a/src/runtime/server/content-index.ts
+++ b/src/runtime/server/content-index.ts
@@ -2,7 +2,7 @@ import type { H3Event } from 'h3'
 import type { ParsedContent } from '../types'
 import type { ContentQueryBuilder } from '../types/query'
 import { isPreview } from './preview'
-import { cacheStorage, getContent, getContentsList } from './storage'
+import { cacheStorage, chunksFromArray, getContent, getContentsList } from './storage'
 import { useRuntimeConfig } from '#imports'
 
 export async function getContentIndex (event: H3Event) {
@@ -39,7 +39,13 @@ export async function getIndexedContentsList<T = ParsedContent> (event: H3Event,
       .filter(key => (path as any).test ? (path as any).test(key) : key === String(path))
       .flatMap(key => index[key])
 
-    const contents = await Promise.all(keys.map(key => getContent(event, key)))
+    const keyChunks = [...chunksFromArray(keys, 10)]
+
+    const contents = []
+    for (const chunk of keyChunks) {
+      const result = await Promise.all(chunk.map(key => getContent(event, key)))
+      contents.push(...result)
+    }
 
     return contents as unknown as Promise<T[]>
   }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
Resolves https://github.com/nuxt/content/issues/2354
Split `getContent` promises to chunks, to prevent EMFILE error.
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
