### PR TITLE
Update 2.installation.md

### DIFF
--- a/docs/content/docs/1.getting-started/2.installation.md
+++ b/docs/content/docs/1.getting-started/2.installation.md
@@ -9,19 +9,19 @@ Choose your preferred package manager to install Nuxt Content v3:
 
 ::code-group
 ```bash [pnpm]
-pnpm add @nuxt/content@next
+pnpm add @nuxt/content
 ```
 
 ```bash [yarn]
-yarn add @nuxt/content@next
+yarn add @nuxt/content
 ```
 
 ```bash [npm]
-npm install @nuxt/content@next
+npm install @nuxt/content
 ```
 
 ```bash [bun]
-bun add @nuxt/content@next
+bun add @nuxt/content
 ```
 ::
 


### PR DESCRIPTION
docs: update Nuxt Content installation instructions to use stable version

Removed the @next tag from installation commands to ensure users install the latest stable version of Nuxt Content instead of the beta version. This prevents potential issues with unintended beta features or breaking changes.


<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
This update removes the @next tag from Nuxt Content installation instructions to ensure users default to the latest stable version. It helps prevent confusion or issues caused by beta releases that may have experimental or unstable features.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
