### PR TITLE
fix: optimise nested dependencies

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -408,7 +408,7 @@ export default defineNuxtModule<ModuleOptions>({
     extendViteConfig((config) => {
       config.optimizeDeps = config.optimizeDeps || {}
       config.optimizeDeps.include = config.optimizeDeps.include || []
-      config.optimizeDeps.include.push('@nuxtjs/content > slugify')
+      config.optimizeDeps.include.push('@nuxt/content > slugify')
 
       config.plugins?.push({
         name: 'content-slot',

--- a/src/module.ts
+++ b/src/module.ts
@@ -408,7 +408,7 @@ export default defineNuxtModule<ModuleOptions>({
     extendViteConfig((config) => {
       config.optimizeDeps = config.optimizeDeps || {}
       config.optimizeDeps.include = config.optimizeDeps.include || []
-      config.optimizeDeps.include.push('slugify')
+      config.optimizeDeps.include.push('@nuxtjs/content > slugify')
 
       config.plugins?.push({
         name: 'content-slot',

--- a/src/module.ts
+++ b/src/module.ts
@@ -801,6 +801,12 @@ export default defineNuxtModule<ModuleOptions>({
 
     await installModule('@nuxtjs/mdc', nuxtMDCOptions)
 
+    // Update mdc optimizeDeps options
+    extendViteConfig((config) => {
+      config.optimizeDeps = config.optimizeDeps || {}
+      config.optimizeDeps.include = config.optimizeDeps.include?.map(id => id.replace(/^@nuxtjs\/mdc > /, '@nuxt/content >'))
+    })
+
     nuxt.options.runtimeConfig.public.content = defu(nuxt.options.runtimeConfig.public.content, {
       locales: options.locales,
       defaultLocale: contentContext.defaultLocale,


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

resolves https://github.com/nuxt/content/issues/2381 together with https://github.com/nuxt-modules/mdc/pull/160

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Vite requires dependencies that are optimised to be installed, but `slugify` won't be directly installed by users. So we can indicate to vite to resolve the dependency from within another dependency that _is_ installed, in this case `@nuxt/content`...

We also have to modify the list for deps injected by `@nuxtjs/mdc` as that module won't be directly installed _either_.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
