### PR TITLE
fix: add Nitro hooks types declarations

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -22,7 +22,7 @@ import type { BuiltinLanguage as ShikiLang, BuiltinTheme as ShikiTheme, Language
 import { joinURL, withLeadingSlash, withTrailingSlash } from 'ufo'
 import { createStorage, type WatchEvent } from 'unstorage'
 import { name, version } from '../package.json'
-import type { MarkdownPlugin, QueryBuilderParams, QueryBuilderWhere } from './runtime/types'
+import type { MarkdownPlugin, ParsedContent, QueryBuilderParams, QueryBuilderWhere } from './runtime/types'
 import { makeIgnored } from './runtime/utils/config'
 import {
   CACHE_VERSION,
@@ -1051,5 +1051,13 @@ declare module '@nuxt/schema' {
   }
   interface PrivateRuntimeConfig {
     content: ModulePrivateRuntimeConfig & ContentContext;
+  }
+}
+
+// Keep sync with src/runtime/server/storage.ts
+declare module 'nitropack' {
+  interface NitroRuntimeHooks {
+    'content:file:beforeParse': (file: { _id: string; body: string }) => void;
+    'content:file:afterParse': (file: ParsedContent) => void;
   }
 }


### PR DESCRIPTION
### 🔗 Linked issue

#2177 

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Resolves #2177  by augmenting the NitroRuntimeHook typing to provide typings of hook `content:beforeParse` and `content:afterParse` (and also IDE intellisense of course)

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
