### PR TITLE
fix(docs): ensure card prose on the homepage matches the correct title

### DIFF
--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -136,7 +136,7 @@ Nuxt Content is a module for Nuxt that provides a simple way to manage content f
   Navigation Generation
   
   #description{unwrap="p"}
-  Customize HTML typography tags with Vue components to give your content a consistent style.
+  Generate a structured object from your content files and display a navigation menu in minutes.
   :::
 
   :::u-page-card
@@ -149,7 +149,7 @@ Nuxt Content is a module for Nuxt that provides a simple way to manage content f
   Prose Components
   
   #description{unwrap="p"}
-  Nuxt Content works on all hosting providers, static, server, serverless & edge.
+  Customize HTML typography tags with Vue components to give your content a consistent style.
   :::
 
   :::u-page-card
@@ -162,7 +162,7 @@ Nuxt Content is a module for Nuxt that provides a simple way to manage content f
   Deploy everywhere
   
   #description{unwrap="p"}
-  Generate a structured object from your content files and display a navigation menu in minutes.
+  Nuxt Content works on all hosting providers, static, server, serverless & edge.
   :::
 ::
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

Admittedly I neglected to open a tracking issue for this. It's a very miniscule PR.

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

I noticed a few of the cards on the home page (https://content3.nuxt.org) were a bit out of order. It was really triggering my OCD, so I decided to switch 'em around real quick so all of the card bodies are matching the correct titles. It's less confusing for new users :)

If you're a visual person, like I am, this image pretty much sums up the changes I've made:

![image](https://github.com/user-attachments/assets/73c13311-4773-4426-8946-9af87dd830bc)


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
