### PR TITLE
fix: generate correct collection insert for object and array default values

### DIFF
--- a/src/utils/collection.ts
+++ b/src/utils/collection.ts
@@ -160,11 +160,8 @@ export function generateCollectionInsert(collection: ResolvedCollection, data: P
     const value = (collection.extendedSchema).shape[key]
     const underlyingType = getUnderlyingType(value as ZodType<unknown, ZodOptionalDef>)
 
-    let defaultValue = value?._def.defaultValue ? value?._def.defaultValue() : 'NULL'
+    const defaultValue = value?._def.defaultValue ? value?._def.defaultValue() : 'NULL'
 
-    if (!(defaultValue instanceof Date) && typeof defaultValue === 'object') {
-      defaultValue = JSON.stringify(defaultValue)
-    }
     const valueToInsert = (typeof data[key] === 'undefined' || String(data[key]) === 'null')
       ? defaultValue
       : data[key]

--- a/test/unit/generateCollectionInsert.test.ts
+++ b/test/unit/generateCollectionInsert.test.ts
@@ -12,6 +12,8 @@ describe('generateCollectionInsert', () => {
         otherField: z.string().default('untitled'),
         otherField2: z.boolean().default(true),
         date: z.date().default(new Date('2022-01-01')),
+        object: z.object({ foo: z.string() }).default(() => ({ foo: 'bar' })),
+        array: z.array(z.string()).default(() => []),
       }),
     }))!
     const { queries: sql } = generateCollectionInsert(collection, {
@@ -24,7 +26,7 @@ describe('generateCollectionInsert', () => {
     expect(sql[0]).toBe([
       `INSERT INTO ${getTableName('content')}`,
       ' VALUES',
-      ' (\'foo.md\', 13, \'2022-01-01T00:00:00.000Z\', \'md\', \'{}\', \'untitled\', true, \'foo\', \'vPdICyZ7sjhw1YY4ISEATbCTIs_HqNpMVWHnBWhOOYY\');',
+      ' (\'foo.md\', \'[]\', 13, \'2022-01-01T00:00:00.000Z\', \'md\', \'{}\', \'{"foo":"bar"}\', \'untitled\', true, \'foo\', \'bnUQ85H_Zf72faGIQhV0i9QeTEnf1ueEIaMAO8aAAGw\');',
     ].join(''))
   })
 
@@ -37,6 +39,8 @@ describe('generateCollectionInsert', () => {
         otherField: z.string().default('untitled'),
         otherField2: z.boolean().default(true),
         date: z.date().default(new Date('2022-01-01')),
+        object: z.object({ foo: z.string() }).default(() => ({ foo: 'bar' })),
+        array: z.array(z.string()).default(() => []),
       }),
     }))!
     const { queries: sql } = generateCollectionInsert(collection, {
@@ -48,12 +52,14 @@ describe('generateCollectionInsert', () => {
       otherField: 'foo',
       otherField2: false,
       date: new Date('2022-01-02'),
+      object: { foo: 'baz' },
+      array: ['foo'],
     })
 
     expect(sql[0]).toBe([
       `INSERT INTO ${getTableName('content')}`,
       ' VALUES',
-      ' (\'foo.md\', 42, \'2022-01-02T00:00:00.000Z\', \'md\', \'{}\', \'foo\', false, \'foo\', \'R5zX5zuyfvCtvXPcgINuEjEoHmZnse8kATeDd4V7I-c\');',
+      ' (\'foo.md\', \'["foo"]\', 42, \'2022-01-02T00:00:00.000Z\', \'md\', \'{}\', \'{"foo":"baz"}\', \'foo\', false, \'foo\', \'ImMjHvkHl82Jx1bjlpanb9d3i_HQIbjNFverKKbZLME\');',
     ].join(''))
   })
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When the collection schema has an object with a default value, this object gets stringified two times instead of once.
This PR removes the `JSON.stringify` for default values of objects and adds code to test for correct insert code for objects and arrays.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
