### PR TITLE
docs: correct default `highlight.langs` in JSDoc

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -177,7 +177,7 @@ export interface ModuleOptions {
      *
      * Unlike the `preload` option, when this option is provided, it will override the default languages.
      *
-     * @default ['js','ts','vue','css','html','vue','shell']
+     * @default ['js','jsx','json','ts','tsx','vue','css','html','vue','bash','md','mdc','yaml']
      */
     langs?: (ShikiLang | LanguageRegistration)[]
 


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The current JSDoc comment mentions that the default setting for highlight.langs is `['js', 'ts', 'vue', 'css', 'html', 'vue', 'shell']`. However, the actual default in @nuxtjs/mdc is `['js', 'jsx', 'json', 'ts', 'tsx', 'vue', 'css', 'html', 'vue', 'bash', 'md', 'mdc', 'yaml']`.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
