### PR TITLE
docs: add missing section for the count method and fix some typos in the same file

### DIFF
--- a/docs/content/docs/4.utils/1.query-collection.md
+++ b/docs/content/docs/4.utils/1.query-collection.md
@@ -254,7 +254,7 @@ const { data } = await useAsyncData(route.path, () => {
 
 ## Examples
 
-Here is a complete example of how to fetch list of documents in `docs` collections.
+Here is a complete example of how to fetch a list of documents in the `docs` collections.
 
 ```vue [index.vue]
 <script setup lang="ts">

--- a/docs/content/docs/4.utils/1.query-collection.md
+++ b/docs/content/docs/4.utils/1.query-collection.md
@@ -221,6 +221,37 @@ const { data } = await useAsyncData(route.path, () => {
 })
 ```
 
+### `count()`
+
+Count the number of matched collection entries based on the query.
+
+```ts
+const route = useRoute()
+const { data } = await useAsyncData(route.path, () => {
+  return queryCollection('docs')
+    // Count matches
+    .count()
+})
+
+// Returns
+5 // number of matches
+```
+
+You can also use `count()` with other methods defined above such as `where()` in order to apply additional conditions within the collection query.
+
+```ts
+const route = useRoute()
+const { data } = await useAsyncData(route.path, () => {
+  return queryCollection('docs')
+    .where('date', '<', '2024-04-04')
+    // Count matches
+    .count()
+})
+
+// Returns
+3 // number of matches for the provided query
+```
+
 ## Examples
 
 Here is a complete example of how to fetch list of documents in `docs` collections.
@@ -264,4 +295,3 @@ Make sure to create `server/tsconfig.json` file with the following content to av
 }
 ```
 :::
-


### PR DESCRIPTION
### 🔗 Linked issue
#3208, #2200

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [X] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Re-add the documentation section for the `count()` method, which was already added in v2 and removed somewhere on the path to the current state of the repo.

This PR adds a section to document the `count()` method so that one is able to find out such functionality is already implemented by this module.

Resolves #3208

### 📝 Checklist
- [X] I have linked an issue or discussion.
- [X] I have updated the documentation accordingly.
