### PR TITLE
docs: <ContentSlot> are not supported in v3, replaced by <slot>

### DIFF
--- a/docs/content/studio/index.md
+++ b/docs/content/studio/index.md
@@ -134,10 +134,10 @@ orientation: horizontal
       </div>
       <div class="flex flex-col">
         <h3 class="font-semibold">
-          <ContentSlot name="title" />
+          <slot name="title" />
         </h3>
         <span>
-          <ContentSlot name="description" />
+          <slot name="description" />
         </span>
       </div>
     </div>


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

As mentionned in https://content.nuxt.com/docs/getting-started/migration#components <ContentSlot> are not supported in v3 so I replaced them with <slot>

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
