### PR TITLE
docs(examples): add key to dynamic asyncData

### DIFF
--- a/examples/blog/app/pages/[...slug].vue
+++ b/examples/blog/app/pages/[...slug].vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
 const route = useRoute()
-const { data: post } = await useAsyncData(() => {
+const { data: post } = await useAsyncData(computed(() => 'blog-' + route.path), () => {
   return queryCollection('blog')
     .path(route.path)
     .first()


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue


### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Async data keys should always uniquely identify a payload. Auto-keyed asyncData should be used in case of a unique payload. Data between dynamic routes are not considered as a unique payload since `queryCollection('blog').path(route.path).first()` returns a data depending on the current route.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
