### PR TITLE
docs: fix missing quote in collection sources glob pattern

### DIFF
--- a/docs/content/docs/2.collections/3.sources.md
+++ b/docs/content/docs/2.collections/3.sources.md
@@ -26,7 +26,7 @@ The `source` property can be defined as either a string (following a glob patter
 
 **Example:**
 
-- `source: '**` includes all files within the content directory and its subdirectories.
+- `source: '**'` includes all files within the content directory and its subdirectories.
 - `source: '**/*.md'`includes all `Markdown` files within the content directory and its subdirectories.
 - `source: 'docs/**/*.yml'` includes all `YML` files within the `content/docs` and its subdirectories.
 - `source: '**/*.{json,yml}'` includes `JSON` or `YML` file within the content directory and all its subdirectories.


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR fixes a small typo in the `sources` section of the documentation.
In the line:

- `source: '**` includes all files within the content directory and its subdirectories.

a closing quote was missing in the glob pattern example. It has been corrected to:

- `source: '**'` includes all files within the content directory and its subdirectories.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
