### PR TITLE
fix: align app and nitro utils type

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   ],
   "scripts": {
     "prepack": "nuxt-module-build build",
-    "typecheck": "nuxt typecheck",
+    "typecheck": "nuxt typecheck && nuxt typecheck playground",
     "example": "run () { nuxt dev examples/$*; }; run",
     "docs": "nuxt dev -e docus docs",
     "docs:build": "nuxt-module-build build && nuxt build -e docus docs",

--- a/playground/components/ContentPage.vue
+++ b/playground/components/ContentPage.vue
@@ -13,6 +13,7 @@ interface TocLink {
 interface ContentData {
   title?: string
   description?: string
+  stem?: string
   body?: {
     toc?: {
       links?: TocLink[]
@@ -21,8 +22,8 @@ interface ContentData {
 }
 
 interface Props {
-  data: ContentData | null
-  navigation?: ContentNavigationItem[] | null
+  data?: ContentData | null
+  navigation?: ContentNavigationItem[]
   surround?: ContentNavigationItem[] | null
 }
 

--- a/playground/components/playground.vue
+++ b/playground/components/playground.vue
@@ -31,11 +31,11 @@ const value = computed(() => {
 
 const tags = ['TestA', 'TestB', 'TestC']
 const randomize = () => {
-  let tag = body.value.children[0].children[1].tag
-  while (tag === body.value.children[0].children[1].tag) {
+  let tag = body.value.children[0]?.children[1]?.tag
+  while (tag === body.value.children[0]?.children[1]?.tag) {
     tag = tags[Math.floor(Math.random() * tags.length)]
   }
-  body.value.children[0].children[1].tag = tag
-  body.value.children[0].children[1].children![0]!.value = `world (${tag})`
+  body.value.children[0]!.children[1]!.tag = tag
+  body.value.children[0]!.children[1]!.children![0]!.value = `world (${tag})`
 }
 </script>

--- a/playground/package.json
+++ b/playground/package.json
@@ -6,7 +6,8 @@
     "dev": "nuxi dev",
     "build": "nuxi build",
     "generate": "nuxi generate",
-    "dev:prepare": "nuxt prepare"
+    "dev:prepare": "nuxt prepare",
+    "typecheck": "nuxt typecheck"
   },
   "devDependencies": {
     "@nuxt/content": "latest",

--- a/playground/pages/[...slug].vue
+++ b/playground/pages/[...slug].vue
@@ -2,9 +2,11 @@
 const route = useRoute()
 
 const { data: navigation } = await useAsyncData('contents-list', () => queryCollectionNavigation('content'))
-const { data } = await useAsyncData('posts' + route.path, async () => {
-  return await queryCollection('content').path(route.path).first()
-})
+const { data } = await useAsyncData('posts' + route.path, async () => $fetch(`/api/content`, {
+  params: {
+    path: route.path,
+  },
+}))
 
 const { data: surround } = await useAsyncData('content-surround' + route.path, () => {
   return queryCollectionItemSurroundings('content', route.path, {

--- a/playground/server/api/content.ts
+++ b/playground/server/api/content.ts
@@ -1,0 +1,6 @@
+export default defineEventHandler(async (event) => {
+  const params = getQuery<{
+    path: string
+  }>(event)
+  return queryCollection(event, 'content').path(params.path).first()
+})

--- a/playground/tsconfig.json
+++ b/playground/tsconfig.json
@@ -1,3 +1,17 @@
 {
-  "extends": "./.nuxt/tsconfig.json"
+  "files": [],
+  "references": [
+    {
+      "path": "./.nuxt/tsconfig.app.json"
+    },
+    {
+      "path": "./.nuxt/tsconfig.server.json"
+    },
+    {
+      "path": "./.nuxt/tsconfig.shared.json"
+    },
+    {
+      "path": "./.nuxt/tsconfig.node.json"
+    }
+  ]
 }

--- a/src/runtime/app.ts
+++ b/src/runtime/app.ts
@@ -19,7 +19,7 @@ export function queryCollection<T extends keyof Collections>(collection: T): Col
 export function queryCollection<T extends keyof Collections>(event: H3Event, collection: T): CollectionQueryBuilder<Collections[T]>
 export function queryCollection<T extends keyof Collections>(...args: [H3Event, T] | [T]): CollectionQueryBuilder<Collections[T]> {
   if (isEvent(args[0])) {
-    throw new Error("Unexpected H3Event. Use 'queryCollection(event, collection)' only in server-side context.")
+    throw new Error('Unexpected H3Event. Use \'queryCollection(event, collection)\' only in server-side context.')
   }
   const collection = args[0] as T
   const event = tryUseNuxtApp()?.ssrContext?.event
@@ -30,7 +30,7 @@ export function queryCollectionNavigation<T extends keyof PageCollections>(event
 export function queryCollectionNavigation<T extends keyof PageCollections>(collection: T, fields?: Array<keyof PageCollections[T]>): ChainablePromise<T, ContentNavigationItem[]>
 export function queryCollectionNavigation<T extends keyof PageCollections>(...args: [H3Event, T, Array<keyof PageCollections[T]>?] | [T, Array<keyof PageCollections[T]>?]): ChainablePromise<T, ContentNavigationItem[]> {
   if (isEvent(args[0])) {
-    throw new Error("Unexpected H3Event. Use 'queryCollectionNavigation(event, collection, fields)' only in server-side context.")
+    throw new Error('Unexpected H3Event. Use \'queryCollectionNavigation(event, collection, fields)\' only in server-side context.')
   }
   const [collection, fields] = args as [T, Array<keyof PageCollections[T]>?]
   return chainablePromise(collection, qb => generateNavigationTree(qb, fields))
@@ -40,7 +40,7 @@ export function queryCollectionItemSurroundings<T extends keyof PageCollections>
 export function queryCollectionItemSurroundings<T extends keyof PageCollections>(collection: T, path: string, opts?: SurroundOptions<keyof PageCollections[T]>): ChainablePromise<T, ContentNavigationItem[]>
 export function queryCollectionItemSurroundings<T extends keyof PageCollections>(...args: [H3Event, T, string, SurroundOptions<keyof PageCollections[T]>?] | [T, string, SurroundOptions<keyof PageCollections[T]>?]): ChainablePromise<T, ContentNavigationItem[]> {
   if (isEvent(args[0])) {
-    throw new Error("Unexpected H3Event. Use 'queryCollectionItemSurroundings(event, collection, path, opts)' only in server-side context.")
+    throw new Error('Unexpected H3Event. Use \'queryCollectionItemSurroundings(event, collection, path, opts)\' only in server-side context.')
   }
   const [collection, path, opts] = args as [T, string, SurroundOptions<keyof PageCollections[T]>?]
   return chainablePromise(collection, qb => generateItemSurround(qb, path, opts))
@@ -50,7 +50,7 @@ export function queryCollectionSearchSections<T extends keyof Collections>(event
 export function queryCollectionSearchSections<T extends keyof Collections>(collection: T, opts?: { ignoredTags: string[] }): ChainablePromise<T, Section[]>
 export function queryCollectionSearchSections<T extends keyof Collections>(...args: [H3Event, T, { ignoredTags: string[] }?] | [T, { ignoredTags: string[] }?]): ChainablePromise<T, Section[]> {
   if (isEvent(args[0])) {
-    throw new Error("Unexpected H3Event. Use 'queryCollectionSearchSections(event, collection, opts)' only in server-side context.")
+    throw new Error('Unexpected H3Event. Use \'queryCollectionSearchSections(event, collection, opts)\' only in server-side context.')
   }
   const [collection, opts] = args as [T, { ignoredTags: string[] }?]
   return chainablePromise(collection, qb => generateSearchSections(qb, opts))

--- a/src/runtime/app.ts
+++ b/src/runtime/app.ts
@@ -1,11 +1,12 @@
-import type { H3Event } from 'h3'
-import { collectionQueryBuilder } from './internal/query'
-import { generateNavigationTree } from './internal/navigation'
-import { generateItemSurround } from './internal/surround'
-import { generateSearchSections } from './internal/search'
-import { fetchQuery } from './internal/api'
-import type { Collections, PageCollections, CollectionQueryBuilder, SurroundOptions, SQLOperator, QueryGroupFunction, ContentNavigationItem } from '@nuxt/content'
 import { tryUseNuxtApp } from '#imports'
+import type { CollectionQueryBuilder, Collections, ContentNavigationItem, PageCollections, QueryGroupFunction, SQLOperator, SurroundOptions } from '@nuxt/content'
+import type { H3Event } from 'h3'
+import { isEvent } from 'h3'
+import { fetchQuery } from './internal/api'
+import { generateNavigationTree } from './internal/navigation'
+import { collectionQueryBuilder } from './internal/query'
+import { generateSearchSections, type Section } from './internal/search'
+import { generateItemSurround } from './internal/surround'
 
 interface ChainablePromise<T extends keyof PageCollections, R> extends Promise<R> {
   where(field: keyof PageCollections[T] | string, operator: SQLOperator, value?: unknown): ChainablePromise<T, R>
@@ -14,20 +15,44 @@ interface ChainablePromise<T extends keyof PageCollections, R> extends Promise<R
   order(field: keyof PageCollections[T], direction: 'ASC' | 'DESC'): ChainablePromise<T, R>
 }
 
-export const queryCollection = <T extends keyof Collections>(collection: T): CollectionQueryBuilder<Collections[T]> => {
+export function queryCollection<T extends keyof Collections>(collection: T): CollectionQueryBuilder<Collections[T]>
+export function queryCollection<T extends keyof Collections>(event: H3Event, collection: T): CollectionQueryBuilder<Collections[T]>
+export function queryCollection<T extends keyof Collections>(...args: [H3Event, T] | [T]): CollectionQueryBuilder<Collections[T]> {
+  if (isEvent(args[0])) {
+    throw new Error("Unexpected H3Event. Use 'queryCollection(event, collection)' only in server-side context.")
+  }
+  const collection = args[0] as T
   const event = tryUseNuxtApp()?.ssrContext?.event
   return collectionQueryBuilder<T>(collection, (collection, sql) => executeContentQuery(event, collection, sql))
 }
 
-export function queryCollectionNavigation<T extends keyof PageCollections>(collection: T, fields?: Array<keyof PageCollections[T]>): ChainablePromise<T, ContentNavigationItem[]> {
+export function queryCollectionNavigation<T extends keyof PageCollections>(event: H3Event, collection: T, fields?: Array<keyof PageCollections[T]>): ChainablePromise<T, ContentNavigationItem[]>
+export function queryCollectionNavigation<T extends keyof PageCollections>(collection: T, fields?: Array<keyof PageCollections[T]>): ChainablePromise<T, ContentNavigationItem[]>
+export function queryCollectionNavigation<T extends keyof PageCollections>(...args: [H3Event, T, Array<keyof PageCollections[T]>?] | [T, Array<keyof PageCollections[T]>?]): ChainablePromise<T, ContentNavigationItem[]> {
+  if (isEvent(args[0])) {
+    throw new Error("Unexpected H3Event. Use 'queryCollectionNavigation(event, collection, fields)' only in server-side context.")
+  }
+  const [collection, fields] = args as [T, Array<keyof PageCollections[T]>?]
   return chainablePromise(collection, qb => generateNavigationTree(qb, fields))
 }
 
-export function queryCollectionItemSurroundings<T extends keyof PageCollections>(collection: T, path: string, opts?: SurroundOptions<keyof PageCollections[T]>): ChainablePromise<T, ContentNavigationItem[]> {
+export function queryCollectionItemSurroundings<T extends keyof PageCollections>(event: H3Event, collection: T, path: string, opts?: SurroundOptions<keyof PageCollections[T]>): ChainablePromise<T, ContentNavigationItem[]>
+export function queryCollectionItemSurroundings<T extends keyof PageCollections>(collection: T, path: string, opts?: SurroundOptions<keyof PageCollections[T]>): ChainablePromise<T, ContentNavigationItem[]>
+export function queryCollectionItemSurroundings<T extends keyof PageCollections>(...args: [H3Event, T, string, SurroundOptions<keyof PageCollections[T]>?] | [T, string, SurroundOptions<keyof PageCollections[T]>?]): ChainablePromise<T, ContentNavigationItem[]> {
+  if (isEvent(args[0])) {
+    throw new Error("Unexpected H3Event. Use 'queryCollectionItemSurroundings(event, collection, path, opts)' only in server-side context.")
+  }
+  const [collection, path, opts] = args as [T, string, SurroundOptions<keyof PageCollections[T]>?]
   return chainablePromise(collection, qb => generateItemSurround(qb, path, opts))
 }
 
-export function queryCollectionSearchSections(collection: keyof Collections, opts?: { ignoredTags: string[] }) {
+export function queryCollectionSearchSections<T extends keyof Collections>(event: H3Event, collection: T, opts?: { ignoredTags: string[] }): ChainablePromise<T, Section[]>
+export function queryCollectionSearchSections<T extends keyof Collections>(collection: T, opts?: { ignoredTags: string[] }): ChainablePromise<T, Section[]>
+export function queryCollectionSearchSections<T extends keyof Collections>(...args: [H3Event, T, { ignoredTags: string[] }?] | [T, { ignoredTags: string[] }?]): ChainablePromise<T, Section[]> {
+  if (isEvent(args[0])) {
+    throw new Error("Unexpected H3Event. Use 'queryCollectionSearchSections(event, collection, opts)' only in server-side context.")
+  }
+  const [collection, opts] = args as [T, { ignoredTags: string[] }?]
   return chainablePromise(collection, qb => generateSearchSections(qb, opts))
 }
 
@@ -48,7 +73,7 @@ async function queryContentSqlClientWasm<T extends keyof Collections, Result = C
   return rows as Result[]
 }
 
-function chainablePromise<T extends keyof PageCollections, Result>(collection: T, fn: (qb: CollectionQueryBuilder<PageCollections[T]>) => Promise<Result>) {
+function chainablePromise<T extends keyof PageCollections, Result>(collection: T, fn: (qb: CollectionQueryBuilder<PageCollections[T]>) => Promise<Result>): ChainablePromise<T, Result> {
   const queryBuilder = queryCollection(collection)
 
   const chainable: ChainablePromise<T, Result> = {

--- a/src/runtime/internal/search.ts
+++ b/src/runtime/internal/search.ts
@@ -1,10 +1,10 @@
-import type { MDCNode, MDCRoot, MDCElement } from '@nuxtjs/mdc'
-import { toHast } from 'minimark/hast'
+import type { MDCElement, MDCNode, MDCRoot } from '@nuxtjs/mdc'
 import type { MinimarkTree } from 'minimark'
-import { pick } from './utils'
+import { toHast } from 'minimark/hast'
 import type { CollectionQueryBuilder, PageCollectionItemBase } from '~/src/types'
+import { pick } from './utils'
 
-type Section = {
+export type Section = {
   // Path to the section
   id: string
   // Title of the section

--- a/src/runtime/server.ts
+++ b/src/runtime/server.ts
@@ -1,10 +1,11 @@
+import type { CollectionQueryBuilder, Collections, ContentNavigationItem, PageCollections, QueryGroupFunction, SQLOperator, SurroundOptions } from '@nuxt/content'
 import type { H3Event } from 'h3'
-import { collectionQueryBuilder } from './internal/query'
-import { generateNavigationTree } from './internal/navigation'
-import { generateItemSurround } from './internal/surround'
-import { generateSearchSections } from './internal/search'
+import { isEvent } from 'h3'
 import { fetchQuery } from './internal/api'
-import type { Collections, CollectionQueryBuilder, PageCollections, SurroundOptions, SQLOperator, QueryGroupFunction } from '@nuxt/content'
+import { generateNavigationTree } from './internal/navigation'
+import { collectionQueryBuilder } from './internal/query'
+import { generateSearchSections, type Section } from './internal/search'
+import { generateItemSurround } from './internal/surround'
 
 interface ChainablePromise<T extends keyof PageCollections, R> extends Promise<R> {
   where(field: keyof PageCollections[T] | string, operator: SQLOperator, value?: unknown): ChainablePromise<T, R>
@@ -13,19 +14,43 @@ interface ChainablePromise<T extends keyof PageCollections, R> extends Promise<R
   order(field: keyof PageCollections[T], direction: 'ASC' | 'DESC'): ChainablePromise<T, R>
 }
 
-export const queryCollection = <T extends keyof Collections>(event: H3Event, collection: T): CollectionQueryBuilder<Collections[T]> => {
+export function queryCollection<T extends keyof Collections>(collection: T): CollectionQueryBuilder<Collections[T]>
+export function queryCollection<T extends keyof Collections>(event: H3Event, collection: T): CollectionQueryBuilder<Collections[T]>
+export function queryCollection<T extends keyof Collections>(...args: [H3Event, T] | [T]): CollectionQueryBuilder<Collections[T]> {
+  if (!isEvent(args[0])) {
+    throw new Error('Missing H3Event. Use \'queryCollection(event, collection)\' in server-side context.')
+  }
+  const [event, collection] = args as [H3Event, T]
   return collectionQueryBuilder<T>(collection, (collection, sql) => fetchQuery(event, collection, sql))
 }
 
-export function queryCollectionNavigation<T extends keyof PageCollections>(event: H3Event, collection: T, fields?: Array<keyof PageCollections[T]>) {
+export function queryCollectionNavigation<T extends keyof PageCollections>(event: H3Event, collection: T, fields?: Array<keyof PageCollections[T]>): ChainablePromise<T, ContentNavigationItem[]>
+export function queryCollectionNavigation<T extends keyof PageCollections>(collection: T, fields?: Array<keyof PageCollections[T]>): ChainablePromise<T, ContentNavigationItem[]>
+export function queryCollectionNavigation<T extends keyof PageCollections>(...args: [H3Event, T, Array<keyof PageCollections[T]>?] | [T, Array<keyof PageCollections[T]>?]): ChainablePromise<T, ContentNavigationItem[]> {
+  if (!isEvent(args[0])) {
+    throw new Error('Missing H3Event. Use \'queryCollectionNavigation(event, collection, fields)\' in server-side context.')
+  }
+  const [event, collection, fields] = args as [H3Event, T, Array<keyof PageCollections[T]>?]
   return chainablePromise(event, collection, qb => generateNavigationTree(qb, fields))
 }
 
-export function queryCollectionItemSurroundings<T extends keyof PageCollections>(event: H3Event, collection: T, path: string, opts?: SurroundOptions<keyof PageCollections[T]>) {
+export function queryCollectionItemSurroundings<T extends keyof PageCollections>(event: H3Event, collection: T, path: string, opts?: SurroundOptions<keyof PageCollections[T]>): ChainablePromise<T, ContentNavigationItem[]>
+export function queryCollectionItemSurroundings<T extends keyof PageCollections>(collection: T, path: string, opts?: SurroundOptions<keyof PageCollections[T]>): ChainablePromise<T, ContentNavigationItem[]>
+export function queryCollectionItemSurroundings<T extends keyof PageCollections>(...args: [H3Event, T, string, SurroundOptions<keyof PageCollections[T]>?] | [T, string, SurroundOptions<keyof PageCollections[T]>?]): ChainablePromise<T, ContentNavigationItem[]> {
+  if (!isEvent(args[0])) {
+    throw new Error('Missing H3Event. Use \'queryCollectionItemSurroundings(event, collection, path, opts)\' in server-side context.')
+  }
+  const [event, collection, path, opts] = args as [H3Event, T, string, SurroundOptions<keyof PageCollections[T]>?]
   return chainablePromise(event, collection, qb => generateItemSurround(qb, path, opts))
 }
 
-export function queryCollectionSearchSections(event: H3Event, collection: keyof Collections, opts?: { ignoredTags: string[] }) {
+export function queryCollectionSearchSections<T extends keyof Collections>(event: H3Event, collection: T, opts?: { ignoredTags: string[] }): ChainablePromise<T, Section[]>
+export function queryCollectionSearchSections<T extends keyof Collections>(collection: T, opts?: { ignoredTags: string[] }): ChainablePromise<T, Section[]>
+export function queryCollectionSearchSections<T extends keyof Collections>(...args: [H3Event, T, { ignoredTags: string[] }?] | [T, { ignoredTags: string[] }?]): ChainablePromise<T, Section[]> {
+  if (!isEvent(args[0])) {
+    throw new Error('Missing H3Event. Use \'queryCollectionSearchSections(event, collection, opts)\' in server-side context.')
+  }
+  const [event, collection, opts] = args as [H3Event, T, { ignoredTags: string[] }?]
   return chainablePromise(event, collection, qb => generateSearchSections(qb, opts))
 }
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

close #3514 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Using the same type for utils on app and nitro, to prevent type check error when using utils on nitro side.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
