### PR TITLE
docs(PostPage): fix surround order

### DIFF
--- a/docs/app/components/post/PostPage.vue
+++ b/docs/app/components/post/PostPage.vue
@@ -16,7 +16,7 @@ const { data } = await useAsyncData(route.path, () => Promise.all([
   queryCollectionItemSurroundings('posts', route.path, { fields: ['title', 'description'] })
     .where('path', 'LIKE', `/${type}%`)
     .where('draft', '=', 0)
-    .order('date', 'ASC'),
+    .order('date', 'DESC'),
 ]), {
   transform: ([page, surround]) => ({ page, surround }),
 })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

@farnabaz There is still an issue with the surround links being in the wrong order at the bottom.

![Capture d’écran 2025-01-16 à 18 09 40](https://github.com/user-attachments/assets/528ccc0c-a86d-4f4d-9581-dc868e4587a5)



### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
