### PR TITLE
fix(module): prevent conflict with auth & security tools

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -168,7 +168,7 @@ export default defineNuxtModule<ModuleOptions>({
 
       config.handlers ||= []
       config.handlers.push({
-        route: '/api/content/:collection/query',
+        route: '/__nuxt_content/:collection/query',
         handler: resolver.resolve('./runtime/api/query.post'),
       })
 
@@ -185,7 +185,7 @@ export default defineNuxtModule<ModuleOptions>({
     nuxt.options.routeRules ||= {}
     manifest.collections.forEach((collection) => {
       if (!collection.private) {
-        nuxt.options.routeRules![`/api/content/${collection.name}/database.sql`] = { prerender: true }
+        nuxt.options.routeRules![`/__nuxt_content/${collection.name}/sql_dump`] = { prerender: true }
       }
     })
 

--- a/src/presets/cloudflare-pages.ts
+++ b/src/presets/cloudflare-pages.ts
@@ -26,7 +26,7 @@ export default definePreset({
     // Add raw content dump to public assets
     nitroConfig.publicAssets.push({ dir: join(nitroConfig.buildDir!, 'content', 'raw'), maxAge: 60 })
     nitroConfig.handlers.push({
-      route: '/api/content/:collection/database.sql',
+      route: '/__nuxt_content/:collection/sql_dump',
       handler: resolver.resolve('./runtime/presets/cloudflare-pages/database-handler'),
     })
   },

--- a/src/presets/node.ts
+++ b/src/presets/node.ts
@@ -11,7 +11,7 @@ export default definePreset({
 
     nitroConfig.alias['#content/dump'] = addTemplate(fullDatabaseCompressedDumpTemplate(manifest)).dst
     nitroConfig.handlers.push({
-      route: '/api/content/:collection/database.sql',
+      route: '/__nuxt_content/:collection/sql_dump',
       handler: resolver.resolve('./runtime/presets/node/database-handler'),
     })
   },

--- a/src/runtime/internal/api.ts
+++ b/src/runtime/internal/api.ts
@@ -2,7 +2,7 @@ import type { H3Event } from 'h3'
 import { checksums } from '#content/manifest'
 
 export async function fetchDatabase(event: H3Event | undefined, collection: string): Promise<string> {
-  return await $fetch(`/api/content/${collection}/database.sql`, {
+  return await $fetch(`/__nuxt_content/${collection}/sql_dump`, {
     context: event ? { cloudflare: event.context.cloudflare } : {},
     responseType: 'text',
     headers: { 'content-type': 'text/plain' },
@@ -11,7 +11,7 @@ export async function fetchDatabase(event: H3Event | undefined, collection: stri
 }
 
 export async function fetchQuery<Item>(event: H3Event | undefined, collection: string, sql: string): Promise<Item[]> {
-  return await $fetch(`/api/content/${collection}/query`, {
+  return await $fetch(`/__nuxt_content/${collection}/query`, {
     context: event ? { cloudflare: event.context.cloudflare } : {},
     headers: { 'content-type': 'application/json' },
     query: { v: checksums[String(collection)], t: import.meta.dev ? Date.now() : undefined },

--- a/src/utils/templates.ts
+++ b/src/utils/templates.ts
@@ -42,7 +42,7 @@ export const moduleTemplates = {
   manifest: 'content/manifest.ts',
   components: 'content/components.ts',
   fullCompressedDump: 'content/database.compressed.mjs',
-  fullRawDump: 'content/database.sql',
+  fullRawDump: 'content/sql_dump',
 }
 
 export const contentTypesTemplate = (collections: ResolvedCollection[]) => ({

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -84,7 +84,7 @@ describe('basic', async () => {
     })
 
     test('is downloadable', async () => {
-      const response: string = await $fetch('/api/content/content/database.sql', { responseType: 'text' })
+      const response: string = await $fetch('/__nuxt_content/content/sql_dump', { responseType: 'text' })
       expect(response).toBeDefined()
 
       const parsedDump = await decompressSQLDump(response as string)

--- a/test/empty.test.ts
+++ b/test/empty.test.ts
@@ -88,7 +88,7 @@ describe('empty', async () => {
     })
 
     test('is downloadable', async () => {
-      const response: string = await $fetch('/api/content/content/database.sql', { responseType: 'text' })
+      const response: string = await $fetch('/__nuxt_content/content/sql_dump', { responseType: 'text' })
       expect(response).toBeDefined()
 
       const parsedDump = await decompressSQLDump(response as string)


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue
resolves #3043
resovles #3243
resovles #3091


### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

- resolves #3043

Due to the behavior of the `serve` package, using the `database.sql` as filename for the database dump breaks the spa apps. Renaming the filename to `sql_dump` fixes the issue

- resolves #3243

Rename `database.sql` to `sql_dump` to prevent having conflict with security services.

- resovles #3091

Instead of registering API routes under `/api/content`, module now registers APIs under `/__nuxt_content` prefix. By doing so, the module APIs will no longer conflict with user APIs and authentication.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
