### PR TITLE
docs(migration): state how to register components in `content` folder as global components

### DIFF
--- a/docs/content/docs/1.getting-started/4.migration.md
+++ b/docs/content/docs/1.getting-started/4.migration.md
@@ -30,7 +30,7 @@ Don't worry, you don't need to modify your content files. We made sure that Cont
 - We consolidated the `ProsePre`, `ProseCode`, and `ProseCodeInline` components
   - `ProseCodeInline` is now `ProseCode`
   - `ProseCode` is now `ProsePre`
-- Components created under the `components/content` directory are no longer automatically registered as global components. You need to register them manually in your Nuxt app. Check out the [Nuxt - Custom Components Directories](https://nuxt.com/docs/guide/directory-structure/components#custom-directories) documentation for more information on how to do so.
+- Components created under the `components/content` directory are no longer automatically registered as global components. If you use [dynamic rendering](https://vuejs.org/guide/essentials/component-basics.html#dynamic-components) to render these components outside markdown files, you must manually register them in your Nuxt app. Check out the [Nuxt - Custom Components Directories](https://nuxt.com/docs/guide/directory-structure/components#custom-directories) documentation for more information on how to do so.
 
 ### General Changes
 

--- a/docs/content/docs/1.getting-started/4.migration.md
+++ b/docs/content/docs/1.getting-started/4.migration.md
@@ -30,6 +30,7 @@ Don't worry, you don't need to modify your content files. We made sure that Cont
 - We consolidated the `ProsePre`, `ProseCode`, and `ProseCodeInline` components
   - `ProseCodeInline` is now `ProseCode`
   - `ProseCode` is now `ProsePre`
+- Components created under the `components/content` directory are no longer automatically registered as global components. You need to register them manually in your Nuxt app. Check out the [Nuxt - Custom Components Directories](https://nuxt.com/docs/guide/directory-structure/components#custom-directories) documentation for more information on how to do so.
 
 ### General Changes
 
@@ -118,33 +119,3 @@ Many `ProsePre` components are thin wrappers around the `ProseCode` component. W
 Suggested Changes
 1. Your _current_ `ProseCode` logic should be moved to `ProsePre`
 2. Rename your `ProseCodeInline` component to `ProseCode`
-
-## Mark Components in the `content` folder as global
-
-In v2, all components in the `components/content` folder were automatically marked as global. This allowed you to pass the name of the component as a string to the `is` attribute of the `<component/>` element. In v3, you need to explicitly mark components as global.
-
-- Add this to the top of your `nuxt.config.ts` file:
-
-```ts
-import { createResolver } from '@nuxt/kit';
-
-const { resolve } = createResolver(import.meta.url);
-```
-
-- Add this to the `modules` array in your `nuxt.config.ts` file:
-
-```ts
-export default defineNuxtConfig({
-  // ...
-  modules: [
-    (_, nuxt) => {
-      nuxt.hook('components:dirs', (dirs) => {
-        dirs.unshift({ path: resolve(PATH_TO_GLOBAL_CONTENT_FOLDER), pathPrefix: false, prefix: '', global: true })
-      })
-    }
-  ]
-  // ...
-})
-```
-
-Be sure to replace `PATH_TO_GLOBAL_CONTENT_FOLDER` with the path: E.g: `./app/components/content`

--- a/docs/content/docs/1.getting-started/4.migration.md
+++ b/docs/content/docs/1.getting-started/4.migration.md
@@ -118,3 +118,33 @@ Many `ProsePre` components are thin wrappers around the `ProseCode` component. W
 Suggested Changes
 1. Your _current_ `ProseCode` logic should be moved to `ProsePre`
 2. Rename your `ProseCodeInline` component to `ProseCode`
+
+## Mark Components in the `content` folder as global
+
+In v2, all components in the `components/content` folder were automatically marked as global. This allowed you to pass the name of the component as a string to the `is` attribute of the `<component/>` element. In v3, you need to explicitly mark components as global.
+
+- Add this to the top of your `nuxt.config.ts` file:
+
+```ts
+import { createResolver } from '@nuxt/kit';
+
+const { resolve } = createResolver(import.meta.url);
+```
+
+- Add this to the `modules` array in your `nuxt.config.ts` file:
+
+```ts
+export default defineNuxtConfig({
+  // ...
+  modules: [
+    (_, nuxt) => {
+      nuxt.hook('components:dirs', (dirs) => {
+        dirs.unshift({ path: resolve(PATH_TO_GLOBAL_CONTENT_FOLDER), pathPrefix: false, prefix: '', global: true })
+      })
+    }
+  ]
+  // ...
+})
+```
+
+Be sure to replace `PATH_TO_GLOBAL_CONTENT_FOLDER` with the path: E.g: `./app/components/content`


### PR DESCRIPTION
In v2, this was done automatically. It has to be explicitly added in v3.

The issue raised can be found here #2930 

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

While migrating from v2, I noticed that all the components that were once global and could be passed as a string to the `<component />` element were no longer being displayed. The components created under `components/content` were no longer automatically registered as global components.

This PR just adds this note to the migration page so that users know that they have to explicitly mark components within the `components/content` folder as global. 

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
