### PR TITLE
feat: pre / post parsing hooks

### DIFF
--- a/docs/content/docs/7.advanced/5.hooks.md
+++ b/docs/content/docs/7.advanced/5.hooks.md
@@ -45,7 +45,7 @@ export interface FileAfterParseHook {
 ```ts
 export default defineNuxtConfig({
   hooks: {
-    'content:file:afterParse'(ctx) {
+    'content:file:afterParse'(ctx: FileAfterParseHook) {
       // ...
     }
   }

--- a/docs/content/docs/7.advanced/5.hooks.md
+++ b/docs/content/docs/7.advanced/5.hooks.md
@@ -5,14 +5,14 @@ navigation:
   title: Hooks
 ---
 
-## `content:parsed`{lang="ts"}
+## `collection:parsedFile`{lang="ts"}
 
 This hook is called after the content is parsed and before it is saved to the database.
 
 ```ts
 export default defineNuxtConfig({
   hooks: {
-    'content:parsed'(ctx) {
+    'collection:parsedFile'(ctx) {
       // { content: CollectionItemBase, collection: ResolvedCollection }
     }
   }

--- a/docs/content/docs/7.advanced/5.hooks.md
+++ b/docs/content/docs/7.advanced/5.hooks.md
@@ -13,14 +13,8 @@ It can be used to modify the raw content from a `file` before it is transformed
 or modify the transform options.
 
 ```ts
-export interface FileBeforeParseHook {
-  collection: ResolvedCollection
-  file: ContentFile
-  parserOptions: TransformContentOptions
-}
-```
+import type { FileBeforeParseHook } from '@nuxt/content'
 
-```ts
 export default defineNuxtConfig({
   hooks: {
     'content:file:beforeParse'(ctx: FileBeforeParseHook) {
@@ -35,14 +29,8 @@ export default defineNuxtConfig({
 This hook is called after the content is parsed and before it is saved to the database.
 
 ```ts
-export interface FileAfterParseHook {
-  collection: ResolvedCollection
-  file: ContentFile
-  content: ParsedContentFile
-}
-```
+import type { FileAfterParseHook } from '@nuxt/content'
 
-```ts
 export default defineNuxtConfig({
   hooks: {
     'content:file:afterParse'(ctx: FileAfterParseHook) {

--- a/docs/content/docs/7.advanced/5.hooks.md
+++ b/docs/content/docs/7.advanced/5.hooks.md
@@ -1,0 +1,20 @@
+---
+title: Hooks
+description: Modify your content using Nuxt build time hooks
+navigation:
+  title: Hooks
+---
+
+## `content:parsed`{lang="ts"}
+
+This hook is called after the content is parsed and before it is saved to the database.
+
+```ts
+export default defineNuxtConfig({
+  hooks: {
+    'content:parsed'(ctx) {
+      // { content: CollectionItemBase, collection: ResolvedCollection }
+    }
+  }
+})
+```

--- a/docs/content/docs/7.advanced/5.hooks.md
+++ b/docs/content/docs/7.advanced/5.hooks.md
@@ -5,15 +5,48 @@ navigation:
   title: Hooks
 ---
 
-## `collection:parsedFile`{lang="ts"}
+## `content:file:beforeParse`{lang="ts"}
 
-This hook is called after the content is parsed and before it is saved to the database.
+This hook is called before the content is parsed.
+
+It can be used to modify the raw content from a `file` before it is transformed
+or modify the transform options.
+
+```ts
+export interface FileBeforeParseHook {
+  collection: ResolvedCollection
+  file: ContentFile
+  parserOptions: TransformContentOptions
+}
+```
 
 ```ts
 export default defineNuxtConfig({
   hooks: {
-    'collection:parsedFile'(ctx) {
-      // { content: CollectionItemBase, collection: ResolvedCollection }
+    'content:file:beforeParse'(ctx) {
+      // ...
+    }
+  }
+})
+```
+
+## `content:file:afterParse`{lang="ts"}
+
+This hook is called after the content is parsed and before it is saved to the database.
+
+```ts
+export interface FileAfterParseHook {
+  collection: ResolvedCollection
+  file: ContentFile
+  content: ParsedContentFile
+}
+```
+
+```ts
+export default defineNuxtConfig({
+  hooks: {
+    'content:file:afterParse'(ctx) {
+      // ...
     }
   }
 })

--- a/docs/content/docs/7.advanced/5.hooks.md
+++ b/docs/content/docs/7.advanced/5.hooks.md
@@ -23,7 +23,7 @@ export interface FileBeforeParseHook {
 ```ts
 export default defineNuxtConfig({
   hooks: {
-    'content:file:beforeParse'(ctx) {
+    'content:file:beforeParse'(ctx: FileBeforeParseHook) {
       // ...
     }
   }

--- a/src/types/module.ts
+++ b/src/types/module.ts
@@ -192,5 +192,5 @@ export interface PublicRuntimeConfig {
 export type ContentParsedHook = { content: CollectionItemBase | DataCollectionItemBase | PageCollectionItemBase, collection: ResolvedCollection }
 
 export interface ModuleHooks {
-  'content:parsed': (hook: ContentParsedHook) => void | Promise<void>
+  'collection:parsedFile': (hook: ContentParsedHook) => void | Promise<void>
 }

--- a/src/types/module.ts
+++ b/src/types/module.ts
@@ -193,12 +193,12 @@ export interface PublicRuntimeConfig {
 export type ParsedContentFile = Record<string, unknown>
 
 export interface FileBeforeParseHook {
-  collection: ResolvedCollection
+  collection: Readonly<ResolvedCollection>
   file: ContentFile
   parserOptions: TransformContentOptions
 }
 export interface FileAfterParseHook {
-  collection: ResolvedCollection
+  collection: Readonly<ResolvedCollection>
   file: ContentFile
   content: ParsedContentFile
 }

--- a/src/types/module.ts
+++ b/src/types/module.ts
@@ -1,9 +1,9 @@
 import type { BuiltinLanguage as ShikiLang, BuiltinTheme as ShikiTheme, LanguageRegistration, ThemeRegistrationAny, ThemeRegistrationRaw } from 'shiki'
 import type { ListenOptions } from 'listhen'
 import type { GitInfo } from '../utils/git'
-import type { MarkdownPlugin } from './content'
+import type { ContentFile, MarkdownPlugin, TransformContentOptions } from './content'
 import type { PathMetaOptions } from './path-meta'
-import type { CollectionItemBase, DataCollectionItemBase, PageCollectionItemBase, ResolvedCollection } from './collection'
+import type { ResolvedCollection } from './collection'
 
 export interface D1DatabaseConfig {
   type: 'd1'
@@ -189,8 +189,21 @@ export interface PublicRuntimeConfig {
   }
 }
 
-export type ContentParsedHook = { content: CollectionItemBase | DataCollectionItemBase | PageCollectionItemBase, collection: ResolvedCollection }
+// TODO improve types
+export type ParsedContentFile = Record<string, unknown>
+
+export interface FileBeforeParseHook {
+  collection: ResolvedCollection
+  file: ContentFile
+  parserOptions: TransformContentOptions
+}
+export interface FileAfterParseHook {
+  collection: ResolvedCollection
+  file: ContentFile
+  content: ParsedContentFile
+}
 
 export interface ModuleHooks {
-  'collection:parsedFile': (hook: ContentParsedHook) => void | Promise<void>
+  'content:file:beforeParse': (hook: FileBeforeParseHook) => void | Promise<void>
+  'content:file:afterParse': (hook: FileAfterParseHook) => void | Promise<void>
 }

--- a/src/types/module.ts
+++ b/src/types/module.ts
@@ -3,6 +3,7 @@ import type { ListenOptions } from 'listhen'
 import type { GitInfo } from '../utils/git'
 import type { MarkdownPlugin } from './content'
 import type { PathMetaOptions } from './path-meta'
+import type { CollectionItemBase, DataCollectionItemBase, PageCollectionItemBase, ResolvedCollection } from './collection'
 
 export interface D1DatabaseConfig {
   type: 'd1'
@@ -186,4 +187,10 @@ export interface PublicRuntimeConfig {
     apiURL?: string
     iframeMessagingAllowedOrigins?: string
   }
+}
+
+export type ContentParsedHook = { content: CollectionItemBase | DataCollectionItemBase | PageCollectionItemBase, collection: ResolvedCollection }
+
+export interface ModuleHooks {
+  'content:parsed': (hook: ContentParsedHook) => void | Promise<void>
 }

--- a/src/utils/collection.ts
+++ b/src/utils/collection.ts
@@ -6,7 +6,7 @@ import { metaSchema, pageSchema } from './schema'
 import type { ZodFieldType } from './zod'
 import { getUnderlyingType, ZodToSqlFieldTypes, z, getUnderlyingTypeName } from './zod'
 import { logger } from './dev'
-import type { ParsedContentFile } from '~/src/types'
+import type { ParsedContentFile } from '../types'
 
 const JSON_FIELDS_TYPES = ['ZodObject', 'ZodArray', 'ZodRecord', 'ZodIntersection', 'ZodUnion', 'ZodAny']
 

--- a/src/utils/collection.ts
+++ b/src/utils/collection.ts
@@ -1,12 +1,12 @@
 import type { ZodObject, ZodOptionalDef, ZodRawShape, ZodStringDef, ZodType } from 'zod'
 import type { Collection, ResolvedCollection, CollectionSource, DefinedCollection, ResolvedCollectionSource } from '../types/collection'
 import { getOrderedSchemaKeys } from '../runtime/internal/schema'
+import type { ParsedContentFile } from '../types'
 import { defineLocalSource, defineGitHubSource } from './source'
 import { metaSchema, pageSchema } from './schema'
 import type { ZodFieldType } from './zod'
 import { getUnderlyingType, ZodToSqlFieldTypes, z, getUnderlyingTypeName } from './zod'
 import { logger } from './dev'
-import type { ParsedContentFile } from '../types'
 
 const JSON_FIELDS_TYPES = ['ZodObject', 'ZodArray', 'ZodRecord', 'ZodIntersection', 'ZodUnion', 'ZodAny']
 

--- a/src/utils/collection.ts
+++ b/src/utils/collection.ts
@@ -6,6 +6,7 @@ import { metaSchema, pageSchema } from './schema'
 import type { ZodFieldType } from './zod'
 import { getUnderlyingType, ZodToSqlFieldTypes, z, getUnderlyingTypeName } from './zod'
 import { logger } from './dev'
+import type { ParsedContentFile } from '~/src/types'
 
 const JSON_FIELDS_TYPES = ['ZodObject', 'ZodArray', 'ZodRecord', 'ZodIntersection', 'ZodUnion', 'ZodAny']
 
@@ -98,7 +99,7 @@ function resolveSource(source: string | CollectionSource | CollectionSource[] | 
 }
 
 // Convert collection data to SQL insert statement
-export function generateCollectionInsert(collection: ResolvedCollection, data: Record<string, unknown>): string[] {
+export function generateCollectionInsert(collection: ResolvedCollection, data: ParsedContentFile): string[] {
   const fields: string[] = []
   const values: Array<string | number | boolean> = []
   const sortedKeys = getOrderedSchemaKeys((collection.extendedSchema).shape)

--- a/src/utils/content/index.ts
+++ b/src/utils/content/index.ts
@@ -129,7 +129,7 @@ export async function createParser(collection: ResolvedCollection, nuxt?: Nuxt) 
     },
   }
 
-  return async function parse(file: ContentFile): Promise<ParsedContentFile> {
+  return async function parse(file: ContentFile) {
     if (file.path && !file.dirname) {
       file.dirname = dirname(file.path)
     }

--- a/src/utils/content/index.ts
+++ b/src/utils/content/index.ts
@@ -9,7 +9,7 @@ import { visit } from 'unist-util-visit'
 import type {
   ResolvedCollection,
 } from '../../types/collection'
-import type { FileAfterParseHook, FileBeforeParseHook, ModuleOptions, ParsedContentFile } from '../../types/module'
+import type { FileAfterParseHook, FileBeforeParseHook, ModuleOptions } from '../../types/module'
 import { transformContent } from './transformers'
 import type { ContentFile } from '~/src/types'
 

--- a/src/utils/content/index.ts
+++ b/src/utils/content/index.ts
@@ -136,7 +136,7 @@ export async function createParser(collection: ResolvedCollection, nuxt?: Nuxt) 
     const beforeParseCtx: FileBeforeParseHook = { file, collection, parserOptions }
     // @ts-expect-error runtime type
     await nuxt?.callHook?.('content:file:beforeParse', beforeParseCtx)
-    const { file: hookedFile, collection: hookedCollection } = beforeParseCtx
+    const { file: hookedFile } = beforeParseCtx
 
     const parsedContent = await transformContent(hookedFile, beforeParseCtx.parserOptions)
     const { id: id, ...parsedContentFields } = parsedContent

--- a/src/utils/content/index.ts
+++ b/src/utils/content/index.ts
@@ -161,7 +161,7 @@ export async function createParser(collection: ResolvedCollection, nuxt?: Nuxt) 
     }
 
     const hookCtx = { content: result, collection }
-    await nuxt?.callHook?.('content:parsed', hookCtx)
+    await nuxt?.callHook?.('collection:parsedFile', hookCtx)
     return hookCtx.content
   }
 }

--- a/src/utils/content/index.ts
+++ b/src/utils/content/index.ts
@@ -143,7 +143,7 @@ export async function createParser(collection: ResolvedCollection, nuxt?: Nuxt) 
     const result = { id } as typeof collection.extendedSchema._type
     const meta = {} as Record<string, unknown>
 
-    const collectionKeys = Object.keys(hookedCollection.extendedSchema.shape)
+    const collectionKeys = Object.keys(collection.extendedSchema.shape)
     for (const key of Object.keys(parsedContentFields)) {
       if (collectionKeys.includes(key)) {
         result[key] = parsedContent[key]

--- a/src/utils/content/index.ts
+++ b/src/utils/content/index.ts
@@ -160,6 +160,8 @@ export async function createParser(collection: ResolvedCollection, nuxt?: Nuxt) 
       result.seo.description = result.seo.description || result.description
     }
 
-    return result
+    const hookCtx = { content: result, collection }
+    await nuxt?.callHook?.('content:parsed', hookCtx)
+    return hookCtx.content
   }
 }

--- a/test/unit/hooks.test.ts
+++ b/test/unit/hooks.test.ts
@@ -14,11 +14,11 @@ describe('Hooks', () => {
       foo: z.any(),
     }),
   }))!
-  it('content:parsed', async () => {
+  it('collection:parsedFile', async () => {
     let hookCtx: ContentParsedHook
     const nuxtMock = {
       callHook(hook: string, ctx: ContentParsedHook) {
-        if (hook === 'content:parsed') {
+        if (hook === 'collection:parsedFile') {
           // augment
           ctx.content.bar = 'foo'
           hookCtx = ctx

--- a/test/unit/hooks.test.ts
+++ b/test/unit/hooks.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod'
+import { defineCollection } from '../../src/utils'
+import { resolveCollection } from '../../src/utils/collection'
+import type { ContentParsedHook } from '../../src/types'
+import { parseContent } from '../utils/content'
+
+describe('Hooks', () => {
+  const collection = resolveCollection('hookTest', defineCollection({
+    type: 'data',
+    source: 'content/**',
+    schema: z.object({
+      body: z.any(),
+      foo: z.any(),
+    }),
+  }))!
+  it('content:parsed', async () => {
+    let hookCtx: ContentParsedHook
+    const nuxtMock = {
+      callHook(hook: string, ctx: ContentParsedHook) {
+        if (hook === 'content:parsed') {
+          // augment
+          ctx.content.bar = 'foo'
+          hookCtx = ctx
+        }
+      },
+    }
+    const parsed = await parseContent('content/index.md', `---
+foo: 'bar'
+---
+
+  # Hello World
+`, collection, nuxtMock)
+    expect(hookCtx.collection.name).toEqual('hookTest')
+    expect(parsed.id).toEqual('content/index.md')
+    expect(parsed.foo).toEqual('bar')
+    expect(parsed.bar).toEqual('foo')
+  })
+})


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

https://github.com/nuxt/content/issues/2921

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

The runtime hooks from Content v2 were useful for modules to provide an integration with markdown files. For example, allowing users to provide custom frontmater keys or inferring data from the markdown body.

- [Nuxt Sitemap - Nuxt Content Integration](https://github.com/nuxt-modules/sitemap/blob/main/src/runtime/server/plugins/nuxt-content.ts)

In Content v3 these runtime hooks are moved to the build time which is a great performance win, however, we no longer have access to the parsing hooks. 

This PR introduces the `collection:parsedFile` hook to allow modules to start integrating with v3. 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
