### PR TITLE
docs: fixed example syntax

### DIFF
--- a/docs/content/docs/2.collections/1.define.md
+++ b/docs/content/docs/2.collections/1.define.md
@@ -38,7 +38,7 @@ export default defineContentConfig({
   collections: {
     docs: defineCollection({
       // Specify the type of content in this collection
-      type: 'page'
+      type: 'page',
       // Load every file inside the `content` directory
       source: '**',
     })


### PR DESCRIPTION
fixed the object properties of an example; the syntax highlighting wasn't working because of that either

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Following PR #3493, I've added a missing comma, which fixes the JS object notation (consequently enabling the syntax highlighting)

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
