### PR TITLE
docs[serverless+D1]: correct configuration property name

### DIFF
--- a/docs/content/docs/6.deploy/2.serverless.md
+++ b/docs/content/docs/6.deploy/2.serverless.md
@@ -46,7 +46,7 @@ export default defineNuxtConfig({
   content: {
     database: {
       type: 'd1',
-      binding: '<YOUR_BINDING_NAME>'
+      bindingName: '<YOUR_BINDING_NAME>'
     }
   }
 })


### PR DESCRIPTION
### 🔗 Linked issue

resolves #3387

### ❓ Type of change


- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

D1DatabaseConfig [1] expects 'bindingName' property, documentation refers to it as 'binding'

[1]: https://github.com/nuxt/content/blob/b01e307721e3e88ae9a54997d95aaaec9a36d77f/src/types/module.ts#L9

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
