### PR TITLE
docs: return CollectionQueryGroup instead of void from andWhere and orWhere

### DIFF
--- a/docs/content/docs/4.utils/1.query-collection.md
+++ b/docs/content/docs/4.utils/1.query-collection.md
@@ -118,10 +118,7 @@ Add an AND condition group to the query. This allows for more complex query cond
 const { data } = await useAsyncData('recent-docs', () => {
   return queryCollection('docs')
     .where('published', '=', true)
-    .andWhere(query => {
-      query.where('date', '>', '2024-01-01')
-          .where('category', '=', 'news')
-    })
+    .andWhere(query => query.where('date', '>', '2024-01-01').where('category', '=', 'news'))
     .all()
 })
 ```
@@ -137,10 +134,7 @@ Add an OR condition group to the query. This allows for alternative conditions.
 const { data } = await useAsyncData('featured-docs', () => {
   return queryCollection('docs')
     .where('published', '=', true)
-    .orWhere(query => {
-      query.where('featured', '=', true)
-          .where('priority', '>', 5)
-    })
+    .orWhere(query => query.where('featured', '=', true).where('priority', '>', 5))
     .all()
 })
 ```


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Migrating nuxt content v2 from to v3 on my blog project, I used new fetching methods andWhere and orWhere. Then I found out sample codes about them threw a type error. So I made andWhere and orWhere return CollectionQueryGroup instead of void.

I followed the sample codes in my blog project and got the error below.

```shell
src/pages/posts/[...slug].vue:40:17 - error TS2345: Argument of type '(query: CollectionQueryGroup<PostsCollectionItem>) => void' is not assignable to parameter of type 'QueryGroupFunction<PostsCollectionItem>'.
  Type 'void' is not assignable to type 'CollectionQueryGroup<PostsCollectionItem>'.

40       .andWhere((query) => { query.where('draft', 'IS NULL').where('secret', 'IS NULL') })
                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
