### PR TITLE
docs(installation): fix install command

### DIFF
--- a/docs/content/1.get-started/1.installation.md
+++ b/docs/content/1.get-started/1.installation.md
@@ -11,7 +11,14 @@ description: Get started with Nuxt Content by creating a new project or adding i
 
 You can add Nuxt Content at anytime during your Nuxt project development by installing the `@nuxt/content` module:
 ```bash
-npx nuxi@latest module add @nuxt/content@2
+ # npm
+ npm install @nuxt/content@2
+ # yarn
+ yarn add @nuxt/content@2
+ # pnpm
+ pnpm add @nuxt/content@2
+ # bun
+ bun add @nuxt/content@2
 ```
 
 Then, add `@nuxt/content` to the `modules` section of `nuxt.config.ts`:


### PR DESCRIPTION
Currently, running `nuxi@latest module add @nuxt/content@2` does not work due to this issue: https://github.com/nuxt/cli/issues/697.

Since the `module add` command does not allow specifying a version, I switched to the classic installation method to ensure compatibility.

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
