### PR TITLE
docs: examples now have the declared argument order

### DIFF
--- a/docs/content/docs/2.collections/1.define.md
+++ b/docs/content/docs/2.collections/1.define.md
@@ -37,10 +37,10 @@ import { defineCollection, defineContentConfig } from '@nuxt/content'
 export default defineContentConfig({
   collections: {
     docs: defineCollection({
-      // Load every file inside the `content` directory
-      source: '**',
       // Specify the type of content in this collection
       type: 'page'
+      // Load every file inside the `content` directory
+      source: '**',
     })
   }
 })
@@ -64,8 +64,8 @@ import { defineCollection, defineContentConfig, z } from '@nuxt/content'
 export default defineContentConfig({
   collections: {
     blog: defineCollection({
-      source: 'blog/*.md',
       type: 'page',
+      source: 'blog/*.md',
       // Define custom schema for docs collection
       schema: z.object({
         tags: z.array(z.string()),


### PR DESCRIPTION
Improves the examples, following the order of the parameters declared on `Content` type.

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The Content type declaration, included on the [defineCollection() section](https://content.nuxt.com/docs/collections/define#definecollection), has the params `type` and `source`, whose order is switched on the examples used throughout the page.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
