### PR TITLE
fix: init storage only when used

### DIFF
--- a/src/runtime/server/api/cache.ts
+++ b/src/runtime/server/api/cache.ts
@@ -15,7 +15,7 @@ export default defineEventHandler(async (event) => {
   await getContentIndex(event)
 
   const navigation: NavItem[] = await $fetch(`${content.api.baseURL}/navigation`)
-  await cacheStorage.setItem('content-navigation.json', navigation)
+  await cacheStorage().setItem('content-navigation.json', navigation)
 
   return {
     generatedAt: now,

--- a/src/runtime/server/api/navigation.ts
+++ b/src/runtime/server/api/navigation.ts
@@ -10,7 +10,7 @@ export default defineEventHandler(async (event) => {
 
   // Read from cache if not preview and there is no query
   if (!isPreview(event) && Object.keys(query).length === 0) {
-    const cache = await cacheStorage.getItem('content-navigation.json')
+    const cache = await cacheStorage().getItem('content-navigation.json')
     if (cache) {
       return cache
     }

--- a/src/runtime/server/content-index.ts
+++ b/src/runtime/server/content-index.ts
@@ -7,7 +7,7 @@ import { useRuntimeConfig } from '#imports'
 
 export async function getContentIndex (event: H3Event) {
   const defaultLocale = useRuntimeConfig().content.defaultLocale
-  let contentIndex = await cacheStorage.getItem('content-index.json') as Record<string, string[]>
+  let contentIndex = await cacheStorage().getItem('content-index.json') as Record<string, string[]>
   if (!contentIndex) {
     // Fetch all contents
     const data = await getContentsList(event)
@@ -22,7 +22,7 @@ export async function getContentIndex (event: H3Event) {
       return acc
     }, {} as Record<string, string[]>)
 
-    await cacheStorage.setItem('content-index.json', contentIndex)
+    await cacheStorage().setItem('content-index.json', contentIndex)
   }
 
   return contentIndex

--- a/src/runtime/server/storage.ts
+++ b/src/runtime/server/storage.ts
@@ -2,7 +2,7 @@ import { type StorageValue, prefixStorage, type Storage } from 'unstorage'
 import { joinURL, withLeadingSlash, withoutTrailingSlash } from 'ufo'
 import { hash as ohash } from 'ohash'
 import type { H3Event } from 'h3'
- 
+
 import defu from 'defu'
 import type { ParsedContent, ContentTransformer } from '../types'
 import { createQuery } from '../query/query'
@@ -33,9 +33,9 @@ interface ParseContentOptions {
   [key: string]: any
 }
 
-export const sourceStorage: Storage = prefixStorage(useStorage(), 'content:source')
-export const cacheStorage: Storage = prefixStorage(useStorage(), 'cache:content')
-export const cacheParsedStorage: Storage = prefixStorage(useStorage(), 'cache:content:parsed')
+export const sourceStorage = () => prefixStorage(useStorage(), 'content:source')
+export const cacheStorage = () => prefixStorage(useStorage(), 'cache:content')
+export const cacheParsedStorage = () => prefixStorage(useStorage(), 'cache:content:parsed')
 
 const isProduction = process.env.NODE_ENV === 'production'
 const isPrerendering = import.meta.prerender
@@ -60,7 +60,7 @@ const contentIgnorePredicate = (key: string) => {
     return false
   }
   if (invalidKeyCharacters.some(ik => key.includes(ik))) {
-     
+
     console.warn(`Ignoring [${key}]. File name should not contain any of the following characters: ${invalidKeyCharacters.join(', ')}`)
     return false
   }
@@ -72,24 +72,25 @@ export const getContentsIds = async (event: H3Event, prefix?: string) => {
   let keys: string[] = []
 
   if (isProduction) {
-    keys = await cacheParsedStorage.getKeys(prefix)
+    keys = await cacheParsedStorage().getKeys(prefix)
   }
+  const source = sourceStorage()
 
   // Later: handle preview mode, etc
   if (keys.length === 0) {
-    keys = await sourceStorage.getKeys(prefix)
+    keys = await source.getKeys(prefix)
   }
 
   if (isPreview(event)) {
     const { key } = getPreview(event)
     const previewPrefix = `preview:${key}:${prefix || ''}`
-    const previewKeys = await sourceStorage.getKeys(previewPrefix)
+    const previewKeys = await source.getKeys(previewPrefix)
 
     if (previewKeys.length) {
       const keysSet = new Set(keys)
       await Promise.all(
         previewKeys.map(async (key) => {
-          const meta = await sourceStorage.getMeta(key)
+          const meta = await source.getMeta(key)
           if (meta?.__deleted) {
             keysSet.delete(key.substring(previewPrefix.length))
           } else {
@@ -156,22 +157,24 @@ export const getContent = async (event: H3Event, id: string): Promise<ParsedCont
   if (!contentIgnorePredicate(id)) {
     return { _id: contentId, body: null }
   }
+  const source = sourceStorage()
+  const cache = cacheParsedStorage()
 
   if (isPreview(event)) {
     const { key } = getPreview(event)
     const previewId = `preview:${key}:${id}`
-    const draft = await sourceStorage.getItem(previewId)
+    const draft = await source.getItem(previewId)
     if (draft) {
       id = previewId
     }
   }
 
-  const cached: any = await cacheParsedStorage.getItem(id)
+  const cached: any = await cache.getItem(id)
   if (isProduction && cached) {
     return cached.parsed
   }
 
-  const meta = await sourceStorage.getMeta(id)
+  const meta = await source.getMeta(id)
   const mtime = meta.mtime
   const size = meta.size || 0
   const hash = ohash({
@@ -190,7 +193,7 @@ export const getContent = async (event: H3Event, id: string): Promise<ParsedCont
   if (!pendingPromises[id + hash]) {
     // eslint-disable-next-line no-async-promise-executor
     pendingPromises[id + hash] = new Promise(async (resolve) => {
-      const body = await sourceStorage.getItem(id)
+      const body = await source.getItem(id)
 
       if (body === null) {
         return resolve({ _id: contentId, body: null } as unknown as ParsedContent)
@@ -198,7 +201,7 @@ export const getContent = async (event: H3Event, id: string): Promise<ParsedCont
 
       const parsed = await parseContent(contentId, body) as ParsedContent
 
-      await cacheParsedStorage.setItem(id, { parsed, hash }).catch(() => {})
+      await cache.setItem(id, { parsed, hash }).catch(() => {})
 
       resolve(parsed)
 

--- a/src/runtime/server/storage.ts
+++ b/src/runtime/server/storage.ts
@@ -1,4 +1,4 @@
-import { type StorageValue, prefixStorage, type Storage } from 'unstorage'
+import { type StorageValue, prefixStorage } from 'unstorage'
 import { joinURL, withLeadingSlash, withoutTrailingSlash } from 'ufo'
 import { hash as ohash } from 'ohash'
 import type { H3Event } from 'h3'


### PR DESCRIPTION
This resolves an issue when using nitro-nightly and pre-rendering the pages:

![CleanShot 2024-06-19 at 17 19 05@2x](https://github.com/nuxt/content/assets/904724/b7f5f34d-7eca-441d-affd-428296787eec)

It also avoid creating the storage when not used for better performance 🚀 