### PR TITLE
feat(query): support complex SQL where conditions

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "@nuxt/kit": "^3.14.1592",
-    "@nuxtjs/mdc": "^0.9.5",
+    "@nuxtjs/mdc": "npm:@nuxtjs/mdc-edge@latest",
     "@sqlite.org/sqlite-wasm": "3.47.0-build1",
     "better-sqlite3": "^11.5.0",
     "c12": "^2.0.1",
@@ -121,8 +121,7 @@
   },
   "resolutions": {
     "@nuxt/content": "workspace:*",
-    "vue": "^3.5.12",
-    "@nuxtjs/mdc": "npm:@nuxtjs/mdc-edge@latest"
+    "vue": "^3.5.12"
   },
   "packageManager": "pnpm@9.14.2",
   "unbuild": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,6 @@ settings:
 overrides:
   '@nuxt/content': workspace:*
   vue: ^3.5.12
-  '@nuxtjs/mdc': npm:@nuxtjs/mdc-edge@latest
 
 importers:
 
@@ -1312,16 +1311,16 @@ packages:
     resolution: {integrity: sha512-AFbhEo10DP095/45EauinQJ5hJ3rJUmuuqltGguvc3WsvezZN+g8qNHLGWKu60FHQVizMrQY7VJ+zVlBXlQQkQ==}
     engines: {node: '>= 16'}
 
-  '@intlify/message-compiler@11.0.0-beta.1':
-    resolution: {integrity: sha512-yMXfN4hg/EeSdtWfmoMrwB9X4TXwkBoZlTIpNydQaW9y0tSJHGnUPRoahtkbsyACCm9leSJINLY4jQ0rK6BK0Q==}
+  '@intlify/message-compiler@11.0.0-beta.2':
+    resolution: {integrity: sha512-/cJHP1n45Zlf9tbm/hudLrUwXzJZngR9OMTQk32H1S4lBjM2996wzKTHuLbaJJlJZNTTjnfWZUHPb+F6sE6p1Q==}
     engines: {node: '>= 16'}
 
   '@intlify/shared@10.0.4':
     resolution: {integrity: sha512-ukFn0I01HsSgr3VYhYcvkTCLS7rGa0gw4A4AMpcy/A9xx/zRJy7PS2BElMXLwUazVFMAr5zuiTk3MQeoeGXaJg==}
     engines: {node: '>= 16'}
 
-  '@intlify/shared@11.0.0-beta.1':
-    resolution: {integrity: sha512-Md/4T/QOx7wZ7zqVzSsMx2M/9Mx/1nsgsjXS5SFIowFKydqUhMz7K+y7pMFh781aNYz+rGXYwad8E9/+InK9SA==}
+  '@intlify/shared@11.0.0-beta.2':
+    resolution: {integrity: sha512-N6ngJfFaVA0l2iLtx/SymgHOBW4wiS5Pyue7YmY/G+mrGjesi+S+U+u/Xlv6pZa/YIBfeM4QB07lI7rz1YqKLg==}
     engines: {node: '>= 16'}
 
   '@intlify/unplugin-vue-i18n@5.3.1':
@@ -8092,8 +8091,8 @@ snapshots:
 
   '@intlify/bundle-utils@9.0.0(vue-i18n@10.0.4(vue@3.5.13(typescript@5.6.3)))':
     dependencies:
-      '@intlify/message-compiler': 11.0.0-beta.1
-      '@intlify/shared': 11.0.0-beta.1
+      '@intlify/message-compiler': 11.0.0-beta.2
+      '@intlify/shared': 11.0.0-beta.2
       acorn: 8.14.0
       escodegen: 2.1.0
       estree-walker: 2.0.2
@@ -8124,14 +8123,14 @@ snapshots:
       '@intlify/shared': 10.0.4
       source-map-js: 1.2.1
 
-  '@intlify/message-compiler@11.0.0-beta.1':
+  '@intlify/message-compiler@11.0.0-beta.2':
     dependencies:
-      '@intlify/shared': 11.0.0-beta.1
+      '@intlify/shared': 11.0.0-beta.2
       source-map-js: 1.2.1
 
   '@intlify/shared@10.0.4': {}
 
-  '@intlify/shared@11.0.0-beta.1': {}
+  '@intlify/shared@11.0.0-beta.2': {}
 
   '@intlify/unplugin-vue-i18n@5.3.1(@vue/compiler-dom@3.5.13)(eslint@9.15.0(jiti@2.4.0))(rollup@4.27.3)(typescript@5.6.3)(vue-i18n@10.0.4(vue@3.5.13(typescript@5.6.3)))(vue@3.5.13(typescript@5.6.3))':
     dependencies:

--- a/src/runtime/nitro.ts
+++ b/src/runtime/nitro.ts
@@ -1,4 +1,4 @@
-import type { Collections, CollectionQueryBuilder, PageCollections, SurroundOptions, SQLOperator } from '@nuxt/content'
+import type { Collections, CollectionQueryBuilder, PageCollections, SurroundOptions, SQLOperator, QueryGroupFunction } from '@nuxt/content'
 import type { H3Event } from 'h3'
 import { collectionQureyBuilder } from './internal/query'
 import { generateNavigationTree } from './internal/navigation'
@@ -8,6 +8,8 @@ import { fetchQuery } from './internal/api'
 
 interface ChainablePromise<T extends keyof PageCollections, R> extends Promise<R> {
   where(field: keyof PageCollections[T] | string, operator: SQLOperator, value?: unknown): ChainablePromise<T, R>
+  andWhere(groupFactory: QueryGroupFunction<PageCollections[T]>): ChainablePromise<T, R>
+  orWhere(groupFactory: QueryGroupFunction<PageCollections[T]>): ChainablePromise<T, R>
   order(field: keyof PageCollections[T], direction: 'ASC' | 'DESC'): ChainablePromise<T, R>
 }
 
@@ -33,6 +35,14 @@ function chainablePromise<T extends keyof PageCollections, Result>(event: H3Even
   const chainable: ChainablePromise<T, Result> = {
     where(field, operator, value) {
       queryBuilder.where(String(field), operator, value)
+      return chainable
+    },
+    andWhere(groupFactory) {
+      queryBuilder.andWhere(groupFactory)
+      return chainable
+    },
+    orWhere(groupFactory) {
+      queryBuilder.orWhere(groupFactory)
       return chainable
     },
     order(field, direction) {

--- a/src/types/content.ts
+++ b/src/types/content.ts
@@ -54,6 +54,7 @@ export interface MarkdownOptions {
 export const ContentFileExtension = {
   Markdown: 'md',
   Yaml: 'yaml',
+  Yml: 'yml',
   Json: 'json',
   Csv: 'csv',
   Xml: 'xml',

--- a/src/types/query.ts
+++ b/src/types/query.ts
@@ -1,8 +1,9 @@
 export type SQLOperator = '=' | '>' | '<' | '<>' | 'in' | 'BETWEEN' | 'NOT BETWEEN' | 'IS NULL' | 'IS NOT NULL' | 'LIKE' | 'NOT LIKE'
 
+export type QueryGroupFunction<T> = (group: CollectionQueryGroup<T>) => CollectionQueryGroup<T>
+
 export interface CollectionQueryBuilder<T> {
   path(path: string): CollectionQueryBuilder<T>
-  where(field: string, operator: SQLOperator, value?: unknown): CollectionQueryBuilder<T>
   select<K extends keyof T>(...fields: K[]): CollectionQueryBuilder<Pick<T, K>>
   order(field: keyof T, direction: 'ASC' | 'DESC'): CollectionQueryBuilder<T>
   skip(skip: number): CollectionQueryBuilder<T>
@@ -10,4 +11,13 @@ export interface CollectionQueryBuilder<T> {
   all(): Promise<T[]>
   first(): Promise<T>
   count(field?: keyof T | '*', distinct?: boolean): Promise<number>
+  where(field: string, operator: SQLOperator, value?: unknown): CollectionQueryBuilder<T>
+  andWhere(groupFactory: QueryGroupFunction<T>): CollectionQueryBuilder<T>
+  orWhere(groupFactory: QueryGroupFunction<T>): CollectionQueryBuilder<T>
+}
+
+export interface CollectionQueryGroup<T> {
+  where(field: string, operator: SQLOperator, value?: unknown): CollectionQueryGroup<T>
+  andWhere(groupFactory: QueryGroupFunction<T>): CollectionQueryGroup<T>
+  orWhere(groupFactory: QueryGroupFunction<T>): CollectionQueryGroup<T>
 }

--- a/src/utils/schema.ts
+++ b/src/utils/schema.ts
@@ -32,5 +32,5 @@ export const pageSchema = z.object({
       description: z.string(),
       icon: z.string(),
     }),
-  ]).default(true),
+  ]).optional().default(true),
 })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Introduce `orWhere` and `andWhere` query functions to create complex where conditions

```ts
queryCollection('docs')
    .where('extension', '=', 'md')
    .or(group => group
      .where('navigation', '<>', 'false')
      .where('navigation', 'IS NULL'),
    )

Result will be:
select * from _content_docs where extension = 'md' AND (navigation <> 'false' OR navigation IS NULL)
```
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
