### PR TITLE
fix(types): add const type parameter for .only() and .without()

### DIFF
--- a/src/runtime/types/index.ts
+++ b/src/runtime/types/index.ts
@@ -437,14 +437,14 @@ export interface QueryBuilder<T = ParsedContentMeta> {
   /**
    * Select a subset of fields
    */
-  only<K extends keyof T>(keys: K): QueryBuilder<Pick<T, K>>
-  only<K extends (keyof T)[]>(keys: K): QueryBuilder<Pick<T, K[number]>>
+  only<const K extends keyof T>(keys: K): QueryBuilder<Pick<T, K>>
+  only<const K extends (keyof T)[]>(keys: K): QueryBuilder<Pick<T, K[number]>>
 
   /**
    * Remove a subset of fields
    */
-  without<K extends keyof T | string>(keys: K): QueryBuilder<Omit<T, K>>
-  without<K extends (keyof T | string)[]>(keys: K): QueryBuilder<Omit<T, K[number]>>
+  without<const K extends keyof T | string>(keys: K): QueryBuilder<Omit<T, K>>
+  without<const K extends (keyof T | string)[]>(keys: K): QueryBuilder<Omit<T, K[number]>>
 
   /**
    * Sort results

--- a/src/runtime/types/query.ts
+++ b/src/runtime/types/query.ts
@@ -286,8 +286,8 @@ export interface ContentQueryBuilder<T = ParsedContentMeta, Y = {}> {
   /**
    * Remove a subset of fields
    */
-  without<K extends keyof T | string>(keys: K): ContentQueryBuilder<Omit<T, K>, Y>
-  without<K extends (keyof T | string)[]>(keys: K): ContentQueryBuilder<Omit<T, K[number]>, Y>
+  without<const K extends keyof T | string>(keys: K): ContentQueryBuilder<Omit<T, K>, Y>
+  without<const K extends (keyof T | string)[]>(keys: K): ContentQueryBuilder<Omit<T, K[number]>, Y>
 
   /**
    * Filter results


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue
#2546 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
> This PR enables having better types when using the .only() function and uses the const type parameter feature that was introduced in Typescript 5.0  

I noticed that my previous PR only included the .only() in runtime/types/query.ts when it should have also included the ones in runtime/types/index.ts 
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
