### PR TITLE
fix(renderer): do not ignore component objects

### DIFF
--- a/src/runtime/components/ContentRenderer.vue
+++ b/src/runtime/components/ContentRenderer.vue
@@ -167,11 +167,12 @@ function resolveContentComponents(body: MDCRoot, meta: Record<string, unknown>) 
 
   const result = {} as Record<string, unknown>
   for (const [tag, component] of components) {
-    if (typeof component === 'object' && renderFunctions.some(fn => Object.hasOwnProperty.call(component, fn))) {
+    if (result[tag]) {
       continue
     }
 
-    if (result[tag]) {
+    if (typeof component === 'object' && renderFunctions.some(fn => Object.hasOwnProperty.call(component, fn))) {
+      result[tag] = component
       continue
     }
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

reported in https://github.com/nuxt/content/issues/2148#issuecomment-2642846245


### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
The content Renderer was ignoring components in the resolve function. The component object should be passed down to the MDC renderer.
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
