### PR TITLE
feat: using _path from front-matter to overwrite default path

### DIFF
--- a/src/runtime/transformers/path-meta.ts
+++ b/src/runtime/transformers/path-meta.ts
@@ -38,7 +38,7 @@ export default defineTransformer({
     const filePath = generatePath(parts.join('/'), { respectPathCase })
 
     return <ParsedContent> {
-      _path: filePath,
+      _path: content._path ?? filePath,
       _dir: filePath.split('/').slice(-2)[0],
       _draft: content._draft ?? isDraft(_path),
       _partial: isPartial(_path),


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue


### ❓ Type of change

Reference _path from front-matter that user can overwrite url path inside markdown file.

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

During the path-meta transformer generatePath is using slugify to auto-generate path from file name, but when I using file that including Japanese name, slugify will remove it, and will result to an incorrect url path.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
