### PR TITLE
docs: fixed names slots prop name

### DIFF
--- a/docs/content/docs/5.components/1.slot.md
+++ b/docs/content/docs/5.components/1.slot.md
@@ -59,7 +59,7 @@ Now the rendered HTML will be:
 
 ### Named Slots
 
-The `use` prop allows you to bind a slot by its name. This is useful when you want to render a slot that is not the default one.
+The `name` prop allows you to bind a slot by its name. This is useful when you want to render a slot that is not the default one.
 
 Let's improve our `Callout` component to have a `title` slot:
 


### PR DESCRIPTION
### 🔗 Linked issue
No relevant issue was found. 

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
The v3 documentation for named slots wrongly stated that you should use the 'use' prop instead of the 'name' prop to create a named slot. Fixed text mistake: 'use' --> 'name'.

<!-- Why is this change required? What problem does it solve? -->
The correctness of the documentation. 

<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
I didn't find an open issue for that. It's my first contribution here. Sorry for not knowing if I should create an issue first or simply the PR itself to fix it is enough. Please let me know. 

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
