### PR TITLE
fix: opt in to `import.meta.*` properties

### DIFF
--- a/src/runtime/composables/head.ts
+++ b/src/runtime/composables/head.ts
@@ -26,7 +26,7 @@ export const useContentHead = (
     const title = head.title || data?.title
     if (title) {
       head.title = title
-      if (process.server && !head.meta.some(m => m.property === 'og:title')) {
+      if (import.meta.server && !head.meta.some(m => m.property === 'og:title')) {
         head.meta.push({
           property: 'og:title',
           content: title as string
@@ -35,14 +35,14 @@ export const useContentHead = (
     }
 
     const host = config.public.content.host
-    // if (process.server && !host) {
+    // if (import.meta.server && !host) {
     //   const req = useRequestEvent().node?.req
     //   if (req && req.headers.host !== 'localhost') {
     //     const protocol = req.headers['x-forwarded-proto'] || req.connection.encrypted ? 'https' : 'http'
     //     host = `${protocol}://${req.headers.host}`
     //   }
     // }
-    if (process.server && host) {
+    if (import.meta.server && host) {
       const _url = joinURL(host ?? '/', config.app.baseURL, to.fullPath)
       const url = config.public.content.trailingSlash ? withTrailingSlash(_url) : withoutTrailingSlash(_url)
       if (!head.meta.some(m => m.property === 'og:url')) {
@@ -70,7 +70,7 @@ export const useContentHead = (
         content: description
       })
     }
-    if (process.server && description && !head.meta.some(m => m.property === 'og:description')) {
+    if (import.meta.server && description && !head.meta.some(m => m.property === 'og:description')) {
       head.meta.push({
         property: 'og:description',
         content: description
@@ -82,7 +82,7 @@ export const useContentHead = (
     const image = head?.image || data?.image
 
     // Shortcut for head.image to og:image in meta
-    if (process.server && image && head.meta.filter(m => m.property === 'og:image').length === 0) {
+    if (import.meta.server && image && head.meta.filter(m => m.property === 'og:image').length === 0) {
       // Handles `image: '/image/src.jpg'`
       if (typeof image === 'string') {
         head.meta.push({
@@ -125,7 +125,7 @@ export const useContentHead = (
     }
 
     // @ts-ignore
-    if (process.client) { nextTick(() => useHead(head)) } else { useHead(head) }
+    if (import.meta.client) { nextTick(() => useHead(head)) } else { useHead(head) }
   }
 
   watch(() => unref(_content), refreshHead, { immediate: true })

--- a/src/runtime/composables/navigation.ts
+++ b/src/runtime/composables/navigation.ts
@@ -24,7 +24,7 @@ export const fetchContentNavigation = async (queryBuilder?: QueryBuilder | Query
     : withContentBase(process.dev ? `/navigation/${hash(params)}` : `/navigation/${hash(params)}.${content.integrity}.json`)
 
   // Add `prefetch` to `<head>` in production
-  if (!process.dev && process.server) {
+  if (!process.dev && import.meta.server) {
     addPrerenderPath(apiPath)
   }
 

--- a/src/runtime/composables/preview.ts
+++ b/src/runtime/composables/preview.ts
@@ -5,7 +5,7 @@ let showWarning = true
 export const useContentPreview = () => {
   const getPreviewToken = () => {
     return useCookie('previewToken').value ||
-    (process.client && sessionStorage.getItem('previewToken')) ||
+    (import.meta.client && sessionStorage.getItem('previewToken')) ||
     undefined
   }
 
@@ -14,7 +14,7 @@ export const useContentPreview = () => {
 
     useRoute().query.preview = token || ''
 
-    if (process.client) {
+    if (import.meta.client) {
       if (token) {
         sessionStorage.setItem('previewToken', token)
       } else {
@@ -42,7 +42,7 @@ export const useContentPreview = () => {
       return true
     }
 
-    if (process.client && sessionStorage.getItem('previewToken')) {
+    if (import.meta.client && sessionStorage.getItem('previewToken')) {
       return true
     }
 

--- a/src/runtime/composables/query.ts
+++ b/src/runtime/composables/query.ts
@@ -22,7 +22,7 @@ export const createQueryFetch = <T = ParsedContent>() => async (query: ContentQu
     : withContentBase(process.dev ? '/query' : `/query/${hash(params)}.${content.integrity}.json`)
 
   // Prefetch the query
-  if (!process.dev && process.server) {
+  if (!process.dev && import.meta.server) {
     addPrerenderPath(apiPath)
   }
 

--- a/src/runtime/composables/utils.ts
+++ b/src/runtime/composables/utils.ts
@@ -40,7 +40,7 @@ export const addPrerenderPath = (path: string) => {
 
 export const shouldUseClientDB = () => {
   const { experimental } = useRuntimeConfig().public.content
-  if (process.server) { return false }
+  if (import.meta.server) { return false }
   if (experimental.clientDB) { return true }
 
   return useContentPreview().isEnabled()

--- a/src/runtime/legacy/composables/navigation.ts
+++ b/src/runtime/legacy/composables/navigation.ts
@@ -24,7 +24,7 @@ export const fetchContentNavigation = async (queryBuilder?: QueryBuilder | Query
     : withContentBase(process.dev ? `/navigation/${hash(params)}` : `/navigation/${hash(params)}.${content.integrity}.json`)
 
   // Add `prefetch` to `<head>` in production
-  if (!process.dev && process.server) {
+  if (!process.dev && import.meta.server) {
     addPrerenderPath(apiPath)
   }
 

--- a/src/runtime/legacy/composables/query.ts
+++ b/src/runtime/legacy/composables/query.ts
@@ -21,7 +21,7 @@ export const createQueryFetch = <T = ParsedContent>() => async (query: QueryBuil
     : withContentBase(process.dev ? '/query' : `/query/${hash(params)}.${content.integrity}.json`)
 
   // Prefetch the query
-  if (!process.dev && process.server) {
+  if (!process.dev && import.meta.server) {
     addPrerenderPath(apiPath)
   }
 

--- a/src/runtime/legacy/plugins/documentDriven.ts
+++ b/src/runtime/legacy/plugins/documentDriven.ts
@@ -254,7 +254,7 @@ export default defineNuxtPlugin((nuxt) => {
   }
 
   // Prefetch page content
-  if (process.client) {
+  if (import.meta.client) {
     const router = useRouter()
     nuxt.hook('link:prefetch', (link) => {
       if (!(link in pages.value) && !hasProtocol(link)) {
@@ -275,7 +275,7 @@ export default defineNuxtPlugin((nuxt) => {
   // Route middleware
   addRouteMiddleware(async (to, from) => {
     // Avoid calling on hash change
-    if (process.client && !isClientDBEnabled && to.path === from.path) {
+    if (import.meta.client && !isClientDBEnabled && to.path === from.path) {
       if (!to.meta.layout) {
         const _path = withoutTrailingSlash(to.path)
         if (pages.value[_path]) {
@@ -297,7 +297,7 @@ export default defineNuxtPlugin((nuxt) => {
   })
 
   // @ts-ignore - Refresh on client-side
-  nuxt.hook('app:data:refresh', async () => process.client && await refresh(useRoute(), true))
+  nuxt.hook('app:data:refresh', async () => import.meta.client && await refresh(useRoute(), true))
 })
 
 function prefetchBodyComponents (nodes: MarkdownNode[]) {

--- a/src/runtime/pages/document-driven.vue
+++ b/src/runtime/pages/document-driven.vue
@@ -6,7 +6,7 @@ const { contentHead } = useRuntimeConfig().public.content
 const { page, layout } = useContent()
 
 // Page not found, set correct status code on SSR
-if (!(page as any).value && process.server) {
+if (!(page as any).value && import.meta.server) {
   const event = useRequestEvent()
   event.res.statusCode = 404
 }

--- a/src/runtime/plugins/documentDriven.ts
+++ b/src/runtime/plugins/documentDriven.ts
@@ -235,7 +235,7 @@ export default defineNuxtPlugin((nuxt) => {
   }
 
   // Prefetch page content
-  if (process.client) {
+  if (import.meta.client) {
     const router = useRouter()
     nuxt.hook('link:prefetch', (link) => {
       if (!(link in pages.value) && !hasProtocol(link)) {
@@ -256,7 +256,7 @@ export default defineNuxtPlugin((nuxt) => {
   // Route middleware
   addRouteMiddleware(async (to, from) => {
     // Avoid calling on hash change
-    if (process.client && !isClientDBEnabled && to.path === from.path) {
+    if (import.meta.client && !isClientDBEnabled && to.path === from.path) {
       if (!to.meta.layout) {
         const _path = withoutTrailingSlash(to.path)
         if (pages.value[_path]) {
@@ -278,7 +278,7 @@ export default defineNuxtPlugin((nuxt) => {
   })
 
   // @ts-ignore - Refresh on client-side
-  nuxt.hook('app:data:refresh', async () => process.client && await refresh(useRoute(), true))
+  nuxt.hook('app:data:refresh', async () => import.meta.client && await refresh(useRoute(), true))
 })
 
 function prefetchBodyComponents (nodes: MarkdownNode[]) {

--- a/src/runtime/plugins/ws.ts
+++ b/src/runtime/plugins/ws.ts
@@ -3,7 +3,7 @@ import { defineNuxtPlugin, useRuntimeConfig } from '#imports'
 export default defineNuxtPlugin(() => {
   const publicConfig = useRuntimeConfig().public
 
-  if (process.client && publicConfig.content.wsUrl) {
+  if (import.meta.client && publicConfig.content.wsUrl) {
     // Connect to websocket
     import('../composables/web-socket').then(({ useContentWebSocket }) => useContentWebSocket())
   }

--- a/src/runtime/transformers/component-resolver.ts
+++ b/src/runtime/transformers/component-resolver.ts
@@ -35,7 +35,7 @@ export default defineTransformer({
   name: 'component-resolver',
   extensions: ['.*'],
   async transform (content, options = {}) {
-    if (process.server) {
+    if (import.meta.server) {
       // This transformer is only needed on client side to resolve components
       return content
     }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This is a very early PR to make this module compatible with [changes we expect to release in Nuxt v5](https://github.com/nuxt/nuxt/issues/25323).

In [Nuxt v3.7.0](https://github.com/nuxt/nuxt/releases/tag/v3.7.0) we added support for `import.meta.*` (see [original PR](https://github.com/nuxt/nuxt/pull/22428)) and we've been gradually updating docs and moving across from the old `process.*` patterned variables.

As I'm sure you're aware, these variables are replaced at build-time and enable tree-shaking in bundled code.
This change affects _runtime_ code (that is, that is processed by the Nuxt bundler, like vite or webpack) rather than code running in Node. So it really doesn't matter what the string is, but it makes more sense in an ESM-world to use `import.meta` rather than `process`.

(It might be worth updating the module compatibility as well to indicate it needs to have Nuxt v3.7.0+, but I'll leave that with you if you think this is a good approach.)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
