### PR TITLE
fix: add missing `await` keyword in search documentation

### DIFF
--- a/docs/content/2.usage/3.search.md
+++ b/docs/content/2.usage/3.search.md
@@ -29,7 +29,7 @@ You can use the [`searchContent`](/composables/search-content) composable to sea
 <script lang="ts" setup>
 const search  = ref('')
 
-const results = searchContent(search)
+const results = await searchContent(search)
 </script>
 
 <template>


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

One of the code examples in the [search usage  documentation](https://content.nuxt.com/usage/search) was rendering a promise in html instead of the actual result.
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
![Screenshot 2024-07-04 at 11 22 17](https://github.com/nuxt/content/assets/810579/ed0349d1-9a4a-4d1e-a295-6abd1e46238b)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
