### PR TITLE
fix: manage concurent initializations

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -246,9 +246,10 @@ async function processCollectionItems(nuxt: Nuxt, collections: ResolvedCollectio
     collectionDump[collection.name] = []
 
     // we start by telling everyone that we are setting up the collection
+    // so we create a new entry in the info table saying that it is not ready yet
     collectionDump[collection.name]!.push(
       generateCollectionTableDefinition(infoCollection, { drop: false }),
-      ...generateCollectionInsert(infoCollection, { id: `checksum_${collection.name}`, ready: false }),
+      ...generateCollectionInsert(infoCollection, { id: `checksum_${collection.name}`, version: '', ready: false }),
     )
 
     // Collection table definition

--- a/src/module.ts
+++ b/src/module.ts
@@ -315,7 +315,6 @@ async function processCollectionItems(nuxt: Nuxt, collections: ResolvedCollectio
         ...generateCollectionInsert(infoCollection, { id: `checksum_${collection.name}`, version: collectionChecksum[collection.name], ready: false }),
       )
 
-
       collectionDump[collection.name]!.push(...insertQueriesListWithDefinition)
 
       // and finally when we are finished, we update the info table to say that the init is done

--- a/src/module.ts
+++ b/src/module.ts
@@ -307,7 +307,7 @@ async function processCollectionItems(nuxt: Nuxt, collections: ResolvedCollectio
       collectionDump[collection.name]!.push(
         generateCollectionTableDefinition(infoCollection, { drop: false }),
         `DELETE FROM ${infoCollection.tableName} WHERE id = 'checksum_${collection.name}';`,
-        ...generateCollectionInsert(infoCollection, { id: `checksum_${collection.name}`, version: insertList, ready: false }),
+        ...generateCollectionInsert(infoCollection, { id: `checksum_${collection.name}`, version: collectionChecksum[collection.name], ready: false }),
       )
 
       // Collection table definition

--- a/src/module.ts
+++ b/src/module.ts
@@ -296,7 +296,6 @@ async function processCollectionItems(nuxt: Nuxt, collections: ResolvedCollectio
           }
         }))
       }
-
       // Sort by file name to ensure consistent order
       list.sort((a, b) => String(a[0]).localeCompare(String(b[0])))
       const insertList = list.flatMap(([, sql]) => sql!)
@@ -307,6 +306,7 @@ async function processCollectionItems(nuxt: Nuxt, collections: ResolvedCollectio
       // so we create a new entry in the info table saying that it is not ready yet
       collectionDump[collection.name]!.push(
         generateCollectionTableDefinition(infoCollection, { drop: false }),
+        `DELETE FROM ${infoCollection.tableName} WHERE id = 'checksum_${collection.name}';`,
         ...generateCollectionInsert(infoCollection, { id: `checksum_${collection.name}`, version: insertList, ready: false }),
       )
 
@@ -318,7 +318,7 @@ async function processCollectionItems(nuxt: Nuxt, collections: ResolvedCollectio
       collectionDump[collection.name]!.push(...insertList)
 
       collectionDump[collection.name]!.push(
-        `UPDATE ${infoCollection.tableName} SET ready = true WHERE id = 'checksum_${collection.name}'})`,
+        `UPDATE ${infoCollection.tableName} SET ready = true WHERE id = 'checksum_${collection.name}'`,
       )
     }
   }

--- a/src/module.ts
+++ b/src/module.ts
@@ -244,6 +244,13 @@ async function processCollectionItems(nuxt: Nuxt, collections: ResolvedCollectio
     }
     const collectionHash = hash(collection)
     collectionDump[collection.name] = []
+
+    // we start by telling everyone that we are setting up the collection
+    collectionDump[collection.name]!.push(
+      generateCollectionTableDefinition(infoCollection, { drop: false }),
+      ...generateCollectionInsert(infoCollection, { id: `checksum_${collection.name}`, ready: false }),
+    )
+
     // Collection table definition
     collectionDump[collection.name]!.push(
       ...generateCollectionTableDefinition(collection, { drop: true }).split('\n'),
@@ -307,9 +314,7 @@ async function processCollectionItems(nuxt: Nuxt, collections: ResolvedCollectio
       collectionChecksum[collection.name] = hash(collectionDump[collection.name])
 
       collectionDump[collection.name]!.push(
-        generateCollectionTableDefinition(infoCollection, { drop: false }),
-        `DELETE FROM ${infoCollection.tableName} WHERE id = 'checksum_${collection.name}';`,
-        ...generateCollectionInsert(infoCollection, { id: `checksum_${collection.name}`, version: collectionChecksum[collection.name] }),
+        `UPDATE ${infoCollection.tableName} SET version = '${collectionChecksum[collection.name]}', ready = true WHERE id = 'checksum_${collection.name}'})`,
       )
     }
   }

--- a/src/module.ts
+++ b/src/module.ts
@@ -298,11 +298,16 @@ async function processCollectionItems(nuxt: Nuxt, collections: ResolvedCollectio
       }
       // Sort by file name to ensure consistent order
       list.sort((a, b) => String(a[0]).localeCompare(String(b[0])))
-      const insertList = list.flatMap(([, sql]) => sql!)
+      const insertQueriesList = list.flatMap(([, sql]) => sql!)
 
-      collectionChecksum[collection.name] = hash(insertList)
+      // Collection table definition
+      const insertQueriesListWithDefinition = [...generateCollectionTableDefinition(collection, { drop: true }).split('\n'), ...insertQueriesList]
 
-      // we start by telling everyone that we are setting up the collection
+      collectionChecksum[collection.name] = hash(insertQueriesListWithDefinition)
+
+      // we have to start the series of queries
+      // by telling everyone that we are setting up the collection so no
+      // other request start doing the same work and fail
       // so we create a new entry in the info table saying that it is not ready yet
       collectionDump[collection.name]!.push(
         generateCollectionTableDefinition(infoCollection, { drop: false }),
@@ -310,13 +315,10 @@ async function processCollectionItems(nuxt: Nuxt, collections: ResolvedCollectio
         ...generateCollectionInsert(infoCollection, { id: `checksum_${collection.name}`, version: collectionChecksum[collection.name], ready: false }),
       )
 
-      // Collection table definition
-      collectionDump[collection.name]!.push(
-        ...generateCollectionTableDefinition(collection, { drop: true }).split('\n'),
-      )
 
-      collectionDump[collection.name]!.push(...insertList)
+      collectionDump[collection.name]!.push(...insertQueriesListWithDefinition)
 
+      // and finally when we are finished, we update the info table to say that the init is done
       collectionDump[collection.name]!.push(
         `UPDATE ${infoCollection.tableName} SET ready = true WHERE id = 'checksum_${collection.name}'`,
       )

--- a/src/runtime/internal/database.server.ts
+++ b/src/runtime/internal/database.server.ts
@@ -73,6 +73,9 @@ async function _checkAndImportDatabaseIntegrity(event: H3Event, collection: stri
     if (before.ready === false && before.version === integrityVersion) {
       // if another request has already started the initialization of
       // this version of this collection, wait for it to finish
+      // then respond that the database is ready
+      // NOTE: only wait if the version is the same so if the previous init
+      // was interrupted or has failed, it will not block the new init
       let iterationCount = 0
       await new Promise((resolve, reject) => {
         const interval = setInterval(async () => {

--- a/src/runtime/internal/database.server.ts
+++ b/src/runtime/internal/database.server.ts
@@ -103,16 +103,6 @@ async function _checkAndImportDatabaseIntegrity(event: H3Event, collection: stri
     await db.exec(`DELETE FROM ${tables.info} WHERE id = ?`, [`checksum_${collection}`])
   }
 
-  // if the collection is already initialized and the version is the same
-  if (before.ready === true && before?.version) {
-    if (before.version === integrityVersion) {
-      return true
-    }
-
-    // Delete old version
-    await db.exec(`DELETE FROM ${tables.info} WHERE id = ?`, [`checksum_${collection}`])
-  }
-
   const dump = await loadDatabaseDump(event, collection).then(decompressSQLDump)
 
   await dump.reduce(async (prev: Promise<void>, sql: string) => {

--- a/src/runtime/internal/database.server.ts
+++ b/src/runtime/internal/database.server.ts
@@ -63,9 +63,10 @@ async function _checkAndImportDatabaseIntegrity(event: H3Event, collection: stri
 
   const before = await db.first<{ version: string, ready: boolean }>(`select * from ${tables.info} where id = ?`, [`checksum_${collection}`]).catch(() => ({ version: '', ready: true }))
 
-  // if another request has already started the initialization of this collection
+  // if another request has already started the initialization of
+  // this version of this collection
   // wait for it to finish
-  if (before.ready === false) {
+  if (before.ready === false && before.version === integrityVersion) {
     await new Promise((resolve) => {
       const interval = setInterval(async () => {
         const { ready } = await db.first<{ ready: boolean }>(`select ready from ${tables.info} where id = ?`, [`checksum_${collection}`]).catch(() => ({ ready: true }))
@@ -79,7 +80,7 @@ async function _checkAndImportDatabaseIntegrity(event: H3Event, collection: stri
   }
 
   // if the collection is already initialized and the version is the same
-  if (before?.version) {
+  if (before.ready === true && before?.version) {
     if (before.version === integrityVersion) {
       return true
     }

--- a/src/runtime/internal/database.server.ts
+++ b/src/runtime/internal/database.server.ts
@@ -63,7 +63,7 @@ export async function checkAndImportDatabaseIntegrity(event: H3Event, collection
 async function _checkAndImportDatabaseIntegrity(event: H3Event, collection: string, integrityVersion: string, config: RuntimeConfig['content']) {
   const db = loadDatabaseAdapter(config)
 
-  const before = await db.first<{ version: string, ready: boolean }>(`select * from ${tables.info} where id = ?`, [`checksum_${collection}`]).catch(() => null)
+  const before: { version: string, ready: boolean } | null = await db.first<{ version: string, ready: boolean }>(`select * from ${tables.info} where id = ?`, [`checksum_${collection}`]).catch((): null => null)
 
   if (before?.version) {
     if (before.ready === true && before.version === integrityVersion) {

--- a/src/runtime/internal/database.server.ts
+++ b/src/runtime/internal/database.server.ts
@@ -67,6 +67,7 @@ async function _checkAndImportDatabaseIntegrity(event: H3Event, collection: stri
 
   if (before?.version) {
     if (before.ready === true && before.version === integrityVersion) {
+      // table is already initialized and ready, use it
       return true
     }
 

--- a/src/utils/collection.ts
+++ b/src/utils/collection.ts
@@ -84,10 +84,12 @@ export function resolveCollections(collections: Record<string, DefinedCollection
     schema: z.object({
       id: z.string(),
       version: z.string(),
+      ready: z.boolean(),
     }),
     extendedSchema: z.object({
       id: z.string(),
       version: z.string(),
+      ready: z.boolean(),
     }),
     fields: {},
   }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

closes #3129

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Improve the concurent initialization of collections by waiting until one is finished to start another init.

#### Prevent double init

- At startup add a record in the info table to state we are about to init
- When launching a new loadAdapter(), check if info table and the init record are already here. If not, proceed with init.
- If already in the process of initialization, poll the table every 100ms to see if the record remains
- When the record has disappeared, return the query
- If a previous init of a previous version does not go all the way, the version will be different. Then we ignore the flag and init anyway.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
