### PR TITLE
Update 5.typescript.md - changed types path

### DIFF
--- a/docs/content/2.usage/5.typescript.md
+++ b/docs/content/2.usage/5.typescript.md
@@ -23,7 +23,7 @@ The recommended way to do it is by using this method:
 
 ```vue
 <script setup lang="ts">
-import type { ParsedContent } from '@nuxt/content/dist/runtime/types'
+import type { ParsedContent } from '@nuxt/content'
 
 interface MyCustomParsedContent extends ParsedContent {
   yourOwn: 'keys'
@@ -45,7 +45,7 @@ type-safety.
 
 ```vue
 <script setup lang="ts">
-import type { MarkdownParsedContent } from '@nuxt/content/dist/runtime/types'
+import type { MarkdownParsedContent } from '@nuxt/content'
 
 interface Article extends MarkdownParsedContent {
   author: string


### PR DESCRIPTION
When importing types like that:
`import type { QueryBuilderParams } from '@nuxt/content/dist/runtime/types'`
- typescript gives an error: Cannot find module '@nuxt/content/dist/runtime/types' or its corresponding type declarations Making path: @nuxt/content fixes this error.

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
