### PR TITLE
docs: use vue `slot`

### DIFF
--- a/docs/content/docs/8.studio/3.content.md
+++ b/docs/content/docs/8.studio/3.content.md
@@ -77,10 +77,10 @@ You can create Vue components and integrate them into Markdown. They just need t
     </div>
     <div class="flex flex-col">
       <h3 class="font-semibold">
-        <ContentSlot name="title" />
+        <slot name="title" />
       </h3>
       <span>
-        <ContentSlot name="description" />
+        <slot name="description" />
       </span>
     </div>
   </div>


### PR DESCRIPTION
changed ContentSlot to slot for version 3

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
The change in doc for this page in doc:
https://content.nuxt.com/docs/studio/content
<!-- Why is this change required? What problem does it solve? -->
I just copied paste the example from the Doc, but it didn't work. Eventually I figured out for version 3 nuxt/content you need to use `<slot>` instead of `<ContentSlot>`
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
