### PR TITLE
fix(index): .gradient style overflow

### DIFF
--- a/docs/pages/index.vue
+++ b/docs/pages/index.vue
@@ -342,6 +342,7 @@ const { format: formatNumber } = Intl.NumberFormat('en-GB', { notation: 'compact
   filter: blur(180px);
   opacity: 0.6;
   z-index: -1;
+  left: 0;
 }
 
 .prose {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Hey, I noticed a small bug while browsing the homepage. It might not have appeared during testing, but it’s happening on my end.

The issue is mainly caused by the .gradient style, which is shifting to the right, resulting in an `x-overflow` problem.

I resolved it by using `left: 0`;.

![CleanShot 2024-08-20 at 22 11 14](https://github.com/user-attachments/assets/4071d6e9-6ece-4920-9e83-c501573ba29e)


### fix:

![CleanShot 2024-08-20 at 22 11 38](https://github.com/user-attachments/assets/2060eee2-f9ab-4267-8239-eb2f66c65ae8)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
