### PR TITLE
feat: collection hashing for multi instance support

### DIFF
--- a/src/types/collection.ts
+++ b/src/types/collection.ts
@@ -73,6 +73,7 @@ export interface ResolvedCollection<T extends ZodRawShape = ZodRawShape> {
    * Private collections will not be available in the runtime.
    */
   private: boolean
+  hash: string
 }
 
 export interface CollectionInfo {

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -1,4 +1,5 @@
 import type { Primitive, Connector } from 'db0'
+import type { ResolvedCollection } from '../module'
 
 export type CacheEntry = { id: string, checksum: string, parsedContent: string }
 
@@ -19,7 +20,7 @@ export interface LocalDevelopmentDatabase {
   fetchDevelopmentCacheForKey(key: string): Promise<CacheEntry | undefined>
   insertDevelopmentCache(id: string, checksum: string, parsedContent: string): void
   deleteDevelopmentCache(id: string): void
-  dropContentTables(): void
+  dropOldContentTables(collections: ResolvedCollection[]): Promise<{ upToDateTables: string[] }>
   exec(sql: string): void
   close(): void
   database?: Connector

--- a/src/utils/collection.ts
+++ b/src/utils/collection.ts
@@ -11,8 +11,9 @@ import { logger } from './dev'
 
 const JSON_FIELDS_TYPES = ['ZodObject', 'ZodArray', 'ZodRecord', 'ZodIntersection', 'ZodUnion', 'ZodAny', 'ZodMap']
 
-export function getTableName(name: string) {
-  return `_content_${name}`
+export function getTableName(name: string, collectionHash: string) {
+  const tableNameSafeHash = collectionHash.split('-').join('').toLowerCase().substring(0, 4)
+  return `_content_${name}_${tableNameSafeHash}`
 }
 
 export function defineCollection<T extends ZodRawShape>(collection: Collection<T>): DefinedCollection {
@@ -75,12 +76,19 @@ export function resolveCollection(name: string, collection: DefinedCollection): 
     return undefined
   }
 
-  return {
+  const resolvedCollection: Omit<ResolvedCollection, 'hash' | 'tableName'> = {
     ...collection,
     name,
     type: collection.type || 'page',
-    tableName: getTableName(name),
     private: name === 'info',
+  }
+
+  const collectionHash = hash(resolvedCollection)
+
+  return {
+    ...resolvedCollection,
+    tableName: getTableName(name, collectionHash),
+    hash: collectionHash,
   }
 }
 

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -62,12 +62,13 @@ describe('basic', async () => {
     })
 
     test('content table is created', async () => {
-      const cache = await db.database?.prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name=?;`)
-        .all(getTableName('content')) as { name: string }[]
+      const tableNameNoHash = getTableName('content', 'xxxx').slice(0, -4)
+      const cache = await db.database?.prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name LIKE ? || '%';`)
+        .all(tableNameNoHash) as { name: string }[]
 
       expect(cache).toBeDefined()
       expect(cache).toHaveLength(1)
-      expect(cache![0].name).toBe(getTableName('content'))
+      expect(cache![0].name.slice(0, -4)).toBe(tableNameNoHash)
     })
   })
 

--- a/test/empty.test.ts
+++ b/test/empty.test.ts
@@ -67,12 +67,13 @@ describe('empty', async () => {
     })
 
     test('content table is created', async () => {
-      const cache = await db.database?.prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name=?;`)
-        .all(getTableName('content')) as { name: string }[]
+      const tableNameNoHash = getTableName('content', 'xxxx').slice(0, -4)
+      const cache = await db.database?.prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name LIKE ? || '%';`)
+        .all(tableNameNoHash) as { name: string }[]
 
       expect(cache).toBeDefined()
       expect(cache).toHaveLength(1)
-      expect(cache![0]!.name).toBe(getTableName('content'))
+      expect(cache![0].name.slice(0, -4)).toBe(tableNameNoHash)
     })
   })
 

--- a/test/unit/generateCollectionInsert.test.ts
+++ b/test/unit/generateCollectionInsert.test.ts
@@ -22,7 +22,7 @@ describe('generateCollectionInsert', () => {
     })
 
     expect(sql[0]).toBe([
-      `INSERT INTO ${getTableName('content')}`,
+      `INSERT INTO ${getTableName('content', collection.hash)}`,
       ' VALUES',
       ' (\'foo.md\', 13, \'2022-01-01T00:00:00.000Z\', \'md\', \'{}\', \'untitled\', true, \'foo\', \'vPdICyZ7sjhw1YY4ISEATbCTIs_HqNpMVWHnBWhOOYY\');',
     ].join(''))
@@ -51,7 +51,7 @@ describe('generateCollectionInsert', () => {
     })
 
     expect(sql[0]).toBe([
-      `INSERT INTO ${getTableName('content')}`,
+      `INSERT INTO ${getTableName('content', collection.hash)}`,
       ' VALUES',
       ' (\'foo.md\', 42, \'2022-01-02T00:00:00.000Z\', \'md\', \'{}\', \'foo\', false, \'foo\', \'R5zX5zuyfvCtvXPcgINuEjEoHmZnse8kATeDd4V7I-c\');',
     ].join(''))
@@ -88,14 +88,14 @@ describe('generateCollectionInsert', () => {
     expect(content).toEqual(querySlices.join(''))
 
     expect(sql[0]).toBe([
-      `INSERT INTO ${getTableName('content')}`,
+      `INSERT INTO ${getTableName('content', collection.hash)}`,
       ' VALUES',
       ` ('foo.md', '${querySlices[0]}', 'md', '{}', 'foo', 'QMyFxMru9gVfaNx0fzjs5is7SvAZMEy3tNDANjkdogg');`,
     ].join(''))
     let index = 1
     while (index < sql.length - 1) {
       expect(sql[index]).toBe([
-        `UPDATE ${getTableName('content')}`,
+        `UPDATE ${getTableName('content', collection.hash)}`,
         ' SET',
         ` content = CONCAT(content, '${querySlices[index]}')`,
         ' WHERE id = \'foo.md\';',

--- a/test/unit/generateCollectionTableDefinition.test.ts
+++ b/test/unit/generateCollectionTableDefinition.test.ts
@@ -11,7 +11,7 @@ describe('generateCollectionTableDefinition', () => {
     const sql = generateCollectionTableDefinition(collection)
 
     expect(sql).toBe([
-      `CREATE TABLE IF NOT EXISTS ${getTableName('content')} (`,
+      `CREATE TABLE IF NOT EXISTS ${getTableName('content', collection.hash)} (`,
       'id TEXT PRIMARY KEY,',
       ' "title" VARCHAR,',
       ' "body" TEXT,',
@@ -38,7 +38,7 @@ describe('generateCollectionTableDefinition', () => {
     const sql = generateCollectionTableDefinition(collection)
 
     expect(sql).toBe([
-      `CREATE TABLE IF NOT EXISTS ${getTableName('content')} (`,
+      `CREATE TABLE IF NOT EXISTS ${getTableName('content', collection.hash)} (`,
       'id TEXT PRIMARY KEY,',
       ' "title" VARCHAR,',
       ' "body" TEXT,',
@@ -66,7 +66,7 @@ describe('generateCollectionTableDefinition', () => {
     const sql = generateCollectionTableDefinition(collection)
 
     expect(sql).toBe([
-      `CREATE TABLE IF NOT EXISTS ${getTableName('content')} (`,
+      `CREATE TABLE IF NOT EXISTS ${getTableName('content', collection.hash)} (`,
       'id TEXT PRIMARY KEY,',
       ' "customField" VARCHAR,',
       ' "extension" VARCHAR,',
@@ -89,7 +89,7 @@ describe('generateCollectionTableDefinition', () => {
     const sql = generateCollectionTableDefinition(collection)
 
     expect(sql).toBe([
-      `CREATE TABLE IF NOT EXISTS ${getTableName('content')} (`,
+      `CREATE TABLE IF NOT EXISTS ${getTableName('content', collection.hash)} (`,
       'id TEXT PRIMARY KEY,',
       ' "customField" VARCHAR(64) DEFAULT \'foo\',',
       ' "extension" VARCHAR,',
@@ -111,7 +111,7 @@ describe('generateCollectionTableDefinition', () => {
     const sql = generateCollectionTableDefinition(collection)
 
     expect(sql).toBe([
-      `CREATE TABLE IF NOT EXISTS ${getTableName('content')} (`,
+      `CREATE TABLE IF NOT EXISTS ${getTableName('content', collection.hash)} (`,
       'id TEXT PRIMARY KEY,',
       ' "customField" INT DEFAULT 13,',
       ' "extension" VARCHAR,',
@@ -133,7 +133,7 @@ describe('generateCollectionTableDefinition', () => {
     const sql = generateCollectionTableDefinition(collection)
 
     expect(sql).toBe([
-      `CREATE TABLE IF NOT EXISTS ${getTableName('content')} (`,
+      `CREATE TABLE IF NOT EXISTS ${getTableName('content', collection.hash)} (`,
       'id TEXT PRIMARY KEY,',
       ' "customField" BOOLEAN DEFAULT false,',
       ' "extension" VARCHAR,',
@@ -155,7 +155,7 @@ describe('generateCollectionTableDefinition', () => {
     const sql = generateCollectionTableDefinition(collection)
 
     expect(sql).toBe([
-      `CREATE TABLE IF NOT EXISTS ${getTableName('content')} (`,
+      `CREATE TABLE IF NOT EXISTS ${getTableName('content', collection.hash)} (`,
       'id TEXT PRIMARY KEY,',
       ' "customField" DATE,',
       ' "extension" VARCHAR,',
@@ -180,7 +180,7 @@ describe('generateCollectionTableDefinition', () => {
     const sql = generateCollectionTableDefinition(collection)
 
     expect(sql).toBe([
-      `CREATE TABLE IF NOT EXISTS ${getTableName('content')} (`,
+      `CREATE TABLE IF NOT EXISTS ${getTableName('content', collection.hash)} (`,
       'id TEXT PRIMARY KEY,',
       ' "customField" TEXT,',
       ' "extension" VARCHAR,',
@@ -205,7 +205,7 @@ describe('generateCollectionTableDefinition', () => {
     const sql = generateCollectionTableDefinition(collection)
 
     expect(sql).toBe([
-      `CREATE TABLE IF NOT EXISTS ${getTableName('content')} (`,
+      `CREATE TABLE IF NOT EXISTS ${getTableName('content', collection.hash)} (`,
       'id TEXT PRIMARY KEY,',
       ' "customField" TEXT,',
       ' "extension" VARCHAR,',
@@ -237,7 +237,7 @@ describe('generateCollectionTableDefinition', () => {
     const sql = generateCollectionTableDefinition(collection)
 
     expect(sql).toBe([
-      `CREATE TABLE IF NOT EXISTS ${getTableName('content')} (`,
+      `CREATE TABLE IF NOT EXISTS ${getTableName('content', collection.hash)} (`,
       'id TEXT PRIMARY KEY,',
       ' "extension" VARCHAR,',
       ' "f1" BOOLEAN NULL,',

--- a/test/unit/resolveCollection.test.ts
+++ b/test/unit/resolveCollection.test.ts
@@ -10,4 +10,20 @@ describe('resolveCollection', () => {
     const resolvedCollection = resolveCollection('invalid-name', collection)
     expect(resolvedCollection).toBeUndefined()
   })
+
+  test('Collection hash changes with content', () => {
+    const collectionA = defineCollection({
+      type: 'page',
+      source: '**',
+    })
+    const collectionB = defineCollection({
+      type: 'page',
+      source: 'someEmpty/**',
+    })
+    const resolvedCollectionA = resolveCollection('collection', collectionA)
+    const resolvedCollectionB = resolveCollection('collection', collectionB)
+    expect(resolvedCollectionA?.hash).toBeDefined()
+    expect(resolvedCollectionB?.hash).toBeDefined()
+    expect(resolvedCollectionA?.hash).not.toBe(resolvedCollectionB?.hash)
+  })
 })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

fixes #3273 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

This PR aims to address issues related to multiple running instances of Nuxt connecting to the same collection database by optimizing the module initialization and removing the need to drop all content tables and recreate each time.

I have proposed moving the collection `hash` into the `resolveCollection` function and using the first four safe characters as part of the table name. This allows collections that have not been altered to be left untouched during initialization allowing for multiple connecting Nuxt instances to run the module without interfering with each other.

Do let me know if there is anything you would like me to change here.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
