### PR TITLE
Replace node:22-alpine with node:22

### DIFF
--- a/docs/content/docs/6.deploy/7.docker.md
+++ b/docs/content/docs/6.deploy/7.docker.md
@@ -31,7 +31,9 @@ RUN pnpm run build
 
 # Build Stage 2
 
-FROM node:22-alpine
+# node:22-alpine is not compatible with better-sqlite-3 module
+# See https://github.com/nuxt/content/issues/3248 for more details
+FROM node:22
 WORKDIR /app
 
 # Only `.output` folder is needed from the build stage


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

https://github.com/nuxt/content/issues/3248

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

node:22-alpine does not have a proper glibc, this makes better-sqlite-3 not working.
```
PS C:\Users\Admin> docker run --rm -it node:22-alpine sh
/ # ldd --version
musl libc (x86_64)
Version 1.2.5
Dynamic Program Loader
Usage: /lib/ld-musl-x86_64.so.1 [options] [--] pathname
```

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
