### PR TITLE
fix(docs): add warning about using `ssr: false` with Content

### DIFF
--- a/docs/content/1.get-started/1.installation.md
+++ b/docs/content/1.get-started/1.installation.md
@@ -55,7 +55,7 @@ npm run dev
 ## Add to a project
 
 ::callout{type="warning"}
-⚠️ Nuxt Content requires `ssr: true` to be set in [Nuxt Config](https://nuxt.com/docs/guide/directory-structure/nuxt-config). Nuxt applications with `ssr: false` will generate as a Single-Page Application, which is currently incombatible with prerendering Nuxt Content files.
+⚠️ Nuxt Content requires `ssr: true` (default value) to be set in [Nuxt Config](https://nuxt.com/docs/guide/directory-structure/nuxt-config). Nuxt applications with `ssr: false` will generate as a Single-Page Application, which is currently incombatible with prerendering Nuxt Content files.
 ::
 
 You can add Nuxt Content at anytime during your Nuxt project development by installing the `@nuxt/content` module:

--- a/docs/content/1.get-started/1.installation.md
+++ b/docs/content/1.get-started/1.installation.md
@@ -54,6 +54,10 @@ npm run dev
 
 ## Add to a project
 
+::callout{type="warning"}
+⚠️ Nuxt Content requires `ssr: true` to be set in [Nuxt Config](https://nuxt.com/docs/guide/directory-structure/nuxt-config). Nuxt applications with `ssr: false` will generate as a Single-Page Application, which is currently incombatible with prerendering Nuxt Content files.
+::
+
 You can add Nuxt Content at anytime during your Nuxt project development by installing the `@nuxt/content` module:
 ```bash
 npx nuxi@latest module add content


### PR DESCRIPTION
Add warning about using Nuxt Content with SPA static generation (`ssr: false` in Nuxt Config) on the Installation guide in the documentation.

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue
[Issue #1229](https://github.com/nuxt/content/issues/1229)

### ❓ Type of change
Documentation edit

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The following change to the Installation page of the docs makes a note that Nuxt Content currently requires `ssr: true` to be set due to static SPA (`ssr: false`) being incompatible.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
