### PR TITLE
fix: update route rules to include robots directive for SQL dumps

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -188,13 +188,14 @@ export default defineNuxtModule<ModuleOptions>({
 
     // Prerender database.sql routes for each collection to fetch dump
     nuxt.options.routeRules ||= {}
+
+    // @ts-expect-error - Prevent nuxtseo from indexing nuxt-content routes
+    // @see https://github.com/nuxt/content/pull/3299
+    nuxt.options.routeRules![`/__nuxt_content/**`] = { robots: false }
+
     manifest.collections.forEach((collection) => {
       if (!collection.private) {
-        nuxt.options.routeRules![`/__nuxt_content/${collection.name}/sql_dump`] = {
-          prerender: true,
-          // @ts-expect-error - Only used in @nuxtjs/sitemap
-          robots: false,
-        }
+        nuxt.options.routeRules![`/__nuxt_content/${collection.name}/sql_dump`] = { prerender: true }
       }
     })
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -190,7 +190,7 @@ export default defineNuxtModule<ModuleOptions>({
     nuxt.options.routeRules ||= {}
     manifest.collections.forEach((collection) => {
       if (!collection.private) {
-        nuxt.options.routeRules![`/__nuxt_content/${collection.name}/sql_dump`] = { prerender: true }
+        nuxt.options.routeRules![`/__nuxt_content/${collection.name}/sql_dump`] = { prerender: true, robots: false }
       }
     })
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -190,7 +190,11 @@ export default defineNuxtModule<ModuleOptions>({
     nuxt.options.routeRules ||= {}
     manifest.collections.forEach((collection) => {
       if (!collection.private) {
-        nuxt.options.routeRules![`/__nuxt_content/${collection.name}/sql_dump`] = { prerender: true, robots: false }
+        nuxt.options.routeRules![`/__nuxt_content/${collection.name}/sql_dump`] = {
+          prerender: true,
+          // @ts-expect-error - Only used in @nuxtjs/sitemap
+          robots: false,
+        }
       }
     })
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

resolves #3298

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR add `robots: false` to SQL dump route rules to prevent nuxt sitemap from including it.

Note: This PR won't remove your existing dump from google index, but prevent new from beeing indexed. If you need your dump to be removed from Google index, you need to perform a manual request here: https://search.google.com/search-console/removals

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
