### PR TITLE
feat(parser): Allow extra transformers to provide components used

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -253,6 +253,11 @@ async function processCollectionItems(nuxt: Nuxt, collections: ResolvedCollectio
   let cachedFilesCount = 0
   let parsedFilesCount = 0
 
+  // Store components used in the content provided by
+  // custom parsers using the `__metadata.components` field.
+  // This will allow to correctly generate production imports
+  const usedComponents: Array<string> = []
+
   // Remove all existing content collections to start with a clean state
   db.dropContentTables()
   // Create database dump
@@ -319,6 +324,11 @@ async function processCollectionItems(nuxt: Nuxt, collections: ResolvedCollectio
               }
             }
 
+            // Add manually provided components from the content
+            if (parsedContent) {
+              usedComponents.push(...(parsedContent.meta?.__components || []))
+            }
+
             const { queries, hash } = generateCollectionInsert(collection, parsedContent)
             list.push([key, queries, hash])
           }
@@ -366,6 +376,7 @@ async function processCollectionItems(nuxt: Nuxt, collections: ResolvedCollectio
   const uniqueTags = [
     ...Object.values(options.renderer.alias || {}),
     ...new Set(tags),
+    ...new Set(usedComponents),
   ]
     .map(tag => getMappedTag(tag, options?.renderer?.alias))
     .filter(tag => !htmlTags.includes(kebabCase(tag)))


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [X] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
These changes allow a custom transformer to manually provide the component used in the parsed content.
This fixes production builds where component used by content imports would previously be missing.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
