### PR TITLE
docs: fix nuxtlabs studio url in migration

### DIFF
--- a/docs/content/blog/ui-pro-docs-migration.md
+++ b/docs/content/blog/ui-pro-docs-migration.md
@@ -215,7 +215,7 @@ All `_dir.yml` files become `.navigation.yml`
 
 ### 8. Migrate Studio activation
 
-Since the [studio module](https://nuxtlabs/studio-module) has been deprecated and a new generic `Preview API` has been implemented directly into Nuxt Content, we can remove the `@nuxthq/studio` package from our dependencies and from the `nuxt.config.ts` modules.
+Since the [studio module](https://nuxt.studio) has been deprecated and a new generic `Preview API` has been implemented directly into Nuxt Content, we can remove the `@nuxthq/studio` package from our dependencies and from the `nuxt.config.ts` modules.
 
 Instead we just need to enable the preview mode in the Nuxt configuration file by binding the Studio API.
 

--- a/docs/content/docs/1.getting-started/4.migration.md
+++ b/docs/content/docs/1.getting-started/4.migration.md
@@ -49,7 +49,7 @@ The new API is backed by SQL and content queries happens within a specific colle
 
 ### Nuxt Studio integration
 
-- The [studio module](https://nuxtlabs/studio-module) has been deprecated and a new generic `Preview API` has been implemented directly into Nuxt Content, you can remove the `@nuxthq/studio` package from your dependencies and from the `nuxt.config.ts` modules. Instead we just need to enable the preview mode in the Nuxt configuration file by binding the Studio API.
+- The [studio module](https://nuxt.studio) has been deprecated and a new generic `Preview API` has been implemented directly into Nuxt Content, you can remove the `@nuxthq/studio` package from your dependencies and from the `nuxt.config.ts` modules. Instead we just need to enable the preview mode in the Nuxt configuration file by binding the Studio API.
 
 ```ts [nuxt.config.ts]
 export default defineNuxtConfig({


### PR DESCRIPTION
### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Fixes the link to the Studio module in https://content.nuxt.com/docs/getting-started/migration#nuxt-studio-integration.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
