### PR TITLE
Bitbucket as a repository content collection source 

### DIFF
--- a/src/types/collection.ts
+++ b/src/types/collection.ts
@@ -13,6 +13,10 @@ export type CollectionSource = {
   exclude?: string[]
   repository?: string
   authToken?: string
+  authBasic?: {
+    username: string
+    password: string
+  }
   cwd?: string
 }
 

--- a/src/utils/collection.ts
+++ b/src/utils/collection.ts
@@ -3,7 +3,7 @@ import { hash } from 'ohash'
 import type { Collection, ResolvedCollection, CollectionSource, DefinedCollection, ResolvedCollectionSource, CustomCollectionSource, ResolvedCustomCollectionSource } from '../types/collection'
 import { getOrderedSchemaKeys } from '../runtime/internal/schema'
 import type { ParsedContentFile } from '../types'
-import { defineLocalSource, defineGitHubSource } from './source'
+import { defineLocalSource, defineGitHubSource, defineBitbucketSource } from './source'
 import { metaSchema, pageSchema } from './schema'
 import type { ZodFieldType } from './zod'
 import { getUnderlyingType, ZodToSqlFieldTypes, z, getUnderlyingTypeName } from './zod'
@@ -122,9 +122,12 @@ function resolveSource(source: string | CollectionSource | CollectionSource[] | 
     }
 
     if (source.repository) {
+      if(source.repository.includes('bitbucket')) {
+        return defineBitbucketSource(source)
+      }
       return defineGitHubSource(source)
     }
-
+    
     return defineLocalSource(source)
   })
 }

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -90,6 +90,26 @@ export function parseGitHubUrl(url: string) {
   return null
 }
 
+export function parseBitBucketUrl(url: string){
+  const bitbucketRegex = /https:\/\/bitbucket\.org\/([^/]+)\/([^/]+)(?:\/get\/([^.]+)\.tar.gz)?/
+  const bitbucketMatch = url.match(bitbucketRegex)
+
+  if (bitbucketMatch) {
+    const org = bitbucketMatch[1]
+    const repo = bitbucketMatch[2]
+    const branch = bitbucketMatch[3] || 'main' // Default to 'main' if no branch is provided
+
+    return {
+      org: org,
+      repo: repo,
+      branch: branch,
+      path: '',
+    }
+  }
+
+  return null
+}
+
 export async function getLocalGitInfo(rootDir: string): Promise<GitInfo | undefined> {
   const remote = await getLocalGitRemote(rootDir)
   if (!remote) {

--- a/src/utils/source.ts
+++ b/src/utils/source.ts
@@ -3,7 +3,7 @@ import { join } from 'pathe'
 import { withLeadingSlash, withoutTrailingSlash } from 'ufo'
 import FastGlob from 'fast-glob'
 import type { CollectionSource, ResolvedCollectionSource } from '../types/collection'
-import { downloadRepository, parseGitHubUrl } from './git'
+import { downloadRepository, parseBitBucketUrl, parseGitHubUrl } from './git'
 import { logger } from './dev'
 
 export function defineLocalSource(source: CollectionSource | ResolvedCollectionSource): ResolvedCollectionSource {
@@ -60,6 +60,41 @@ export function defineGitHubSource(source: CollectionSource): ResolvedCollection
   }
 
   return resolvedSource
+}
+
+export function defineBitbucketSource(
+  source: CollectionSource,
+): ResolvedCollectionSource {
+  const resolvedSource = defineLocalSource(source);
+
+  resolvedSource.prepare = async ({ rootDir }) => {
+    const repository =
+      source?.repository && parseBitBucketUrl(source.repository!);
+    if (repository) {
+      const { org, repo, branch } = repository;
+      resolvedSource.cwd = join(
+        rootDir,
+        ".data",
+        "content",
+        `bitbucket-${org}-${repo}-${branch}`,
+      );
+
+      let headers: Record<string, string> = {};
+      if (resolvedSource.authBasic) {
+        const credentials = `${resolvedSource.authBasic.username}:${resolvedSource.authBasic.password}`;
+        const encodedCredentials = btoa(credentials);
+        headers = {
+          Authorization: `Basic ${encodedCredentials}`,
+        };
+      }
+
+      const url = `https://bitbucket.org/${org}/${repo}/get/${branch}.tar.gz`;
+
+      await downloadRepository(url, resolvedSource.cwd!, { headers });
+    }
+  }
+
+  return resolvedSource;
 }
 
 export function parseSourceBase(source: CollectionSource) {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue: https://github.com/nuxt/content/issues/3217

### ❓ Type of change: Enhancement 

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
Added additional method that allows for using bitbucket as a repository source using the bitbucket api for downloading repository as a zip/gz file (https://confluence.atlassian.com/bbkb/how-to-download-repositories-using-the-api-1188780893.html). As far as I know bitbucket only allows for downloading the entire branch or specifically uploaded files via a different API. These changes allow for downloading all the files of a specific branch. 

<!-- Why is this change required? What problem does it solve? -->
Makes it easier to use bitbucket as a content collection source. 

<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
https://github.com/nuxt/content/issues/3217
### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
