### PR TITLE
fix: `queryCollectionItemSurroundings` type definition in built module

### DIFF
--- a/src/runtime/app.ts
+++ b/src/runtime/app.ts
@@ -1,4 +1,4 @@
-import type { Collections, PageCollections, CollectionQueryBuilder, SurroundOptions, SQLOperator, QueryGroupFunction } from '@nuxt/content'
+import type { Collections, PageCollections, CollectionQueryBuilder, SurroundOptions, SQLOperator, QueryGroupFunction, ContentNavigationItem } from '@nuxt/content'
 import type { H3Event } from 'h3'
 import { collectionQueryBuilder } from './internal/query'
 import { generateNavigationTree } from './internal/navigation'

--- a/src/runtime/app.ts
+++ b/src/runtime/app.ts
@@ -7,6 +7,10 @@ import { generateSearchSections } from './internal/search'
 import { fetchQuery } from './internal/api'
 import { tryUseNuxtApp } from '#imports'
 
+export type {
+  ContentNavigationItem,
+}
+
 interface ChainablePromise<T extends keyof PageCollections, R> extends Promise<R> {
   where(field: keyof PageCollections[T] | string, operator: SQLOperator, value?: unknown): ChainablePromise<T, R>
   andWhere(groupFactory: QueryGroupFunction<PageCollections[T]>): ChainablePromise<T, R>

--- a/src/runtime/app.ts
+++ b/src/runtime/app.ts
@@ -7,10 +7,6 @@ import { generateSearchSections } from './internal/search'
 import { fetchQuery } from './internal/api'
 import { tryUseNuxtApp } from '#imports'
 
-export type {
-  ContentNavigationItem,
-}
-
 interface ChainablePromise<T extends keyof PageCollections, R> extends Promise<R> {
   where(field: keyof PageCollections[T] | string, operator: SQLOperator, value?: unknown): ChainablePromise<T, R>
   andWhere(groupFactory: QueryGroupFunction<PageCollections[T]>): ChainablePromise<T, R>
@@ -23,11 +19,11 @@ export const queryCollection = <T extends keyof Collections>(collection: T): Col
   return collectionQueryBuilder<T>(collection, (collection, sql) => executeContentQuery(event, collection, sql))
 }
 
-export function queryCollectionNavigation<T extends keyof PageCollections>(collection: T, fields?: Array<keyof PageCollections[T]>) {
+export function queryCollectionNavigation<T extends keyof PageCollections>(collection: T, fields?: Array<keyof PageCollections[T]>): ChainablePromise<T, ContentNavigationItem[]> {
   return chainablePromise(collection, qb => generateNavigationTree(qb, fields))
 }
 
-export function queryCollectionItemSurroundings<T extends keyof PageCollections>(collection: T, path: string, opts?: SurroundOptions<keyof PageCollections[T]>) {
+export function queryCollectionItemSurroundings<T extends keyof PageCollections>(collection: T, path: string, opts?: SurroundOptions<keyof PageCollections[T]>): ChainablePromise<T, ContentNavigationItem[]> {
   return chainablePromise(collection, qb => generateItemSurround(qb, path, opts))
 }
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

fix #3120

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

This resolves the broken type definition for `queryCollectionItemSurroundings` in the built module. I am unsure why `nuxi` is building a broken TS file but adding an explicit import and then export (to stop it being tree-shaken) seems to fix this issue with the `ContentNavigationItem` being incorrectly bundled.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
