### PR TITLE
docs: fixed the smallest typo ever

### DIFF
--- a/docs/content/docs/3.utils/1.query-collection.md
+++ b/docs/content/docs/3.utils/1.query-collection.md
@@ -46,7 +46,7 @@ Search for contents that have specific `path`. (`path` is an special field in `p
 ```ts
 const route = useRoute()
 const { data } = await useAsyncData(route.path, () => {
-  return queryCollection('docs').path(rotue.path).first()
+  return queryCollection('docs').path(route.path).first()
 })
 ```
 


### PR DESCRIPTION
A small typo on the `queryCollection` section.
This will probably get copy / paste a lot.

Love the new @nuxt/content package so far.

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

I didn't find another issue for this typo. Also couldn't find any other typos.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
