### PR TITLE
fix: check for ws existence before closing

### DIFF
--- a/src/utils/dev.ts
+++ b/src/utils/dev.ts
@@ -77,7 +77,7 @@ export async function startSocketServer(nuxt: Nuxt, options: ModuleOptions, mani
 
   nuxt.hook('close', async () => {
     // Close WebSocket server
-    await websocket.close()
+    await websocket?.close()
     await listener.server.close()
   })
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

websocket can be undefined if it is disabled so we should check if it exists before accessing `close()`