### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/docs/content/1.get-started/1.installation.md
+++ b/docs/content/1.get-started/1.installation.md
@@ -55,20 +55,9 @@ npm run dev
 ## Add to a project
 
 You can add Nuxt Content at anytime during your Nuxt project development by installing the `@nuxt/content` module:
-
-::code-group
-```bash [pnpm]
-pnpm add @nuxt/content
+```bash
+npx nuxi@latest module add content
 ```
-
-```bash [yarn]
-yarn add @nuxt/content
-```
-
-```bash [npm]
-npm install @nuxt/content
-```
-::
 
 Then, add `@nuxt/content` to the `modules` section of `nuxt.config.ts`:
 

--- a/docs/content/7.v1/1.getting-started/2.installation.md
+++ b/docs/content/7.v1/1.getting-started/2.installation.md
@@ -4,16 +4,9 @@ description: 'Install @nuxt/content in only two steps in your Nuxt project.'
 ---
 
 Add `@nuxt/content` dependency to your project:
-
-::code-group
-```bash [Yarn]
-yarn add @nuxt/content@^1
+```bash
+npx nuxi@latest module add content
 ```
-
-```bash [NPM]
-npm install @nuxt/content@^1
-```
-::
 
 Then, add `@nuxt/content` to the `modules` section of `nuxt.config.js`:
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description


This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
