### PR TITLE
docs: fix `ProseCode` preview syntax highlighting

### DIFF
--- a/docs/content/docs/5.components/2.prose.md
+++ b/docs/content/docs/5.components/2.prose.md
@@ -92,7 +92,7 @@ If you want to use `]` in the filename, you need to escape it with 2 backslashes
   :::code-preview{icon="i-lucide-eye" label="Preview"}
   `code`
 
-  `const code: string = 'highlighted code inline'`
+  `const code: string = 'highlighted code inline'`{lang="ts"}
   :::
 ::
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue
* #2805
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Resolves #2805

before 
<img width="788" height="240" alt="image" src="https://github.com/user-attachments/assets/8ba282b3-9db7-4069-96fd-721ab7548ed2" />
after
<img width="796" height="245" alt="image" src="https://github.com/user-attachments/assets/863cd7dc-f808-4748-aaec-10cab0dd046d" />

BTW, the divider preview is broken, since parent div uses display flex (and I think the divider color matches the background in dark mode)
<img width="798" height="280" alt="image" src="https://github.com/user-attachments/assets/569ffdd9-2d58-4aee-883d-47eabbd6a022" />


<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
