### PR TITLE
perf: reduce zod bundle size

### DIFF
--- a/src/runtime/api/query.post.ts
+++ b/src/runtime/api/query.post.ts
@@ -1,5 +1,5 @@
 import { eventHandler, getRouterParam, readValidatedBody } from 'h3'
-import { z } from 'zod'
+import * as z from 'zod'
 import type { RuntimeConfig } from '@nuxt/content'
 import loadDatabaseAdapter, { checkAndImportDatabaseIntegrity } from '../internal/database.server'
 import { useRuntimeConfig } from '#imports'

--- a/src/utils/schema.ts
+++ b/src/utils/schema.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod'
+import * as z from 'zod'
 import { ContentFileExtension } from '../types/content'
 import { getEnumValues } from './zod'
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue
https://github.com/colinhacks/zod/issues/2596#issuecomment-1643053289

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
The `import { z }` syntax from Zod has issues with tree shaking, bloating the bundle size more than necessary. By switching to a namespace import the tree shaking can act more effectively

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
