### PR TITLE
fix: experimental search type inference

### DIFF
--- a/src/types/module.ts
+++ b/src/types/module.ts
@@ -235,7 +235,7 @@ export interface ModuleOptions {
      *
      * @default undefined
      */
-    search?: {
+    search?: false | {
       /**
        * List of tags where text must not be extracted.
        *


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Experimental search mode missing boolean type inference.
If I try to use the default options by just passing `true`, I would get a typescript error.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
