### PR TITLE
fix: explicitly set the dump's content type

### DIFF
--- a/src/runtime/presets/cloudflare-pages/database-handler.ts
+++ b/src/runtime/presets/cloudflare-pages/database-handler.ts
@@ -1,8 +1,9 @@
-import { eventHandler, getRouterParam } from 'h3'
+import { eventHandler, getRouterParam, setHeader } from 'h3'
 import { useStorage } from 'nitropack/runtime'
 
 export default eventHandler(async (event) => {
   const collection = getRouterParam(event, 'collection')!
+  setHeader(event, 'Content-Type', 'text/plain')
 
   const ASSETS = event?.context?.cloudflare?.env.ASSETS || process.env.ASSETS
   if (ASSETS) {

--- a/src/runtime/presets/node/database-handler.ts
+++ b/src/runtime/presets/node/database-handler.ts
@@ -1,8 +1,9 @@
-import { eventHandler, getRouterParam } from 'h3'
+import { eventHandler, getRouterParam, setHeader } from 'h3'
 import { useStorage } from 'nitropack/runtime'
 
 export default eventHandler(async (event) => {
   const collection = getRouterParam(event, 'collection')!
+  setHeader(event, 'Content-Type', 'text/plain')
 
   const data = await useStorage().getItem(`build:content:database.compressed.mjs`) || ''
   if (data) {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue
resolves #3291

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Explicitly set the content type of SQL dump, this will help modules like html-validator to have a better understanding of API response and not treat it as HTML or something else

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
