### PR TITLE
chore: fix Nuxt extends in renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,5 @@
 {
-  "extends": ["@nuxtjs"],
+  "extends": ["github>nuxt/renovate-config-nuxt"],
   "lockFileMaintenance": {
     "enabled": true
   },


### PR DESCRIPTION
### 🔗 Linked issue

related nuxt/modules#887

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)

### 📚 Description

The usage of [nuxt/renovate-config-nuxt](https://github.com/nuxt/renovate-config-nuxt) has been updated. Therefore, it has been fixed in this PR.

- ref: [fixed commit](https://github.com/nuxt/renovate-config-nuxt/commit/863fb61254efa17e435e4a58557a5243a4ee4655)

#### Usage diff

```suggestion
{
  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
  "extends": [
-   "@nuxtjs"
+   "github>nuxt/renovate-config-nuxt",
  ]
}
```

#### Related

The WARN that is occurring in #957 will be resolved with this fix. related nuxt/renovate-config-nuxt#58 .

```
WARN: Using npm packages for Renovate presets is now deprecated. Please migrate to repository-based presets instead.
```

#### 🙏 Note

The Renovate bot is currently working fine. Therefore, the priority of this pull request is low.
We would appreciate CI approval and review when you are free. 🙏

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
