### PR TITLE
fix: convert boolean value to number in query condition

### DIFF
--- a/docs/content/docs/4.utils/2.query-collection-navigation.md
+++ b/docs/content/docs/4.utils/2.query-collection-navigation.md
@@ -30,7 +30,7 @@ The function returns a chainable promise that allows you to add additional query
 <script setup lang="ts">
 const { data } = await useAsyncData('navigation', () => {
   return queryCollectionNavigation('docs')
-    .where('published', '==', true)
+    .where('published', '=', true)
     .order('date', 'DESC')
 })
 </script>
@@ -81,8 +81,8 @@ Example with additional query conditions and extra fields:
 <script setup lang="ts">
 const { data } = await useAsyncData('navigation', () => {
   return queryCollectionNavigation('docs', ['description', 'badge'])
-    .where('draft', '==', false)
-    .where('partial', '==', false)
+    .where('draft', '=', false)
+    .where('partial', '=', false)
     .order('title', 'ASC')
 })
 </script>

--- a/docs/content/docs/4.utils/3.query-collection-item-surroundings.md
+++ b/docs/content/docs/4.utils/3.query-collection-item-surroundings.md
@@ -31,7 +31,7 @@ The function returns a chainable promise that allows you to add additional query
 <script setup lang="ts">
 const { data } = await useAsyncData('surround', () => {
   return queryCollectionItemSurroundings('docs', '/foo')
-    .where('published', '==', true)
+    .where('published', '=', true)
     .order('date', 'DESC')
 })
 </script>
@@ -96,8 +96,8 @@ const { data } = await useAsyncData('surround', () => {
     after: 1,
     fields: ['badge', 'description']
   })
-    .where('_draft', '==', false)
-    .where('_partial', '==', false)
+    .where('_draft', '=', false)
+    .where('_partial', '=', false)
     .order('date', 'DESC')
 })
 </script>

--- a/src/runtime/internal/query.ts
+++ b/src/runtime/internal/query.ts
@@ -49,7 +49,7 @@ export const collectionQueryGroup = <T extends keyof Collections>(collection: T)
           break
 
         default:
-          condition = `"${String(field)}" ${operator} '${value}'`
+          condition = `"${String(field)}" ${operator} '${typeof value === 'boolean' ? Number(value) : value}'`
       }
       conditions.push(`${condition}`)
       return query

--- a/test/unit/collectionQueryBuilder.test.ts
+++ b/test/unit/collectionQueryBuilder.test.ts
@@ -43,7 +43,7 @@ describe('collectionQueryBuilder', () => {
 
     expect(mockFetch).toHaveBeenCalledWith(
       'articles',
-      'SELECT * FROM _articles WHERE ("title" = \'Test Article\') AND ("published" = \'true\') ORDER BY stem ASC',
+      'SELECT * FROM _articles WHERE ("title" = \'Test Article\') AND ("published" = \'1\') ORDER BY stem ASC',
     )
   })
 
@@ -165,7 +165,7 @@ describe('collectionQueryBuilder', () => {
 
     expect(mockFetch).toHaveBeenCalledWith(
       'articles',
-      'SELECT * FROM _articles WHERE ("published" = \'true\') AND ("category" = \'tech\' AND ("tags" LIKE \'%javascript%\' OR "tags" LIKE \'%typescript%\')) ORDER BY stem ASC',
+      'SELECT * FROM _articles WHERE ("published" = \'1\') AND ("category" = \'tech\' AND ("tags" LIKE \'%javascript%\' OR "tags" LIKE \'%typescript%\')) ORDER BY stem ASC',
     )
   })
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue
https://github.com/nuxt/content/issues/2927

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

After some investigation, I discovered that #2927 is caused by the following code in `query.ts`, where the `value` is wrapped in quotes. This prevents boolean results from being found. 

https://github.com/nuxt/content/blob/d5efff1fdd03612d712661bae7f4596965082e44/src/runtime/internal/query.ts#L52

In SQLite, boolean values are stored as `0` and `1`. When searching with `true` or `false`, they are converted to `0` and `1`, which works fine. However, when searching with `'true'` or `'false'`, it fails.

The solution is to convert them to `0` and `1` before adding quotes.

This should work with both `0/1` and `true/false` in query condition.

Resolves #2927

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
