### PR TITLE
fix(dev-cache): hot reload for documentDriven: false

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -406,6 +406,11 @@ export default defineNuxtModule<ModuleOptions>({
       addImports({ name: 'navigationDisabled', as: 'fetchContentNavigation', from: resolveRuntimeModule('./composables/utils') })
     }
 
+    // Enable hot reload for dev server
+    if (nuxt.options.dev) {
+      addServerPlugin(resolveRuntimeModule("./server/plugins/refresh-cache"));
+    }
+
     // Register document-driven
     if (options.documentDriven) {
       // Enable every feature by default
@@ -443,9 +448,6 @@ export default defineNuxtModule<ModuleOptions>({
           ? './plugins/documentDriven'
           : './legacy/plugins/documentDriven'
       ))
-      if (nuxt.options.dev) {
-        addServerPlugin(resolveRuntimeModule("./server/plugins/refresh-cache"));
-      }
 
       if (options.documentDriven.injectPage) {
         nuxt.options.pages = true


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

#2674

Previous PR: #2675

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Fixing a bug introduced by my previous PR
> perf(dev-cache): improve localhost markdown page navigation performance (when having 2,000+ pages) #2675

(sorry about that 💦)

By loading the `refresh-cache.ts` plugin only for `options.documentDriven` enabled, hot reload on dev server does not work when `documentDriven` is disabled.

### Reproduction

The bug can be reproduced via
https://github.com/coffeephile/nuxt-huge-project-test/tree/nuxt-content-performance-patch?tab=readme-ov-file#run-with-performance-patch

- when applying `./patch-content-localhost-old.sh` the code of the current `content` -> `main` branch gets applied and hot reload does not work.
- when applying `./patch-content-localhost.sh` the new code of this PR gets applied and hot reload is fixed, even when `documentDriven` is disabled.


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
