### PR TITLE
chore: add `sql_dump` file extension

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -147,7 +147,7 @@ export default defineNuxtModule<ModuleOptions>({
 
     manifest.collections.forEach((collection) => {
       if (!collection.private) {
-        nuxt.options.routeRules![`/__nuxt_content/${collection.name}/sql_dump`] = { prerender: true }
+        nuxt.options.routeRules![`/__nuxt_content/${collection.name}/sql_dump.txt`] = { prerender: true }
       }
     })
 

--- a/src/presets/aws-amplify.ts
+++ b/src/presets/aws-amplify.ts
@@ -11,7 +11,7 @@ export default definePreset({
     // Fetching assets on server side is not working with AWS Amplify
     // Disable prerendering to avoid fetching assets on server side
     Object.keys(nuxt.options.routeRules || {}).forEach((route) => {
-      if (route.startsWith('/__nuxt_content/') && route.endsWith('/sql_dump')) {
+      if (route.startsWith('/__nuxt_content/') && route.endsWith('/sql_dump.txt')) {
         nuxt.options.routeRules![route].prerender = false
       }
     })

--- a/src/presets/cloudflare-pages.ts
+++ b/src/presets/cloudflare-pages.ts
@@ -26,7 +26,7 @@ export default definePreset({
     // Add raw content dump to public assets
     nitroConfig.publicAssets.push({ dir: join(nitroConfig.buildDir!, 'content', 'raw'), maxAge: 60 })
     nitroConfig.handlers.push({
-      route: '/__nuxt_content/:collection/sql_dump',
+      route: '/__nuxt_content/:collection/sql_dump.txt',
       handler: resolver.resolve('./runtime/presets/cloudflare-pages/database-handler'),
     })
   },

--- a/src/presets/node.ts
+++ b/src/presets/node.ts
@@ -11,7 +11,7 @@ export default definePreset({
 
     nitroConfig.alias['#content/dump'] = addTemplate(fullDatabaseCompressedDumpTemplate(manifest)).dst
     nitroConfig.handlers.push({
-      route: '/__nuxt_content/:collection/sql_dump',
+      route: '/__nuxt_content/:collection/sql_dump.txt',
       handler: resolver.resolve('./runtime/presets/node/database-handler'),
     })
   },

--- a/src/runtime/internal/api.ts
+++ b/src/runtime/internal/api.ts
@@ -2,7 +2,7 @@ import type { H3Event } from 'h3'
 import { checksums } from '#content/manifest'
 
 export async function fetchDatabase(event: H3Event | undefined, collection: string): Promise<string> {
-  return await $fetch(`/__nuxt_content/${collection}/sql_dump`, {
+  return await $fetch(`/__nuxt_content/${collection}/sql_dump.txt`, {
     context: event ? { cloudflare: event.context.cloudflare } : {},
     responseType: 'text',
     headers: { 'content-type': 'text/plain' },

--- a/src/utils/templates.ts
+++ b/src/utils/templates.ts
@@ -42,7 +42,7 @@ export const moduleTemplates = {
   manifest: 'content/manifest.ts',
   components: 'content/components.ts',
   fullCompressedDump: 'content/database.compressed.mjs',
-  fullRawDump: 'content/sql_dump',
+  fullRawDump: 'content/sql_dump.txt',
 }
 
 export const contentTypesTemplate = (collections: ResolvedCollection[]) => ({

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -83,7 +83,7 @@ describe('basic', async () => {
     })
 
     test('is downloadable', async () => {
-      const response: string = await $fetch('/__nuxt_content/content/sql_dump', { responseType: 'text' })
+      const response: string = await $fetch('/__nuxt_content/content/sql_dump.txt', { responseType: 'text' })
       expect(response).toBeDefined()
 
       const parsedDump = await decompressSQLDump(response as string)

--- a/test/empty.test.ts
+++ b/test/empty.test.ts
@@ -88,7 +88,7 @@ describe('empty', async () => {
     })
 
     test('is downloadable', async () => {
-      const response: string = await $fetch('/__nuxt_content/content/sql_dump', { responseType: 'text' })
+      const response: string = await $fetch('/__nuxt_content/content/sql_dump.txt', { responseType: 'text' })
       expect(response).toBeDefined()
 
       const parsedDump = await decompressSQLDump(response as string)


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

resolves https://github.com/nuxt/content/issues/3337

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Add `sql_dump` routes url file extension `.txt` (including tests). In version `3.5.0` was explicitly set dump's content type to `text/plain` (https://github.com/nuxt/content/pull/3302). It will be good practice to set the dump file extension to `.txt`.

It is known that files without extension in AWS Amplify does not work: https://github.com/aws-amplify/amplify-hosting/issues/225

When you manual deploy a Nuxt project to AWS Amplify, in local environment build the project with `nuxt generate`. The `sql_dump` file is pre-rendered without a file extension.

If `sql_dump` file is uploaded without extension to AWS Amplify, the environment will delete it, causing a 404 error, when `sql_dump` file is fetched.

Resolves #3337

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
