### PR TITLE
fix(docs): Use `bindingName` instead of `binding`

### DIFF
--- a/docs/content/docs/1.getting-started/3.configuration.md
+++ b/docs/content/docs/1.getting-started/3.configuration.md
@@ -310,14 +310,14 @@ export default defineNuxtConfig({
 
 ### `D1`
 
-If you plan to deploy your application to Cloudflare workers, you need to use the `d1` database adapter. Create a `d1` binding in the Cloudflare dashboard and fill in the `binding` field.
+If you plan to deploy your application to Cloudflare workers, you need to use the `d1` database adapter. Create a `d1` binding in the Cloudflare dashboard and fill in the `bindingName` field.
 
 ```ts [nuxt.config.ts]
 export default defineNuxtConfig({
   content: {
     database: {
       type: 'd1',
-      binding: 'CF_BINDING_NAME'
+      bindingName: 'CF_BINDING_NAME'
     }
   }
 })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Updated the docs using a more recent object property name. As per Nuxt content v3.1.0, the property `binding` is deprecated in favor of `bindingName`, as configured in the type [`D1DatabaseConfig`](https://github.com/nuxt/content/blob/bfc58ccf2a155b48d8f585ea8bf206f93c801c27/src/types/module.ts#L8).

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
