### PR TITLE
fix(module): do not force prerender index page

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -155,11 +155,6 @@ export default defineNuxtModule<ModuleOptions>({
       nitroConfig.prerender.routes = nitroConfig.prerender.routes || []
       nitroConfig.handlers = nitroConfig.handlers || []
 
-      // https://github.com/nuxt/nuxt/issues/27490#issuecomment-2162890462
-      if (nitroConfig.prerender.routes.indexOf('/') === -1) {
-        nitroConfig.prerender.routes.push('/')
-      }
-
       // Add server handlers
       nitroConfig.handlers.push(
         {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue
Reported in https://github.com/nuxt/content/pull/2673#issuecomment-2185008228
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Do not manipulate pre-render routes in module and let Nuxt handle missing `/` in pre-render routes
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
