### PR TITLE
docs: leave note about changes in module options

### DIFF
--- a/docs/content/docs/1.getting-started/4.migration.md
+++ b/docs/content/docs/1.getting-started/4.migration.md
@@ -23,7 +23,6 @@ The new API is backed by SQL and content queries happens within a specific colle
 - `useContent()` composable is removed
 - `searchContent()` is dropped in favor of the new `queryCollectionSearchSections` API
 - Full text search can easily be done using the `queryCollectionSearchSections` API, [check this section to see how](/docs/advanced/fulltext-search)
-- Module configuration has changed from v2. Check out [configuration page](/docs/getting-started/configuration) for details.
 
 ### Components
 
@@ -48,6 +47,7 @@ The new API is backed by SQL and content queries happens within a specific colle
 - `useContentHelpers()` is removed
 - Module does not ignore dot files by default, you can ignore them by adding `ignore: ['**/.*']` in `exclude` options of your collection source.
 - Due to SQL limitations, sort order now uses alphabetical order instead for numerical order. Check out the [Ordering Files](/docs/collections/types#ordering-files) section for more information.
+- Module configuration has changed from v2. Check out [configuration page](/docs/getting-started/configuration) for details.
 
 ### Nuxt Studio integration
 

--- a/docs/content/docs/1.getting-started/4.migration.md
+++ b/docs/content/docs/1.getting-started/4.migration.md
@@ -47,7 +47,7 @@ The new API is backed by SQL and content queries happens within a specific colle
 - `useContentHelpers()` is removed
 - Module does not ignore dot files by default, you can ignore them by adding `ignore: ['**/.*']` in `exclude` options of your collection source.
 - Due to SQL limitations, sort order now uses alphabetical order instead for numerical order. Check out the [Ordering Files](/docs/collections/types#ordering-files) section for more information.
-- Module configuration has changed from v2. Check out [configuration page](/docs/getting-started/configuration) for details.
+- Module options have changed from v2. Check out [configuration page](/docs/getting-started/configuration) for details.
 
 ### Nuxt Studio integration
 

--- a/docs/content/docs/1.getting-started/4.migration.md
+++ b/docs/content/docs/1.getting-started/4.migration.md
@@ -23,6 +23,7 @@ The new API is backed by SQL and content queries happens within a specific colle
 - `useContent()` composable is removed
 - `searchContent()` is dropped in favor of the new `queryCollectionSearchSections` API
 - Full text search can easily be done using the `queryCollectionSearchSections` API, [check this section to see how](/docs/advanced/fulltext-search)
+- Module configuration has changed from v2. Check out [configuration page](/docs/getting-started/configuration) for details.
 
 ### Components
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When I migrated nuxt content within my blog project from v2 to v3, I found type for module options changed. It would be nice if the migration guide says module options has changed and tells developers to take a look at the configuration page.  

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
