### PR TITLE
fix: respect `draft` key as `_draft`

### DIFF
--- a/src/runtime/transformers/path-meta.ts
+++ b/src/runtime/transformers/path-meta.ts
@@ -40,7 +40,7 @@ export default defineTransformer({
     return <ParsedContent> {
       _path: filePath,
       _dir: filePath.split('/').slice(-2)[0],
-      _draft: content._draft ?? isDraft(_path),
+      _draft: isDraft(_path) || content._draft || content.draft,
       _partial: isPartial(_path),
       _locale,
       ...content,


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

- [issue in comment](https://github.com/nuxt/content/issues/1523#issuecomment-2262325189)
- [issue in comment](https://github.com/nuxt/content/pull/2648#issuecomment-2223573143)

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Fix [issue in comment](https://github.com/nuxt/content/issues/1523#issuecomment-2262325189) and [issue in comment](https://github.com/nuxt/content/pull/2648#issuecomment-2223573143) that `draft` key not work as expected as [document](https://content.nuxt.com/usage/markdown#front-matter) saying.

> 

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
