### PR TITLE
fix(collection): avoid double update of some record by using the hash column as index

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -32,17 +32,11 @@ import { findPreset } from './presets'
 import type { Manifest } from './types/manifest'
 import { setupPreview, shouldEnablePreview } from './utils/preview/module'
 import { parseSourceBase } from './utils/source'
-import { getLocalDatabase, refineDatabaseConfig, resolveDatabaseAdapter } from './utils/database'
+import { databaseVersion, getLocalDatabase, refineDatabaseConfig, resolveDatabaseAdapter } from './utils/database'
 
 // Export public utils
 export * from './utils'
 export type * from './types'
-
-/**
- * Database version is used to identify schema changes
- * and drop the info table when the version is not supported
- */
-const databaseVersion = 'v3.3.0'
 
 export default defineNuxtModule<ModuleOptions>({
   meta: {
@@ -307,7 +301,7 @@ async function processCollectionItems(nuxt: Nuxt, collections: ResolvedCollectio
             let parsedContent
             if (cache && cache.checksum === checksum) {
               cachedFilesCount += 1
-              parsedContent = JSON.parse(cache.parsedContent)
+              parsedContent = JSON.parse(cache.value)
             }
             else {
               parsedFilesCount += 1
@@ -317,7 +311,7 @@ async function processCollectionItems(nuxt: Nuxt, collections: ResolvedCollectio
                 path: fullPath,
               })
               if (parsedContent) {
-                db.insertDevelopmentCache(keyInCollection, checksum, JSON.stringify(parsedContent))
+                db.insertDevelopmentCache(keyInCollection, JSON.stringify(parsedContent), checksum)
               }
             }
 

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -1,6 +1,6 @@
 import type { Primitive, Connector } from 'db0'
 
-export type CacheEntry = { id: string, checksum: string, parsedContent: string }
+export type CacheEntry = { id: string, value: string, checksum: string }
 
 export type DatabaseBindParams = Primitive[]
 

--- a/src/utils/collection.ts
+++ b/src/utils/collection.ts
@@ -190,7 +190,11 @@ export function generateCollectionInsert(collection: ResolvedCollection, data: P
     }
   })
 
+  console.log('values', values)
+
   const valuesHash = hash(values)
+
+  console.log('valuesHash', valuesHash)
 
   const hashColumn = opts.hashColumn !== false
 
@@ -198,7 +202,7 @@ export function generateCollectionInsert(collection: ResolvedCollection, data: P
 
   let index = 0
   const sql = `INSERT INTO ${collection.tableName} VALUES (${'?, '.repeat(valuesWithHash.length).slice(0, -2)});`
-    .replace(/\?/g, () => values[index++] as string)
+    .replace(/\?/g, () => valuesWithHash[index++] as string)
 
   if (sql.length < MAX_SQL_QUERY_SIZE) {
     return {

--- a/src/utils/collection.ts
+++ b/src/utils/collection.ts
@@ -224,15 +224,15 @@ export function generateCollectionInsert(collection: ResolvedCollection, data: P
       `INSERT INTO ${collection.tableName} VALUES (${'?, '.repeat(bigValueSliceWithHash.length).slice(0, -2)});`.replace(/\?/g, () => bigValueSliceWithHash[index++] as string),
     ]
     while (sliceIndex < biggestColumn.length) {
-      const isLastSlice = sliceIndex + SLICE_SIZE < biggestColumn.length
-      const newSlice = `'${biggestColumn.slice(sliceIndex, sliceIndex + SLICE_SIZE)}` + (isLastSlice ? '\'' : '')
-      const sliceHash = isLastSlice ? valuesHash : `${valuesHash}-${sliceIndex}`
+      const isLastSlice = sliceIndex + SLICE_SIZE > biggestColumn.length
+      const newSlice = `'${biggestColumn.slice(sliceIndex, sliceIndex + SLICE_SIZE)}` + (!isLastSlice ? '\'' : '')
+      const sliceHash = isLastSlice ? valuesHash : `${valuesHash}-${sliceIndex + SLICE_SIZE}`
       const setValues = `SET ${bigColumnName} = CONCAT(${bigColumnName}, ${newSlice})${hashColumn ? `, SET __hash__ = '${sliceHash}'` : ''}`
       const whereCondition = `id = ${values[0]}${hashColumn ? ` AND __hash__ = '${valuesHash}-${prevSliceIndex}'` : ''};`
       SQLQueries.push(
         `UPDATE ${collection.tableName} ${setValues} WHERE ${whereCondition}`,
       )
-      prevSliceIndex = sliceIndex
+      prevSliceIndex = sliceIndex + SLICE_SIZE
       sliceIndex += SLICE_SIZE
     }
     return { queries: SQLQueries, hash: valuesHash }

--- a/src/utils/collection.ts
+++ b/src/utils/collection.ts
@@ -190,11 +190,7 @@ export function generateCollectionInsert(collection: ResolvedCollection, data: P
     }
   })
 
-  console.log('values', values)
-
   const valuesHash = hash(values)
-
-  console.log('valuesHash', valuesHash)
 
   const hashColumn = opts.hashColumn !== false
 

--- a/src/utils/dev.ts
+++ b/src/utils/dev.ts
@@ -136,7 +136,7 @@ export async function watchContents(nuxt: Nuxt, options: ModuleOptions, manifest
       const checksum = getContentChecksum(content)
       const localCache = await db.fetchDevelopmentCacheForKey(keyInCollection)
 
-      let parsedContent = localCache?.parsedContent || ''
+      let parsedContent = localCache?.value || ''
 
       // If the local cache is not present or the checksum does not match, we need to parse the content
       if (!localCache || localCache?.checksum !== checksum) {

--- a/test/unit/generateCollectionInsert.test.ts
+++ b/test/unit/generateCollectionInsert.test.ts
@@ -83,8 +83,10 @@ describe('generateCollectionInsert', () => {
     })
 
     const querySlices: string[] = [content.slice(0, SLICE_SIZE - 1)]
+    const sliceIndexes = [SLICE_SIZE]
     for (let i = 1; i < (content.length / SLICE_SIZE); i++) {
       querySlices.push(content.slice((SLICE_SIZE * i) - 1, (SLICE_SIZE * (i + 1)) - 1))
+      sliceIndexes.push(SLICE_SIZE * (i + 1))
     }
 
     // check that the content will be split into multiple queries
@@ -93,18 +95,26 @@ describe('generateCollectionInsert', () => {
     // check that concatenated all the values are equal to the original content
     expect(content).toEqual(querySlices.join(''))
 
+    const hash = 'QMyFxMru9gVfaNx0fzjs5is7SvAZMEy3tNDANjkdogg'
+
     expect(sql[0]).toBe([
       `INSERT INTO ${getTableName('content')}`,
       ' VALUES',
-      ` ('foo.md', '${querySlices[0]}', 'md', '{}', 'foo', 'QMyFxMru9gVfaNx0fzjs5is7SvAZMEy3tNDANjkdogg');`,
+      ` ('foo.md', '${querySlices[0]}', 'md', '{}', 'foo', '${hash}-${sliceIndexes[0]}');`,
     ].join(''))
     let index = 1
-    while (index < sql.length - 1) {
+
+    while (index < sql.length) {
+      // last statement should update the hash column to the hash itself
+      const nextHash = index === sql.length - 1 ? hash : `${hash}-${sliceIndexes[index]}`
       expect(sql[index]).toBe([
         `UPDATE ${getTableName('content')}`,
         ' SET',
         ` content = CONCAT(content, '${querySlices[index]}')`,
-        ' WHERE id = \'foo.md\';',
+        ', SET ',
+        `__hash__ = '${nextHash}'`,
+        ' WHERE id = \'foo.md\'',
+        ` AND __hash__ = '${hash}-${sliceIndexes[index - 1]}';`,
       ].join(''))
       index++
     }

--- a/test/unit/generateCollectionInsert.test.ts
+++ b/test/unit/generateCollectionInsert.test.ts
@@ -111,10 +111,9 @@ describe('generateCollectionInsert', () => {
         `UPDATE ${getTableName('content')}`,
         ' SET',
         ` content = CONCAT(content, '${querySlices[index]}')`,
-        ', SET ',
-        `__hash__ = '${nextHash}'`,
+        `, "__hash__" = '${nextHash}'`,
         ' WHERE id = \'foo.md\'',
-        ` AND __hash__ = '${hash}-${sliceIndexes[index - 1]}';`,
+        ` AND "__hash__" = '${hash}-${sliceIndexes[index - 1]}';`,
       ].join(''))
       index++
     }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When two users on diferent parts of the world open the same un-deployed nuxt content powered website, they both trigger the deployment at the same time. Since it can take a moment for data to be synchronized, both can still be running the data at the same time, including the concatenation updates.

To avoid duplicating and therefore corrupting the data, I had the idea to use a temporary hash when inserting incomplete data:

example with the hash of the record being `123456798` and the column name `content`

```
INSERT INTO _col_collection VALUES ('52', '[values-slice-1...]', '123456798-50000')
UPDATE _col_collection SET content = CONCAT(content, '[values-slice-2]'), __hash__ = '123456798-100000' WHERE id = 52 AND __hash__ =  '123456798-50000'
UPDATE _col_collection SET content = CONCAT(content, '[values-slice-3]'), __hash__ = '123456798' WHERE id = 52 AND __hash__ =  '123456798-100000'
```

With this we prevent most corruption of data through multiple updates. 
We still need a way to "repair" a system that has stopped deploying mid deployment. 
But this should improve deployment stability slightly.


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
