### PR TITLE
feat(config): enable watch for all layer configs and load in parallel

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -22,8 +22,8 @@ import { generateCollectionInsert, generateCollectionTableDefinition } from './u
 import { componentsManifestTemplate, contentTypesTemplate, fullDatabaseRawDumpTemplate, manifestTemplate, moduleTemplates } from './utils/templates'
 import type { ResolvedCollection } from './types/collection'
 import type { ModuleOptions, SqliteDatabaseConfig } from './types/module'
-import { getContentChecksum, localDatabase, logger, watchContents, chunks, watchComponents, watchConfig, startSocketServer } from './utils/dev'
-import { loadLayersConfig } from './utils/config'
+import { getContentChecksum, localDatabase, logger, watchContents, chunks, watchComponents, startSocketServer } from './utils/dev'
+import { loadContentConfig } from './utils/config'
 import { createParser } from './utils/content'
 import { installMDCModule } from './utils/mdc'
 import { findPreset } from './presets'
@@ -104,7 +104,7 @@ export default defineNuxtModule<ModuleOptions>({
       await mkdir(dirname((options.database as SqliteDatabaseConfig).filename), { recursive: true }).catch(() => {})
     }
 
-    const { collections } = await loadLayersConfig(nuxt)
+    const { collections } = await loadContentConfig(nuxt)
     manifest.collections = collections
 
     // Module Options
@@ -213,7 +213,6 @@ export default defineNuxtModule<ModuleOptions>({
     if (nuxt.options.dev) {
       addPlugin({ src: resolver.resolve('./runtime/plugins/websocket.dev'), mode: 'client' })
       await watchComponents(nuxt)
-      await watchConfig(nuxt)
       const socket = await startSocketServer(nuxt, options, manifest)
       dumpGeneratePromise.then(async () => {
         await watchContents(nuxt, options, manifest, socket)

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -50,7 +50,7 @@ export async function loadContentConfig(nuxt: Nuxt, options: { defaultFallback?:
   const collectionsConfig = contentConfigs.reduce((acc, curr) => ({ ...acc, ...curr.config?.collections }), {} as Record<string, DefinedCollection>)
   const hasNoCollections = Object.keys(collectionsConfig || {}).length === 0
 
-  if (!hasNoCollections) {
+  if (hasNoCollections) {
     logger.warn('No content configuration found, falling back to default collection. In order to have full control over your collections, create the config file in project root. See: https://content.nuxt.com/getting-started/installation')
   }
 

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,8 +1,7 @@
-import { stat } from 'node:fs/promises'
-import { loadConfig, createDefineConfig } from 'c12'
+import { loadConfig, watchConfig, createDefineConfig } from 'c12'
+import { relative } from 'pathe'
 import type { Nuxt } from '@nuxt/schema'
-import { join } from 'pathe'
-import type { ResolvedCollection, DefinedCollection } from '../types'
+import type { DefinedCollection } from '../types'
 import { defineCollection, resolveCollections } from './collection'
 import { logger } from './dev'
 
@@ -21,47 +20,41 @@ const defaultConfig: NuxtContentConfig = {
 
 export const defineContentConfig = createDefineConfig<NuxtContentConfig>()
 
-export async function loadContentConfig(rootDir: string, opts: { defaultFallback?: boolean } = {}) {
+export async function loadContentConfig(nuxt: Nuxt, options: { defaultFallback?: boolean } = {}) {
+  const loader: typeof watchConfig = nuxt.options.dev
+    ? opts => watchConfig({
+      ...opts,
+      onWatch: (e) => {
+        logger.info(relative(nuxt.options.rootDir, e.path) + ' ' + e.type + ', restarting the Nuxt server...')
+        nuxt.hooks.callHook('restart', { hard: true })
+      },
+    })
+    : loadConfig as typeof watchConfig;
+
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (globalThis as any).defineContentConfig = (c: any) => c
-  const { config, configFile } = await loadConfig<NuxtContentConfig>({ name: 'content', cwd: rootDir })
+
+  const contentConfigs = await Promise.all(
+    nuxt.options._layers.reverse().map(
+      layer => loader<NuxtContentConfig>({ name: 'content', cwd: layer.config.rootDir, defaultConfig: options.defaultFallback ? defaultConfig : undefined }),
+    ),
+  )
+
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   delete (globalThis as any).defineContentConfig
 
-  if ((!configFile || configFile === 'content.config') && opts.defaultFallback) {
-    logger.warn('`content.config.ts` is not found, falling back to default collection. In order to have full control over your collections, create the config file in project root. See: https://content.nuxt.com/getting-started/installation')
-    return {
-      collections: resolveCollections(defaultConfig.collections),
-    }
+  if (nuxt.options.dev) {
+    nuxt.hook('close', () => Promise.all(contentConfigs.map(c => c.unwatch())).then(() => {}))
   }
 
-  return {
-    collections: resolveCollections(config.collections || {}),
-  }
-}
+  const collectionsConfig = contentConfigs.reduce((acc, curr) => ({ ...acc, ...curr.config?.collections }), {} as Record<string, DefinedCollection>)
+  const hasNoCollections = Object.keys(collectionsConfig || {}).length === 0
 
-export async function loadLayersConfig(nuxt: Nuxt) {
-  const collectionMap = {} as Record<string, ResolvedCollection>
-  const _layers = [...nuxt.options._layers].reverse()
-  for (const layer of _layers) {
-    const rootDir = layer.config.rootDir
-    const configStat = await stat(join(rootDir, 'content.config.ts')).catch(() => null)
-    if (configStat && configStat.isFile()) {
-      const { collections } = await loadContentConfig(rootDir, { defaultFallback: false })
-      for (const collection of collections) {
-        collectionMap[collection.name] = collection
-      }
-    }
+  if (!hasNoCollections) {
+    logger.warn('No content configuration found, falling back to default collection. In order to have full control over your collections, create the config file in project root. See: https://content.nuxt.com/getting-started/installation')
   }
 
-  if (Object.keys(collectionMap).length === 0) {
-    const collections = resolveCollections(defaultConfig.collections)
-    for (const collection of collections) {
-      collectionMap[collection.name] = collection
-    }
-  }
+  const collections = resolveCollections(hasNoCollections ? defaultConfig.collections : collectionsConfig)
 
-  return {
-    collections: Object.values(collectionMap),
-  }
+  return { collections }
 }

--- a/test/base.test.ts
+++ b/test/base.test.ts
@@ -1,6 +1,7 @@
 import { fileURLToPath } from 'node:url'
 import fs from 'node:fs/promises'
 import { setup, $fetch } from '@nuxt/test-utils'
+import type { Nuxt } from '@nuxt/schema'
 import { afterAll, describe, expect, test } from 'vitest'
 import { loadContentConfig } from '../src/utils/config'
 import { decompressSQLDump } from '../src/runtime/internal/dump'
@@ -33,7 +34,7 @@ describe('empty', async () => {
     })
     test('Default collection is defined', async () => {
       const rootDir = fileURLToPath(new URL('./fixtures/empty', import.meta.url))
-      const config = await loadContentConfig(rootDir, { defaultFallback: true })
+      const config = await loadContentConfig({ options: { _layers: [{ config: { rootDir } }] } } as Nuxt, { defaultFallback: true })
 
       // Pages collection + info collection
       expect(config.collections.length).toBe(2)


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Another small PR inspired from my reading of the implementation for v3..

A few bits I had noticed:

After #2829, we would have enabled `.config/` directory (or even config in different extensions) - but I realised that the fsStat before loading the config would not allow us for this. So it started with that, then I went ahead to parallelise the call to `loadContentConfig`, and then resolve `collectionMap`. I realised that calling `resolveCollections` and iterating over collections was not necessary (as the key is the `collection.name`), so instead we use a reducer to override any low-level layer collections (ideally we would have wanted to use `defu`, but that is deep-default and may have side-effects for collection schemas). In addition to that, I also ensured that the configurations would work with a watcher, so thanks for `watchConfig`, all of this is possible.

Let me know what you think - I had to spend some time scratching my head on updating this code, so would love feedback! 🙂 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
