### PR TITLE
feat: aws amplify preset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ dist
 .vercel_build_output
 .build-*
 .netlify
+.amplify-hosting
 
 # Env
 .env

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5258,6 +5258,7 @@ packages:
 
   libsql@0.4.7:
     resolution: {integrity: sha512-T9eIRCs6b0J1SHKYIvD8+KCJMcWZ900iZyxdnSCdqxN12Z1ijzT+jY5nrk72Jw4B0HGzms2NgpryArlJqvc3Lw==}
+    cpu: [x64, arm64, wasm32]
     os: [darwin, linux, win32]
 
   lighthouse-logger@2.0.1:

--- a/src/module.ts
+++ b/src/module.ts
@@ -138,6 +138,19 @@ export default defineNuxtModule<ModuleOptions>({
       }
     }
 
+    // Prerender database.sql routes for each collection to fetch dump
+    nuxt.options.routeRules ||= {}
+
+    // @ts-expect-error - Prevent nuxtseo from indexing nuxt-content routes
+    // @see https://github.com/nuxt/content/pull/3299
+    nuxt.options.routeRules![`/__nuxt_content/**`] = { robots: false }
+
+    manifest.collections.forEach((collection) => {
+      if (!collection.private) {
+        nuxt.options.routeRules![`/__nuxt_content/${collection.name}/sql_dump`] = { prerender: true }
+      }
+    })
+
     const preset = findPreset(nuxt)
     await preset?.setup?.(options, nuxt)
 
@@ -162,7 +175,7 @@ export default defineNuxtModule<ModuleOptions>({
       const preset = findPreset(nuxt)
       await preset.setupNitro(config, { manifest, resolver, moduleOptions: options })
 
-      const resolveOptions = { resolver, nativeSqlite: options.experimental?.nativeSqlite }
+      const resolveOptions = { resolver, sqliteConnector: options.experimental?.sqliteConnector || (options.experimental?.nativeSqlite ? 'native' : undefined) }
       config.alias ||= {}
       config.alias['#content/adapter'] = resolveDatabaseAdapter(config.runtimeConfig!.content!.database?.type || options.database.type, resolveOptions)
       config.alias['#content/local-adapter'] = resolveDatabaseAdapter(options._localDatabase!.type || 'sqlite', resolveOptions)
@@ -179,19 +192,6 @@ export default defineNuxtModule<ModuleOptions>({
         await watchComponents(nuxt)
         const socket = await startSocketServer(nuxt, options, manifest)
         await watchContents(nuxt, options, manifest, socket)
-      }
-    })
-
-    // Prerender database.sql routes for each collection to fetch dump
-    nuxt.options.routeRules ||= {}
-
-    // @ts-expect-error - Prevent nuxtseo from indexing nuxt-content routes
-    // @see https://github.com/nuxt/content/pull/3299
-    nuxt.options.routeRules![`/__nuxt_content/**`] = { robots: false }
-
-    manifest.collections.forEach((collection) => {
-      if (!collection.private) {
-        nuxt.options.routeRules![`/__nuxt_content/${collection.name}/sql_dump`] = { prerender: true }
       }
     })
 
@@ -236,7 +236,9 @@ async function processCollectionItems(nuxt: Nuxt, collections: ResolvedCollectio
   const collectionDump: Record<string, string[]> = {}
   const collectionChecksum: Record<string, string> = {}
   const collectionChecksumStructure: Record<string, string> = {}
-  const db = await getLocalDatabase(options._localDatabase, { nativeSqlite: options.experimental?.nativeSqlite })
+  const db = await getLocalDatabase(options._localDatabase, {
+    sqliteConnector: options.experimental?.sqliteConnector || (options.experimental?.nativeSqlite ? 'native' : undefined),
+  })
   const databaseContents = await db.fetchDevelopmentCache()
 
   const configHash = hash({

--- a/src/presets/aws-amplify.ts
+++ b/src/presets/aws-amplify.ts
@@ -1,0 +1,37 @@
+import { definePreset } from '../utils/preset'
+import { logger } from '../utils/dev'
+import nodePreset from './node'
+
+export default definePreset({
+  name: 'aws-amplify',
+  parent: nodePreset,
+  async setup(options, nuxt) {
+    options.database ||= { type: 'sqlite', filename: '/tmp/contents.sqlite' }
+
+    // Fetching assets on server side is not working with AWS Amplify
+    // Disable prerendering to avoid fetching assets on server side
+    Object.keys(nuxt.options.routeRules || {}).forEach((route) => {
+      if (route.startsWith('/__nuxt_content/') && route.endsWith('/sql_dump')) {
+        nuxt.options.routeRules![route].prerender = false
+      }
+    })
+
+    try {
+      await import('sqlite3')
+
+      options.experimental ||= {}
+      options.experimental.sqliteConnector = 'sqlite3'
+    }
+    catch {
+      logger.error('Nuxt Content requires `sqlite3` module to work in AWS Amplify environment. Please run `npm install sqlite3` to install it and try again.')
+      process.exit(1)
+    }
+  },
+  async setupNitro(nitroConfig) {
+    const database = nitroConfig.runtimeConfig?.content?.database
+    if (database?.type === 'sqlite' && !database?.filename?.startsWith('/tmp')) {
+      logger.warn('Deploying sqlite database to AWS Amplify is possible only in `/tmp` directory. Using `/tmp/contents.sqlite` instead.')
+      database.filename = '/tmp/contents.sqlite'
+    }
+  },
+})

--- a/src/presets/index.ts
+++ b/src/presets/index.ts
@@ -5,6 +5,7 @@ import vercel from './vercel'
 import node from './node'
 import nuxthub from './nuxthub'
 import netlify from './netlify'
+import awsAmplify from './aws-amplify'
 
 export function findPreset(nuxt: Nuxt) {
   const preset = nuxt.options.nitro.preset?.replace(/_/g, '-')
@@ -23,6 +24,10 @@ export function findPreset(nuxt: Nuxt) {
 
   if (preset === 'vercel' || process.env.VERCEL === '1') {
     return vercel
+  }
+
+  if (preset === 'aws-amplify' || typeof process.env.AWS_AMPLIFY_DEPLOYMENT_ID !== 'undefined') {
+    return awsAmplify
   }
 
   return node

--- a/src/presets/netlify.ts
+++ b/src/presets/netlify.ts
@@ -4,16 +4,15 @@ import nodePreset from './node'
 
 export default definePreset({
   name: 'netlify',
+  parent: nodePreset,
   async setup(options) {
     options.database ||= { type: 'sqlite', filename: '/tmp/contents.sqlite' }
   },
-  async setupNitro(nitroConfig, options) {
+  async setupNitro(nitroConfig) {
     const database = nitroConfig.runtimeConfig?.content?.database
     if (database?.type === 'sqlite' && !database?.filename?.startsWith('/tmp')) {
       logger.warn('Deploying sqlite database to Netlify is possible only in `/tmp` directory. Using `/tmp/contents.sqlite` instead.')
       database.filename = '/tmp/contents.sqlite'
     }
-
-    await nodePreset.setupNitro(nitroConfig, options)
   },
 })

--- a/src/presets/vercel.ts
+++ b/src/presets/vercel.ts
@@ -4,16 +4,15 @@ import nodePreset from './node'
 
 export default definePreset({
   name: 'vercel',
+  parent: nodePreset,
   async setup(options) {
     options.database ||= { type: 'sqlite', filename: '/tmp/contents.sqlite' }
   },
-  async setupNitro(nitroConfig, options) {
+  async setupNitro(nitroConfig) {
     const database = nitroConfig.runtimeConfig?.content?.database
     if (database?.type === 'sqlite' && !database?.filename?.startsWith('/tmp')) {
       logger.warn('Deploying sqlite database to Vercel is possible only in `/tmp` directory. Using `/tmp/contents.sqlite` instead.')
       database.filename = '/tmp/contents.sqlite'
     }
-
-    await nodePreset.setupNitro(nitroConfig, options)
   },
 })

--- a/src/types/module.ts
+++ b/src/types/module.ts
@@ -186,8 +186,16 @@ export interface ModuleOptions {
      * Node.js SQLite introduced in v22.5.0
      *
      * @default false
+     * @deprecated Use `sqliteConnector: 'native'` instead
      */
     nativeSqlite?: boolean
+
+    /**
+     * Use given SQLite connector instead of `better-sqlite3` if available
+     *
+     * @default undefined
+     */
+    sqliteConnector?: SQLiteConnector
   }
 }
 
@@ -207,3 +215,5 @@ export interface PublicRuntimeConfig {
     iframeMessagingAllowedOrigins?: string
   }
 }
+
+export type SQLiteConnector = 'native' | 'sqlite3' | 'better-sqlite3'

--- a/src/utils/database.ts
+++ b/src/utils/database.ts
@@ -6,7 +6,7 @@ import { isAbsolute, join, dirname } from 'pathe'
 import { isWebContainer } from '@webcontainer/env'
 import { z } from 'zod'
 import type { CacheEntry, D1DatabaseConfig, LocalDevelopmentDatabase, ResolvedCollection, SqliteDatabaseConfig } from '../types'
-import type { ModuleOptions } from '../types/module'
+import type { ModuleOptions, SQLiteConnector } from '../types/module'
 import { logger } from './dev'
 import { generateCollectionInsert, generateCollectionTableDefinition } from './collection'
 
@@ -36,9 +36,9 @@ export async function refineDatabaseConfig(database: ModuleOptions['database'], 
   }
 }
 
-export function resolveDatabaseAdapter(adapter: 'sqlite' | 'bunsqlite' | 'postgres' | 'libsql' | 'd1' | 'nodesqlite', opts: { resolver: Resolver, nativeSqlite?: boolean }) {
+export function resolveDatabaseAdapter(adapter: 'sqlite' | 'bunsqlite' | 'postgres' | 'libsql' | 'd1' | 'nodesqlite', opts: { resolver: Resolver, sqliteConnector?: SQLiteConnector }) {
   const databaseConnectors = {
-    sqlite: findBestSqliteAdapter({ nativeSqlite: opts.nativeSqlite }),
+    sqlite: findBestSqliteAdapter({ sqliteConnector: opts.sqliteConnector }),
     nodesqlite: 'db0/connectors/node-sqlite',
     bunsqlite: opts.resolver.resolve('./runtime/internal/connectors/bunsqlite'),
     postgres: 'db0/connectors/postgresql',
@@ -54,7 +54,7 @@ export function resolveDatabaseAdapter(adapter: 'sqlite' | 'bunsqlite' | 'postgr
   return databaseConnectors[adapter]
 }
 
-async function getDatabase(database: SqliteDatabaseConfig | D1DatabaseConfig, opts: { nativeSqlite?: boolean }): Promise<Connector> {
+async function getDatabase(database: SqliteDatabaseConfig | D1DatabaseConfig, opts: { sqliteConnector?: SQLiteConnector }): Promise<Connector> {
   if (database.type === 'd1') {
     return cloudflareD1Connector({ bindingName: database.bindingName })
   }
@@ -67,9 +67,9 @@ async function getDatabase(database: SqliteDatabaseConfig | D1DatabaseConfig, op
 }
 
 const _localDatabase: Record<string, Connector> = {}
-export async function getLocalDatabase(database: SqliteDatabaseConfig | D1DatabaseConfig, { connector, nativeSqlite }: { connector?: Connector, nativeSqlite?: boolean } = {}): Promise<LocalDevelopmentDatabase> {
+export async function getLocalDatabase(database: SqliteDatabaseConfig | D1DatabaseConfig, { connector, sqliteConnector }: { connector?: Connector, nativeSqlite?: boolean, sqliteConnector?: SQLiteConnector } = {}): Promise<LocalDevelopmentDatabase> {
   const databaseLocation = database.type === 'sqlite' ? database.filename : database.bindingName
-  const db = _localDatabase[databaseLocation] || connector || await getDatabase(database, { nativeSqlite })
+  const db = _localDatabase[databaseLocation] || connector || await getDatabase(database, { sqliteConnector })
 
   const cacheCollection = {
     tableName: '_development_cache',
@@ -153,17 +153,34 @@ export async function getLocalDatabase(database: SqliteDatabaseConfig | D1Databa
   }
 }
 
-function findBestSqliteAdapter(opts: { nativeSqlite?: boolean }) {
+function findBestSqliteAdapter(opts: { sqliteConnector?: SQLiteConnector }) {
   if (process.versions.bun) {
     return 'db0/connectors/bun-sqlite'
   }
 
   // if node:sqlite is available, use it
-  if (opts.nativeSqlite && isNodeSqliteAvailable()) {
+  if (opts.sqliteConnector === 'native' && isNodeSqliteAvailable()) {
     return 'db0/connectors/node-sqlite'
   }
 
-  return isSqlite3Available() ? 'db0/connectors/sqlite3' : 'db0/connectors/better-sqlite3'
+  if (opts.sqliteConnector === 'sqlite3' && isSqlite3PackageInstalled()) {
+    return 'db0/connectors/sqlite3'
+  }
+
+  if (opts.sqliteConnector === 'better-sqlite3') {
+    return 'db0/connectors/better-sqlite3'
+  }
+
+  if (isWebContainer()) {
+    if (!isSqlite3PackageInstalled()) {
+      logger.error('Nuxt Content requires `sqlite3` module to work in WebContainer environment. Please run `npm install sqlite3` to install it and try again.')
+      process.exit(1)
+    }
+
+    return 'db0/connectors/sqlite3'
+  }
+
+  return 'db0/connectors/better-sqlite3'
 }
 
 function isNodeSqliteAvailable() {
@@ -200,18 +217,12 @@ function isNodeSqliteAvailable() {
   }
 }
 
-function isSqlite3Available() {
-  if (!isWebContainer()) {
-    return false
-  }
-
+function isSqlite3PackageInstalled() {
   try {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    require('sqlite3')
+    require.resolve('sqlite3')
     return true
   }
   catch {
-    logger.error('Nuxt Content requires `sqlite3` module to work in WebContainer environment. Please run `npm install sqlite3` to install it and try again.')
-    process.exit(1)
+    return false
   }
 }

--- a/src/utils/preset.ts
+++ b/src/utils/preset.ts
@@ -11,10 +11,26 @@ interface Options {
 }
 export interface Preset {
   name: string
-  setup?: (options: ModuleOptions, nuxt: Nuxt) => Promise<void>
+  parent?: Preset
+  setup?: (options: ModuleOptions, nuxt: Nuxt) => Promise<void> | void
   setupNitro: (nitroConfig: NitroConfig, opts: Options) => void | Promise<void>
 }
 
 export function definePreset(preset: Preset) {
-  return preset
+  const _preset: Preset = {
+    ...preset,
+    setup: async (options, nuxt) => {
+      if (preset.parent) {
+        await preset.parent.setup?.(options, nuxt)
+      }
+      await preset.setup?.(options, nuxt)
+    },
+    setupNitro: async (nitroConfig, opts) => {
+      if (preset.parent) {
+        await preset.parent.setupNitro?.(nitroConfig, opts)
+      }
+      await preset.setupNitro?.(nitroConfig, opts)
+    },
+  }
+  return _preset
 }

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -7,7 +7,7 @@ import { loadContentConfig } from '../src/utils/config'
 import { decompressSQLDump } from '../src/runtime/internal/dump'
 import { getTableName } from '../src/utils/collection'
 import { getLocalDatabase } from '../src/utils/database'
-import type { LocalDevelopmentDatabase } from '../dist/module'
+import type { LocalDevelopmentDatabase } from '../src/module'
 
 async function cleanup() {
   await fs.rm(fileURLToPath(new URL('./fixtures/basic/node_modules', import.meta.url)), { recursive: true, force: true })

--- a/test/empty.test.ts
+++ b/test/empty.test.ts
@@ -7,7 +7,7 @@ import { loadContentConfig } from '../src/utils/config'
 import { decompressSQLDump } from '../src/runtime/internal/dump'
 import { getTableName } from '../src/utils/collection'
 import { getLocalDatabase } from '../src/utils/database'
-import type { LocalDevelopmentDatabase } from '../dist/module'
+import type { LocalDevelopmentDatabase } from '../src/module'
 
 async function cleanup() {
   await fs.rm(fileURLToPath(new URL('./fixtures/empty/node_modules', import.meta.url)), { recursive: true, force: true })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue
resolves #3310

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Introduce AWS Amplify preset and new experimental `sqliteConnector` option to change SQLite connection package.
Due to Amplify OS limitation and default SQLite connector of Nuxt Content, Users need to install `sqlite3` package manually into their repo before building for Amplify. (`better-sqlite3` does not work in Amazon Linux)

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
