### PR TITLE
fix(module): invalid rootDir of layer sources

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -278,7 +278,9 @@ async function processCollectionItems(nuxt: Nuxt, collections: ResolvedCollectio
 
     for await (const source of collection.source) {
       if (source.prepare) {
-        await source.prepare({ rootDir: nuxt.options.rootDir })
+        // @ts-expect-error - `__rootDir` is a private property to store the layer's cwd
+        const rootDir = collection.__rootDir || nuxt.options.rootDir
+        await source.prepare({ rootDir })
       }
 
       const { fixed } = parseSourceBase(source)

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -25,12 +25,11 @@ describe('basic', async () => {
     rootDir: fileURLToPath(new URL('./fixtures/basic', import.meta.url)),
     dev: true,
   })
-  console.log('setup')
 
   describe('`content.config.ts`', async () => {
     test('Default collection is defined', async () => {
       const rootDir = fileURLToPath(new URL('./fixtures/basic', import.meta.url))
-      const config = await loadContentConfig({ options: { _layers: [{ config: { rootDir } }] } } as Nuxt, { defaultFallback: true })
+      const config = await loadContentConfig({ options: { _layers: [{ config: { rootDir } }] } } as Nuxt)
 
       // Pages collection + info collection
       expect(config.collections.length).toBe(2)

--- a/test/empty.test.ts
+++ b/test/empty.test.ts
@@ -35,7 +35,7 @@ describe('empty', async () => {
     })
     test('Default collection is defined', async () => {
       const rootDir = fileURLToPath(new URL('./fixtures/empty', import.meta.url))
-      const config = await loadContentConfig({ options: { _layers: [{ config: { rootDir } }] } } as Nuxt, { defaultFallback: true })
+      const config = await loadContentConfig({ options: { _layers: [{ config: { rootDir } }] } } as Nuxt)
 
       // Pages collection + info collection
       expect(config.collections.length).toBe(2)


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue
resolves #3307
 
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When collections are defined in different layers, we should pass `rootDir` of that layer as collection rootDir.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
