### PR TITLE
docs: invalid path filed in query-collection-item-surroundings docs

### DIFF
--- a/docs/content/docs/4.utils/3.query-collection-item-surroundings.md
+++ b/docs/content/docs/4.utils/3.query-collection-item-surroundings.md
@@ -76,10 +76,10 @@ const { data } = await useAsyncData('surround', () => {
 
 <template>
   <div class="flex justify-between">
-    <NuxtLink v-if="data?.[0]" :to="data[0]._path">
+    <NuxtLink v-if="data?.[0]" :to="data[0].path">
       ← {{ data[0].title }}
     </NuxtLink>
-    <NuxtLink v-if="data?.[1]" :to="data[1]._path">
+    <NuxtLink v-if="data?.[1]" :to="data[1].path">
       {{ data[1].title }} →
     </NuxtLink>
   </div>


### PR DESCRIPTION
docs: fix example code by removing underscores from paths

- [ x] 📖 Documentation (updates to the documentation or readme)

### 📚 Description

Updated the example to replace `_path` with `path` to match the updated data structure. This ensures the documentation is accurate and reflects the correct usage of path properties in templates.