### PR TITLE
fix(database): check that table exist before querying

### DIFF
--- a/src/utils/collection.ts
+++ b/src/utils/collection.ts
@@ -245,9 +245,7 @@ export function convertFieldsToSqlFields(sortedKeys: string[], collection: Resol
     }
 
     // Handle optional fields
-    const constraints = [
-      type.isNullable() ? ' NULL' : '',
-    ]
+    const constraints = type.isNullable() ? ['NULL'] : []
 
     // Handle default values
     if (type._def.defaultValue !== undefined) {
@@ -269,7 +267,7 @@ export function convertFieldsToSqlFields(sortedKeys: string[], collection: Resol
 export function generateCollectionTableDefinition(collection: ResolvedCollection, opts: { drop?: boolean } = {}) {
   const sortedKeys = getOrderedSchemaKeys((collection.extendedSchema).shape)
   const sqlFields = convertFieldsToSqlFields(sortedKeys, collection).map(({ key, sqlType, constraints }) => {
-    return `"${key}" ${sqlType}${constraints.join(' ')}`
+    return `"${key}" ${sqlType}${constraints?.length ? ' ' : ''}${constraints.join(' ')}`
   })
 
   let definition = `CREATE TABLE IF NOT EXISTS ${collection.tableName} (${sqlFields.join(', ')});`

--- a/test/unit/generateCollectionTableDefinition.test.ts
+++ b/test/unit/generateCollectionTableDefinition.test.ts
@@ -12,7 +12,7 @@ describe('generateCollectionTableDefinition', () => {
 
     expect(sql).toBe([
       `CREATE TABLE IF NOT EXISTS ${getTableName('content')} (`,
-      'id TEXT PRIMARY KEY,',
+      '"id" TEXT PRIMARY KEY,',
       ' "title" VARCHAR,',
       ' "body" TEXT,',
       ' "description" VARCHAR,',
@@ -38,7 +38,7 @@ describe('generateCollectionTableDefinition', () => {
 
     expect(sql).toBe([
       `CREATE TABLE IF NOT EXISTS ${getTableName('content')} (`,
-      'id TEXT PRIMARY KEY,',
+      '"id" TEXT PRIMARY KEY,',
       ' "title" VARCHAR,',
       ' "body" TEXT,',
       ' "customField" VARCHAR,',
@@ -65,7 +65,7 @@ describe('generateCollectionTableDefinition', () => {
 
     expect(sql).toBe([
       `CREATE TABLE IF NOT EXISTS ${getTableName('content')} (`,
-      'id TEXT PRIMARY KEY,',
+      '"id" TEXT PRIMARY KEY,',
       ' "customField" VARCHAR,',
       ' "extension" VARCHAR,',
       ' "meta" TEXT,',
@@ -87,7 +87,7 @@ describe('generateCollectionTableDefinition', () => {
 
     expect(sql).toBe([
       `CREATE TABLE IF NOT EXISTS ${getTableName('content')} (`,
-      'id TEXT PRIMARY KEY,',
+      '"id" TEXT PRIMARY KEY,',
       ' "customField" VARCHAR(64) DEFAULT \'foo\',',
       ' "extension" VARCHAR,',
       ' "meta" TEXT,',
@@ -108,7 +108,7 @@ describe('generateCollectionTableDefinition', () => {
 
     expect(sql).toBe([
       `CREATE TABLE IF NOT EXISTS ${getTableName('content')} (`,
-      'id TEXT PRIMARY KEY,',
+      '"id" TEXT PRIMARY KEY,',
       ' "customField" INT DEFAULT 13,',
       ' "extension" VARCHAR,',
       ' "meta" TEXT,',
@@ -129,7 +129,7 @@ describe('generateCollectionTableDefinition', () => {
 
     expect(sql).toBe([
       `CREATE TABLE IF NOT EXISTS ${getTableName('content')} (`,
-      'id TEXT PRIMARY KEY,',
+      '"id" TEXT PRIMARY KEY,',
       ' "customField" BOOLEAN DEFAULT false,',
       ' "extension" VARCHAR,',
       ' "meta" TEXT,',
@@ -150,7 +150,7 @@ describe('generateCollectionTableDefinition', () => {
 
     expect(sql).toBe([
       `CREATE TABLE IF NOT EXISTS ${getTableName('content')} (`,
-      'id TEXT PRIMARY KEY,',
+      '"id" TEXT PRIMARY KEY,',
       ' "customField" DATE,',
       ' "extension" VARCHAR,',
       ' "meta" TEXT,',
@@ -174,7 +174,7 @@ describe('generateCollectionTableDefinition', () => {
 
     expect(sql).toBe([
       `CREATE TABLE IF NOT EXISTS ${getTableName('content')} (`,
-      'id TEXT PRIMARY KEY,',
+      '"id" TEXT PRIMARY KEY,',
       ' "customField" TEXT,',
       ' "extension" VARCHAR,',
       ' "meta" TEXT,',
@@ -198,7 +198,7 @@ describe('generateCollectionTableDefinition', () => {
 
     expect(sql).toBe([
       `CREATE TABLE IF NOT EXISTS ${getTableName('content')} (`,
-      'id TEXT PRIMARY KEY,',
+      '"id" TEXT PRIMARY KEY,',
       ' "customField" TEXT,',
       ' "extension" VARCHAR,',
       ' "meta" TEXT,',
@@ -229,7 +229,7 @@ describe('generateCollectionTableDefinition', () => {
 
     expect(sql).toBe([
       `CREATE TABLE IF NOT EXISTS ${getTableName('content')} (`,
-      'id TEXT PRIMARY KEY,',
+      '"id" TEXT PRIMARY KEY,',
       ' "extension" VARCHAR,',
       ' "f1" BOOLEAN NULL,',
       ' "f2" VARCHAR NULL,',


### PR DESCRIPTION
The idea here is to avoid catching errors so that if there is an error, it's not hidden.
The try/catch is troublesome here and makes me worried.

To that end I make sure that the checks are done manually before starting the queries.

Also I figured out why the info ready was not converted: ` FROM _content_info` has to be all caps for it to match.
Fixed this as well.