### PR TITLE
feat(preset): warn if nuxthub is loaded before without database

### DIFF
--- a/src/presets/nuxthub.ts
+++ b/src/presets/nuxthub.ts
@@ -10,7 +10,7 @@ export default definePreset({
     const indexOfNuxtHub = nuxt.options.modules.indexOf('@nuxthub/core')
     const indexOfContentModule = nuxt.options.modules.indexOf('@nuxt/content')
 
-    if (!((nuxt.options as unknown as { hub: { database?: boolean } }).hub?.database) && indexOfNuxtHub > indexOfContentModule) {
+    if (!((nuxt.options as unknown as { hub: { database?: boolean } }).hub?.database) && indexOfNuxtHub < indexOfContentModule) {
       logger.warn('NuxtHub database is not enabled. Please enable it in your NuxtHub configuration. It is recommended to register `@nuxt/content` before `@nuxthub/core`, so that `@nuxt/content` can automatically configure the database if needed.')
     }
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR adds and addtionnal check when using nuxt content with nuxthub.

In cases when nuxt content is after nuxthub and nuxthub doesn't have databse enabled, deploying on nuxthub won't update the DB. Because the modification brought to `nuxt.options.hub` done too late. 

````ts
export default defineNuxtConfig({
  modules: [
    '@nuxthub/core', // nuxt content should load before nuxthub or the user should enable databse themselves
    "@nuxt/content",
  ]
})
````

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
