### PR TITLE
fix: reactively load components when `body` changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   },
   "dependencies": {
     "@nuxt/kit": "^3.16.1",
-    "@nuxtjs/mdc": "^0.16.1",
+    "@nuxtjs/mdc": "https://pkg.pr.new/@nuxtjs/mdc@78a0571",
     "@shikijs/langs": "^3.2.1",
     "@sqlite.org/sqlite-wasm": "3.49.1-build2",
     "@webcontainer/env": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   },
   "dependencies": {
     "@nuxt/kit": "^3.16.1",
-    "@nuxtjs/mdc": "https://pkg.pr.new/@nuxtjs/mdc@78a0571",
+    "@nuxtjs/mdc": "https://pkg.pr.new/@nuxtjs/mdc@cd1c4fd",
     "@shikijs/langs": "^3.2.1",
     "@sqlite.org/sqlite-wasm": "3.49.1-build2",
     "@webcontainer/env": "^1.1.1",

--- a/playground/components/TestA.vue
+++ b/playground/components/TestA.vue
@@ -1,0 +1,5 @@
+<template>
+  <span class="text-red-500">
+    Test A <slot />
+  </span>
+</template>

--- a/playground/components/TestB.vue
+++ b/playground/components/TestB.vue
@@ -1,0 +1,5 @@
+<template>
+  <span class="text-blue-500">
+    Test B <slot />
+  </span>
+</template>

--- a/playground/components/TestC.vue
+++ b/playground/components/TestC.vue
@@ -1,0 +1,5 @@
+<template>
+  <span class="text-green-500">
+    Test C <slot />
+  </span>
+</template>

--- a/playground/components/playground.vue
+++ b/playground/components/playground.vue
@@ -1,0 +1,41 @@
+<template>
+  <div>
+    <ContentRenderer
+      :value="value"
+    />
+    <UButton @click="randomize">
+      Change Component
+    </UButton>
+  </div>
+</template>
+
+<script setup lang="ts">
+const body = ref({
+  type: 'root',
+  children: [
+    {
+      type: 'element', tag: 'p', props: {},
+      children: [
+        { type: 'text', value: 'Hello ' },
+        { type: 'element', tag: 'span', props: {}, children: [
+          { type: 'text', value: 'world' },
+        ] },
+        { type: 'text', value: '!' },
+      ],
+    },
+  ],
+})
+const value = computed(() => {
+  return { body: body.value }
+})
+
+const tags = ['TestA', 'TestB', 'TestC']
+const randomize = () => {
+  let tag = body.value.children[0].children[1].tag
+  while (tag === body.value.children[0].children[1].tag) {
+    tag = tags[Math.floor(Math.random() * tags.length)]
+  }
+  body.value.children[0].children[1].tag = tag
+  body.value.children[0].children[1].children![0]!.value = `world (${tag})`
+}
+</script>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: ^3.16.1
         version: 3.16.1(magicast@0.3.5)
       '@nuxtjs/mdc':
-        specifier: ^0.16.1
-        version: 0.16.1(magicast@0.3.5)
+        specifier: https://pkg.pr.new/@nuxtjs/mdc@78a0571
+        version: https://pkg.pr.new/@nuxtjs/mdc@78a0571(magicast@0.3.5)
       '@shikijs/langs':
         specifier: ^3.2.1
         version: 3.2.1
@@ -1724,8 +1724,9 @@ packages:
     resolution: {integrity: sha512-Rsdv3u4QdhA2ysD5Argu3RkEUgYKyeqfrrUY6tbm7DZSnMafOE2RsmPwbF/eKNEC9uHHUdcLZblBEJ8z7r01sw==}
     engines: {node: ^14.16.0 || >=16.11.0}
 
-  '@nuxtjs/mdc@0.16.1':
-    resolution: {integrity: sha512-di9Ox9QY5pO2eIkQPyKFe9O8L3RvIrGbmjI3rJQRj1xGYRFj2S9RvBPCFbvfaqQGOTjOfxHLg8KtQIGj1Iw/lg==}
+  '@nuxtjs/mdc@https://pkg.pr.new/@nuxtjs/mdc@78a0571':
+    resolution: {tarball: https://pkg.pr.new/@nuxtjs/mdc@78a0571}
+    version: 0.16.1
 
   '@nuxtjs/plausible@1.2.0':
     resolution: {integrity: sha512-pjfps32fFN77BhjqHmq2Jx4XCNso9TcYnB+S4IR2qH/c26WDfYB5mQxN5pOEiWRlMkiKq+Y45mBBFtSOVKClCA==}
@@ -9544,9 +9545,11 @@ snapshots:
       - typescript
       - vue
 
-  '@nuxtjs/mdc@0.16.1(magicast@0.3.5)':
+  '@nuxtjs/mdc@https://pkg.pr.new/@nuxtjs/mdc@78a0571(magicast@0.3.5)':
     dependencies:
       '@nuxt/kit': 3.16.1(magicast@0.3.5)
+      '@shikijs/langs': 3.2.1
+      '@shikijs/themes': 3.2.1
       '@shikijs/transformers': 3.2.1
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: ^3.16.1
         version: 3.16.1(magicast@0.3.5)
       '@nuxtjs/mdc':
-        specifier: https://pkg.pr.new/@nuxtjs/mdc@78a0571
-        version: https://pkg.pr.new/@nuxtjs/mdc@78a0571(magicast@0.3.5)
+        specifier: https://pkg.pr.new/@nuxtjs/mdc@cd1c4fd
+        version: https://pkg.pr.new/@nuxtjs/mdc@cd1c4fd(magicast@0.3.5)
       '@shikijs/langs':
         specifier: ^3.2.1
         version: 3.2.1
@@ -1724,8 +1724,8 @@ packages:
     resolution: {integrity: sha512-Rsdv3u4QdhA2ysD5Argu3RkEUgYKyeqfrrUY6tbm7DZSnMafOE2RsmPwbF/eKNEC9uHHUdcLZblBEJ8z7r01sw==}
     engines: {node: ^14.16.0 || >=16.11.0}
 
-  '@nuxtjs/mdc@https://pkg.pr.new/@nuxtjs/mdc@78a0571':
-    resolution: {tarball: https://pkg.pr.new/@nuxtjs/mdc@78a0571}
+  '@nuxtjs/mdc@https://pkg.pr.new/@nuxtjs/mdc@cd1c4fd':
+    resolution: {tarball: https://pkg.pr.new/@nuxtjs/mdc@cd1c4fd}
     version: 0.16.1
 
   '@nuxtjs/plausible@1.2.0':
@@ -9545,7 +9545,7 @@ snapshots:
       - typescript
       - vue
 
-  '@nuxtjs/mdc@https://pkg.pr.new/@nuxtjs/mdc@78a0571(magicast@0.3.5)':
+  '@nuxtjs/mdc@https://pkg.pr.new/@nuxtjs/mdc@cd1c4fd(magicast@0.3.5)':
     dependencies:
       '@nuxt/kit': 3.16.1(magicast@0.3.5)
       '@shikijs/langs': 3.2.1

--- a/src/runtime/components/ContentRenderer.vue
+++ b/src/runtime/components/ContentRenderer.vue
@@ -100,18 +100,18 @@ const data = computed(() => {
 const proseComponentMap = Object.fromEntries(['p', 'a', 'blockquote', 'code', 'pre', 'code', 'em', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'hr', 'img', 'ul', 'ol', 'li', 'strong', 'table', 'thead', 'tbody', 'td', 'th', 'tr', 'script'].map(t => [t, `prose-${t}`]))
 
 const { mdc } = useRuntimeConfig().public || {}
-const tags = {
+const tags = computed(() => ({
   ...mdc?.components?.prose && props.prose !== false ? proseComponentMap : {},
   ...mdc?.components?.map || {},
   ...toRaw(props.data?.mdc?.components || {}),
   ...props.components,
-}
+}))
 
 const key = computed(() => {
   if (!import.meta.dev) {
     return undefined
   }
-  const res = Array.from(new Set(body.value ? loadComponents(body.value, { tags }) : []))
+  const res = Array.from(new Set(body.value ? loadComponents(body.value, { tags: tags.value }) : []))
     .filter(t => localComponents.includes(pascalCase(String(t))))
     .sort()
     .join('.')
@@ -120,7 +120,7 @@ const key = computed(() => {
 })
 
 const componentsMap = computed(() => {
-  return body.value ? resolveContentComponents(body.value, { tags }) : {}
+  return body.value ? resolveContentComponents(body.value, { tags: tags.value }) : {}
 })
 
 function resolveVueComponent(component: string | Renderable) {

--- a/src/runtime/components/ContentRenderer.vue
+++ b/src/runtime/components/ContentRenderer.vue
@@ -107,18 +107,6 @@ const tags = computed(() => ({
   ...props.components,
 }))
 
-const key = computed(() => {
-  if (!import.meta.dev) {
-    return undefined
-  }
-  const res = Array.from(new Set(body.value ? loadComponents(body.value, { tags: tags.value }) : []))
-    .filter(t => localComponents.includes(pascalCase(String(t))))
-    .sort()
-    .join('.')
-
-  return res
-})
-
 const componentsMap = computed(() => {
   return body.value ? resolveContentComponents(body.value, { tags: tags.value }) : {}
 })
@@ -214,7 +202,6 @@ function findMappedTag(node: MDCElement, tags: Record<string, string>) {
 <template>
   <MDCRenderer
     v-if="!isEmpty"
-    :key="key"
     :body="body"
     :data="data"
     :class="props.class"


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

at the moment when the body passed to `<ContentRenderer>` changes, the new components that are required aren't loaded/processed.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
