### PR TITLE
fix: constant initialization of content tables

### DIFF
--- a/src/runtime/internal/database.server.ts
+++ b/src/runtime/internal/database.server.ts
@@ -66,12 +66,12 @@ async function _checkAndImportDatabaseIntegrity(event: H3Event, collection: stri
   const before: { version: string, ready: boolean } | null = await db.first<{ version: string, ready: boolean }>(`select * from ${tables.info} where id = ?`, [`checksum_${collection}`]).catch((): null => null)
 
   if (before?.version) {
-    if (before.ready === true && before.version === integrityVersion) {
+    if (before.version === integrityVersion) {
+      if (before.ready) {
       // table is already initialized and ready, use it
-      return true
-    }
+        return true
+      }
 
-    if (before.ready === false && before.version === integrityVersion) {
       // if another request has already started the initialization of
       // this version of this collection, wait for it to finish
       // then respond that the database is ready

--- a/src/runtime/internal/database.server.ts
+++ b/src/runtime/internal/database.server.ts
@@ -63,7 +63,7 @@ export async function checkAndImportDatabaseIntegrity(event: H3Event, collection
 async function _checkAndImportDatabaseIntegrity(event: H3Event, collection: string, integrityVersion: string, config: RuntimeConfig['content']) {
   const db = loadDatabaseAdapter(config)
 
-  const before: { version: string, ready: boolean } | null = await db.first<{ version: string, ready: boolean }>(`select * from ${tables.info} where id = ?`, [`checksum_${collection}`]).catch((): null => null)
+  const before = await db.first<{ version: string, ready: boolean }>(`select * from ${tables.info} where id = ?`, [`checksum_${collection}`]).catch((): null => null)
 
   if (before?.version) {
     if (before.version === integrityVersion) {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

follow up on #3129 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The `ready` flag from the database comes out as a 0-1 integer instead of a boolean.
Without this change the database always re-initializes.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
