### PR TITLE
 Forward SSR Cookies in Nuxt Content Internal API Requests

### DIFF
--- a/src/runtime/internal/api.ts
+++ b/src/runtime/internal/api.ts
@@ -7,7 +7,7 @@ export async function fetchDatabase(event: H3Event | undefined, collection: stri
     responseType: 'text',
     headers: {
       'content-type': 'text/plain',
-      ...(event?.node?.req?.headers?.cookie ? { cookie: event.node.req.headers.cookie } : {})
+      ...(event?.node?.req?.headers?.cookie ? { cookie: event.node.req.headers.cookie } : {}),
     },
     query: { v: checksums[String(collection)], t: import.meta.dev ? Date.now() : undefined },
   })
@@ -18,7 +18,7 @@ export async function fetchQuery<Item>(event: H3Event | undefined, collection: s
     context: event ? { cloudflare: event.context.cloudflare } : {},
     headers: {
       'content-type': 'application/json',
-      ...(event?.node?.req?.headers?.cookie ? { cookie: event.node.req.headers.cookie } : {})
+      ...(event?.node?.req?.headers?.cookie ? { cookie: event.node.req.headers.cookie } : {}),
     },
     query: { v: checksums[String(collection)], t: import.meta.dev ? Date.now() : undefined },
     method: 'POST',

--- a/src/runtime/internal/api.ts
+++ b/src/runtime/internal/api.ts
@@ -5,7 +5,10 @@ export async function fetchDatabase(event: H3Event | undefined, collection: stri
   return await $fetch(`/__nuxt_content/${collection}/sql_dump.txt`, {
     context: event ? { cloudflare: event.context.cloudflare } : {},
     responseType: 'text',
-    headers: { 'content-type': 'text/plain' },
+    headers: {
+      'content-type': 'text/plain',
+      ...(event?.node?.req?.headers?.cookie ? { cookie: event.node.req.headers.cookie } : {})
+    },
     query: { v: checksums[String(collection)], t: import.meta.dev ? Date.now() : undefined },
   })
 }
@@ -13,7 +16,10 @@ export async function fetchDatabase(event: H3Event | undefined, collection: stri
 export async function fetchQuery<Item>(event: H3Event | undefined, collection: string, sql: string): Promise<Item[]> {
   return await $fetch(`/__nuxt_content/${collection}/query`, {
     context: event ? { cloudflare: event.context.cloudflare } : {},
-    headers: { 'content-type': 'application/json' },
+    headers: {
+      'content-type': 'application/json',
+      ...(event?.node?.req?.headers?.cookie ? { cookie: event.node.req.headers.cookie } : {})
+    },
     query: { v: checksums[String(collection)], t: import.meta.dev ? Date.now() : undefined },
     method: 'POST',
     body: {


### PR DESCRIPTION
### What this fixes

When Nuxt renders pages in SSR mode and loads content via `@nuxt/content`, it performs internal `$fetch()` calls to endpoints like:

```
/__nuxt_content/<collection>/query
```

These internal fetches previously **did not forward cookies** from the original SSR request. This broke any logic in server middleware that depends on cookie-based user authentication or authorization.

---

### Why this matters

This project uses server middleware to control access to specific content collections based on user authentication. For example:

```ts
if (url?.includes('/__nuxt_content/')) {
  const collection = getCollectionFromUrl(url)
  const user = await serverSupabaseUser(event)

  if (!userHasAccessToCollection(user, collection)) {
    throw createError({ statusCode: 403, statusMessage: 'Unauthorized' })
  }
}
```

Without the cookie being forwarded in internal SSR fetches, `serverSupabaseUser(event)` fails to detect the logged-in user, which causes middleware-based access checks to incorrectly deny access during SSR. Client-side navigation still works because the browser includes the cookie automatically.

---

### What this PR changes

The `fetchQuery()` and `fetchDatabase()` functions in Nuxt Content now forward the original SSR request's cookies by including them in `$fetch` calls:

```ts
headers: {
  'content-type': 'application/json',
  ...(event?.node?.req?.headers?.cookie ? { cookie: event.node.req.headers.cookie } : {})
}
```

This ensures middleware that inspects `/__nuxt_content/**` requests has full access to the request's authentication context.

---

### Result

- 🔐 Middleware-based content access works correctly during SSR
- ✅ Consistent behavior across hard reloads and client-side routing
- 🛠 No changes to runtime or client-side behavior — only internal SSR fetches are affected