### PR TITLE
fix: add string type to gt/lt/gte/lte type definitions

### DIFF
--- a/docs/content/7.v1/1.getting-started/4.fetching.md
+++ b/docs/content/7.v1/1.getting-started/4.fetching.md
@@ -76,6 +76,8 @@ const articles = await this.$content('articles').where({ title: { $eq: 'Home' } 
 
 // $gt
 const articles = await this.$content('articles').where({ age: { $gt: 18 } }).fetch()
+// $lte
+const articles = await this.$content('articles').where({ createdDateTime: { $lte: new Date().toISOString() } }).fetch()
 // $in
 const articles = await this.$content('articles').where({ name: { $in: ['odin', 'thor'] } }).fetch()
 ```

--- a/src/types/query.ts
+++ b/src/types/query.ts
@@ -124,7 +124,7 @@ export interface ContentQueryBuilderWhere extends Partial<Record<keyof ParsedCon
     })
     ```
    */
-  $gt?: number
+  $gt?: number | string
   /**
    * Check if item is greater than or equal to condition
    *
@@ -137,7 +137,7 @@ export interface ContentQueryBuilderWhere extends Partial<Record<keyof ParsedCon
     })
     ```
    */
-  $gte?: number
+  $gte?: number | string
   /**
    * Check if item is less than condition
    *
@@ -150,7 +150,7 @@ export interface ContentQueryBuilderWhere extends Partial<Record<keyof ParsedCon
     })
     ```
    */
-  $lt?: number
+  $lt?: number | string
   /**
    * Check if item is less than or equal to condition
    *
@@ -163,7 +163,7 @@ export interface ContentQueryBuilderWhere extends Partial<Record<keyof ParsedCon
     })
     ```
    */
-  $lte?: number
+  $lte?: number | string
   /**
    * Provides regular expression capabilities for pattern matching strings.
    *

--- a/test/features/query/match.test.ts
+++ b/test/features/query/match.test.ts
@@ -164,25 +164,33 @@ describe('Match', () => {
     })
   })
 
-  describe('Numerical operators', () => {
+  describe('Less-than/Greater-than operators', () => {
     test('$gt', () => {
       expect(match(item, { id: { $gt: 0 } })).toBe(true)
       expect(match(item, { id: { $gt: 1 } })).toBe(false)
+      expect(match(item, { category: { $gt: 'c' } })).toBe(true)
+      expect(match(item, { category: { $gt: 'c1' } })).toBe(false)
     })
 
     test('$gte', () => {
       expect(match(item, { id: { $gte: 1 } })).toBe(true)
       expect(match(item, { id: { $gte: 2 } })).toBe(false)
+      expect(match(item, { category: { $gte: 'c1' } })).toBe(true)
+      expect(match(item, { category: { $gte: 'c11' } })).toBe(false)
     })
 
     test('$lt', () => {
       expect(match(item, { id: { $lt: 2 } })).toBe(true)
       expect(match(item, { id: { $lt: 1 } })).toBe(false)
+      expect(match(item, { category: { $lt: 'c11' } })).toBe(true)
+      expect(match(item, { category: { $lt: 'c1' } })).toBe(false)
     })
 
     test('$lte', () => {
       expect(match(item, { id: { $lte: 1 } })).toBe(true)
       expect(match(item, { id: { $lte: 0 } })).toBe(false)
+      expect(match(item, { category: { $lte: 'c1' } })).toBe(true)
+      expect(match(item, { category: { $lte: 'c' } })).toBe(false)
     })
   })
 


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/content/issues/437

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The `$gte`, `$gt`, `$lt`, `$lte` operators are defined in the Typescript as only taking a number. This is in fact incorrect as they map to the standard JavaScript `>=`, `>`, `<`, `<=` operators which can handle any more types and as the test coverage shows they work perfect with strings.

This fix is needed as anyone trying to use these operators with a string - such as in a common case as filtering by alpha ranges or even a sort-formatted date string - will receive Typescript errors leading them to think this is not the way to do it.

This adds the `string` type to those operators, adds test coverage to prove they work and importantly adds an example to the filtering docs showing how to use the string filtering to sort by a date which is a common situation and one the linked ticket went into.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
