### PR TITLE
chore: add missing space between two strings joined in logger.warn().

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -746,7 +746,7 @@ export default defineNuxtModule<ModuleOptions>({
               logger.warn([
                 'Using `<NuxtLayout>` inside `app.vue` will cause unwanted layout shifting in your application.',
                 'Consider removing `<NuxtLayout>` from `app.vue` and using it in your pages.'
-              ].join(''))
+              ].join(' '))
             }
           }
         })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

There was a missing space between two strings joined using the join() method within the logger.warn() function call. 

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
