### PR TITLE
fix(search): keep page's beginning paragraphs

### DIFF
--- a/src/runtime/server/search.ts
+++ b/src/runtime/server/search.ts
@@ -1,5 +1,5 @@
 import type { H3Event } from 'h3'
-import type { ParsedContent, QueryBuilderWhere } from '../types'
+import type { MarkdownNode, ParsedContent, QueryBuilderWhere } from '../types'
 import { serverQueryContent } from '#content/server'
 
 export async function serverSearchContent (event: H3Event, filterQuery?: QueryBuilderWhere): Promise<ParsedContent[]> {
@@ -37,7 +37,7 @@ export function splitPageIntoSections (page: ParsedContent, { ignoredTags }: { i
   }
 
   // No section
-  let section = -1
+  let section = 0
   let previousHeadingLevel = 0
   const titles = []
   for (const item of page.body.children) {
@@ -76,7 +76,7 @@ export function splitPageIntoSections (page: ParsedContent, { ignoredTags }: { i
     if (!isHeading(tag)) {
       if (!sections[section]) {
         sections[section] = {
-          id: '',
+          id: path,
           title: '',
           titles: [],
           content: '',
@@ -92,12 +92,12 @@ export function splitPageIntoSections (page: ParsedContent, { ignoredTags }: { i
 }
 
 // TODO: Should be tested
-function extractTextFromAst (node: any, ignoredTags: string[] = []) {
+function extractTextFromAst (node: MarkdownNode, ignoredTags: string[] = []) {
   let text = ''
 
   // Get text from markdown AST
   if (node.type === 'text') {
-    text += node.value
+    text += (node.value || '').trim()
   }
 
   // Do not explore children
@@ -107,9 +107,7 @@ function extractTextFromAst (node: any, ignoredTags: string[] = []) {
 
   // Explore children
   if (node.children) {
-    for (const child of node.children) {
-      text += ' ' + extractTextFromAst(child, ignoredTags)
-    }
+    text += node.children.map(child => extractTextFromAst(child, ignoredTags)).filter(Boolean).join(' ')
   }
 
   return text


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR fixed custom search's issue with page's first paragraphs. 

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
