### PR TITLE
docs(migration): added migration instructions for ProsePre, ProseCode, and ProseCodeInline

### DIFF
--- a/docs/content/docs/1.getting-started/4.migration.md
+++ b/docs/content/docs/1.getting-started/4.migration.md
@@ -27,6 +27,9 @@ Here is the list of breaking changes in Content v3:
 - `searchContent()` is dropped in favor of new api `queryCollectionSearchSections`
   - Full text search can easily be done using this API See [Full-Text Search Snippets](/docs/advanced/fulltext-search)
 - `useContentHelpers()` is removed
+- We consolidated the `ProsePre`, `ProseCode`, and `ProseCodeInline` components
+  - `ProseCodeInline` is now `ProseCode`
+  - `ProseCode` is now `ProsePre`
 
 ## Implement Document Driven mode in v3
 
@@ -97,3 +100,15 @@ const v3Surround = await queryCollectionItemSurroundings(
   }
 )
 ```
+
+## Consolidate `ProsePre`, `ProseCode`, and `ProseCodeInline` components
+
+Many `ProsePre` components are thin wrappers around the `ProseCode` component. We've consolidated these three components into two components. There is now no difference between `ProsePre` and multi-line code blocks.
+
+1. MDC will now map and parse single backticks ``` as `ProseCode` instead of `ProseCodeInline`.
+2. Block code examples (starting with three backticks) will now be mapped to the `ProsePre` component.
+
+Suggested Changes
+1. Your _current_ `ProseCode` logic should be moved to `ProsePre`
+2. Rename your `ProseCodeInline` component to `ProseCode`
+


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

#2885 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

The handling of ProseCode, ProsePre, and ProseCodeInline have been updated in Nuxt Content v3. I didn't see instructions for this breaking change when I began my migration and opened a bug (it was not a bug, just a breaking change that hadn't been captured yet)

Resolves #2885 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
