### PR TITLE
docs: add clarification about schema definitions in frontmatter blocks

### DIFF
--- a/docs/content/docs/3.files/1.markdown.md
+++ b/docs/content/docs/3.files/1.markdown.md
@@ -125,6 +125,10 @@ console.log(home.body)
 | `description` | `string`  | First `<p>` of the page  | Description of the page, will be shown below the title and injected into the metas                                     |
 | `navigation`  | `boolean` | `true`                   | Define if the page is included in [`queryCollectionNavigation`](/docs/utils/query-collection-navigation) return value. |
 
+::warning
+Additional parameters that you have defined in your frontmatter block need to be defined in your schema (see the date parameter in the example at top of this page) to be able to use them for querying.
+::
+
 ## MDC Syntax
 
 We created the MDC syntax to supercharge Markdown and give you the ability to integrate Vue components with slots and props inside your Markdown.


### PR DESCRIPTION
I just spend time debugging this until I realized I need to add a schema for my collection first. I think the warning I added makes this immediately apparent. 