### PR TITLE
fix(module): split big sql queries into two

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -282,7 +282,7 @@ async function processCollectionItems(nuxt: Nuxt, collections: ResolvedCollectio
 
       filesCount += _keys.length
 
-      const list: Array<Array<string>> = []
+      const list: Array<[string, Array<string>]> = []
       for await (const chunk of chunks(_keys, 25)) {
         await Promise.all(chunk.map(async (key) => {
           key = key.substring(fixed.length)
@@ -313,14 +313,14 @@ async function processCollectionItems(nuxt: Nuxt, collections: ResolvedCollectio
       }
       // Sort by file name to ensure consistent order
       list.sort((a, b) => String(a[0]).localeCompare(String(b[0])))
-      collectionDump[collection.name]!.push(...list.map(([, sql]) => sql!))
+      collectionDump[collection.name]!.push(...list.flatMap(([, sql]) => sql!))
 
       collectionChecksum[collection.name] = hash(collectionDump[collection.name])
 
       collectionDump[collection.name]!.push(
         generateCollectionTableDefinition(infoCollection, { drop: false }),
-        `DELETE FROM ${infoCollection.tableName} WHERE id = 'checksum_${collection.name}'`,
-        generateCollectionInsert(infoCollection, { id: `checksum_${collection.name}`, version: collectionChecksum[collection.name] }),
+        `DELETE FROM ${infoCollection.tableName} WHERE id = 'checksum_${collection.name}';`,
+        ...generateCollectionInsert(infoCollection, { id: `checksum_${collection.name}`, version: collectionChecksum[collection.name] }),
       )
     }
   }

--- a/src/runtime/internal/studio/collection.ts
+++ b/src/runtime/internal/studio/collection.ts
@@ -81,11 +81,11 @@ export function generateRecordUpdate(collection: CollectionInfo, stem: string, d
 }
 
 export function generateRecordDeletion(collection: CollectionInfo, stem: string) {
-  return `DELETE FROM ${collection.tableName} WHERE stem = '${stem}'`
+  return `DELETE FROM ${collection.tableName} WHERE stem = '${stem}';`
 }
 
 export function generateRecordSelectByColumn(collection: CollectionInfo, column: string, value: string) {
-  return `SELECT * FROM ${collection.tableName} WHERE ${column} = '${value}'`
+  return `SELECT * FROM ${collection.tableName} WHERE ${column} = '${value}';`
 }
 
 function computeValuesBasedOnCollectionSchema(collection: CollectionInfo, data: Record<string, unknown>) {

--- a/src/utils/collection.ts
+++ b/src/utils/collection.ts
@@ -98,7 +98,7 @@ function resolveSource(source: string | CollectionSource | CollectionSource[] | 
 }
 
 // Convert collection data to SQL insert statement
-export function generateCollectionInsert(collection: ResolvedCollection, data: Record<string, unknown>) {
+export function generateCollectionInsert(collection: ResolvedCollection, data: Record<string, unknown>): string[] {
   const fields: string[] = []
   const values: Array<string | number | boolean> = []
   const sortedKeys = getOrderedSchemaKeys((collection.extendedSchema).shape)
@@ -141,9 +141,40 @@ export function generateCollectionInsert(collection: ResolvedCollection, data: R
   })
 
   let index = 0
-
-  return `INSERT INTO ${collection.tableName} VALUES (${'?, '.repeat(values.length).slice(0, -2)})`
+  const sql = `INSERT INTO ${collection.tableName} VALUES (${'?, '.repeat(values.length).slice(0, -2)});`
     .replace(/\?/g, () => values[index++] as string)
+
+  if (sql.length < 100000) {
+    return [sql]
+  }
+
+  // Split the SQL into multiple statements
+  const bigColumn = [...values].sort((a, b) => String(b).length - String(a).length)[0]
+  const bigColumnIndex = values.indexOf(bigColumn)
+  const bigColumnName = fields[bigColumnIndex]
+
+  if (typeof bigColumn === 'string') {
+    let splitIndex = Math.floor(bigColumn.length / 2)
+    while (['\'', '"', '\\'].includes(bigColumn[splitIndex])) {
+      splitIndex -= 1
+    }
+
+    const part1 = bigColumn.slice(0, splitIndex) + '\''
+    const part2 = '\'' + bigColumn.slice(splitIndex)
+
+    values[bigColumnIndex] = part1
+    index = 0
+
+    return [
+      `INSERT INTO ${collection.tableName} VALUES (${'?, '.repeat(values.length).slice(0, -2)});`
+        .replace(/\?/g, () => values[index++] as string),
+      `UPDATE ${collection.tableName} SET ${bigColumnName} = ${part2} WHERE id = ${values[0]};`,
+    ]
+  }
+
+  return [
+    sql,
+  ]
 }
 
 // Convert a collection with Zod schema to SQL table definition

--- a/src/utils/dev.ts
+++ b/src/utils/dev.ts
@@ -41,11 +41,11 @@ export async function startSocketServer(nuxt: Nuxt, options: ModuleOptions, mani
     })
   }
 
-  async function broadcast(collection: ResolvedCollection, key: string, insertQuery?: string) {
-    const removeQuery = `DELETE FROM ${collection.tableName} WHERE id = '${key}'`
+  async function broadcast(collection: ResolvedCollection, key: string, insertQuery?: string[]) {
+    const removeQuery = `DELETE FROM ${collection.tableName} WHERE id = '${key}';`
     await db.exec(removeQuery)
     if (insertQuery) {
-      await db.exec(insertQuery)
+      await Promise.all(insertQuery.map(query => db.exec(query)))
     }
 
     const collectionDump = manifest.dump[collection.name]
@@ -54,7 +54,7 @@ export async function startSocketServer(nuxt: Nuxt, options: ModuleOptions, mani
     const itemsToRemove = keyIndex === -1 ? 0 : 1
 
     if (insertQuery) {
-      collectionDump?.splice(indexToUpdate, itemsToRemove, insertQuery)
+      collectionDump?.splice(indexToUpdate, itemsToRemove, ...insertQuery)
     }
     else {
       collectionDump?.splice(indexToUpdate, itemsToRemove)
@@ -124,7 +124,8 @@ export async function watchContents(nuxt: Nuxt, options: ModuleOptions, manifest
 
       if (localCache && localCache.checksum === checksum) {
         db.exec(`DELETE FROM ${collection.tableName} WHERE id = '${keyInCollection}'`)
-        db.exec(generateCollectionInsert(collection, JSON.parse(localCache.parsedContent)))
+        const insertQuery = generateCollectionInsert(collection, JSON.parse(localCache.parsedContent))
+        await Promise.all(insertQuery.map(query => db.exec(query)))
         return
       }
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

There is some situations that parsed content length might exceed 100K characters (specially for the files with multiple codeblock).

This PR breaks those insert queries into two queries one insert and one update

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
