### PR TITLE
fix(websocket): client url for development with proxy

### DIFF
--- a/src/runtime/internal/websocket.ts
+++ b/src/runtime/internal/websocket.ts
@@ -79,7 +79,9 @@ export function useContentWebSocket() {
     }
 
     // WebSocket Base URL
-    const wsURL = `${(useRuntimeConfig().public.content as { wsUrl: string }).wsUrl}ws`
+    const wsURL = new URL(`${(useRuntimeConfig().public.content as { wsUrl: string }).wsUrl}ws`)
+    wsURL.protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
+    wsURL.hostname = window.location.hostname
 
     logger.log(`WS connect to ${wsURL}`)
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

https://github.com/nuxt/content/issues/3343

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Corrects the websocket client's connection URL so that it also works when a reverse proxy is used in development.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
