### PR TITLE
docs: update source options

### DIFF
--- a/docs/content/docs/2.collections/3.sources.md
+++ b/docs/content/docs/2.collections/3.sources.md
@@ -80,7 +80,25 @@ source: {
 
 ### `repository`
 
-External source representing a remote git repository URL (e.g., <https://github.com/nuxt/content>)
+External source representing a remote git repository URL (e.g., <https://github.com/nuxt/content>).
+
+When defining an external source you must also define the `include` option:
+
+```js
+import { defineCollection, defineContentConfig } from '@nuxt/content'
+
+export default defineContentConfig({
+  collections: {
+    docs: defineCollection({
+      source: {
+        repository: 'https://github.com/nuxt/content',
+        include: '**',
+      },
+      type: 'page'
+    })
+  }
+})
+```
 
 ### `authToken`
 

--- a/docs/content/docs/2.collections/3.sources.md
+++ b/docs/content/docs/2.collections/3.sources.md
@@ -32,7 +32,7 @@ The `source` property can be defined as either a string (following a glob patter
 - `source: '**/*.{json,yml}'` includes `JSON` or `YML` file within the content directory and all its subdirectories.
 - `source: '*.json'` includes only `JSON` files located directly within the content directory, excluding any subdirectories.
 
-### `include`
+### `include` (required)
 
 Glob pattern of your target repository and files in the content folder.
 
@@ -82,7 +82,8 @@ source: {
 
 External source representing a remote git repository URL (e.g., <https://github.com/nuxt/content>).
 
-When defining an external source you must also define the `include` option:
+When defining an external source you must also define the `include` option.
+`include` pattern is essential for the module to know which files to use for the collection.
 
 ```js
 import { defineCollection, defineContentConfig } from '@nuxt/content'
@@ -90,11 +91,11 @@ import { defineCollection, defineContentConfig } from '@nuxt/content'
 export default defineContentConfig({
   collections: {
     docs: defineCollection({
+      type: 'page'
       source: {
         repository: 'https://github.com/nuxt/content',
-        include: '**',
+        include: 'docs/content/**',
       },
-      type: 'page'
     })
   }
 })
@@ -103,3 +104,20 @@ export default defineContentConfig({
 ### `authToken`
 
 Authentication token for private repositories (e.g., GitHub personal access token).
+
+### `authBasic`
+
+Basic authentication for private repositories (e.g., Bitbucket username and password).
+
+```ts
+defineCollection({
+  type: 'page',
+  source: {
+    repository: 'https://bitbucket.org/username/repo',
+    authBasic: {
+      username: 'username',
+      password: 'password',
+    },
+  },
+})
+```


### PR DESCRIPTION
This PR improves the docs for the `repository` option by making it clear that it's mandatory to also specify the `include` option when using it.