### PR TITLE
fix(blog): correct queryCollection path for fetching posts

### DIFF
--- a/docs/content/docs/3.files/1.markdown.md
+++ b/docs/content/docs/3.files/1.markdown.md
@@ -72,7 +72,7 @@ To display the content of a markdown file, you can use the [`<ContentRenderer>`]
 <script setup>
 const slug = useRoute().params.slug
 const { data: post } = await useAsyncData(`blog-${slug}`, () => {
-  return queryCollection('blog').path(slug).first()
+  return queryCollection('blog').path(`/blog/${slug}`).first()
 })
 </script>
 


### PR DESCRIPTION
---
### 🔗 Linked issue  
 [ISSUE] (https://github.com/nuxt/content/issues/3123) 

### ❓ Type of change  
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)  

### 📚 Description  
Previously, `queryCollection('blog').path(slug).first()` did not return the correct post.  
The issue was that `slug` was not resolving to the correct path.  

**Fix:**  
Changed the path from:  
```js
queryCollection('blog').path(slug).first()
```  
To:  
```js
queryCollection('blog').path(`/blog/${slug}`).first()
```  
This ensures that the correct blog post is fetched when visiting its page.  

### 📝 Checklist  
- [x] I have linked an issue or discussion (if applicable).  
- [x] I have tested the fix and confirmed it works as expected.  
- [ ] I have updated the documentation accordingly (if needed).  

---