### PR TITLE
fix: fix csv file collections

### DIFF
--- a/src/utils/content/index.ts
+++ b/src/utils/content/index.ts
@@ -111,7 +111,7 @@ async function _getHighlightPlugin(key: string, options: HighlighterOptions) {
 export async function createParser(collection: ResolvedCollection, nuxt?: Nuxt) {
   const nuxtOptions = nuxt?.options as unknown as { content: ModuleOptions, mdc: MDCModuleOptions }
   const mdcOptions = nuxtOptions?.mdc || {}
-  const { pathMeta = {}, markdown = {}, transformers = [] } = nuxtOptions?.content?.build || {}
+  const { pathMeta = {}, markdown = {}, transformers = [], csv = {}, yaml = {} } = nuxtOptions?.content?.build || {}
 
   const rehypeHighlightPlugin = markdown.highlight !== false
     ? await getHighlightPluginInstance(defu(markdown.highlight as HighlighterOptions, mdcOptions.highlight, { compress: true }))
@@ -149,6 +149,8 @@ export async function createParser(collection: ResolvedCollection, nuxt?: Nuxt) 
       },
       highlight: undefined,
     },
+    csv: csv,
+    yaml: yaml,
   }
 
   return async function parse(file: ContentFile) {


### PR DESCRIPTION
### 🔗 Linked issue
#3511 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Currently, CSV collections don’t behave as described in the documentation.
Instead of allowing each CSV file to contain multiple entries (as the [documentation](https://content.nuxt.com/docs/files/csv)
 states), the current implementation treats each CSV file as a single piece of content.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
