### PR TITLE
chore: Update WebSocket content reload logger prefix for clarity

### DIFF
--- a/src/runtime/internal/websocket.ts
+++ b/src/runtime/internal/websocket.ts
@@ -2,8 +2,8 @@ import { loadDatabaseAdapter } from './database.client'
 import { useRuntimeConfig, refreshNuxtData } from '#imports'
 
 const logger = {
-  log: (...args: unknown[]) => console.log('[Content]', ...args),
-  warn: (...args: unknown[]) => console.warn('[Content]', ...args),
+  log: (...args: unknown[]) => console.log('[Nuxt Content : Hot Content Reload]', ...args),
+  warn: (...args: unknown[]) => console.warn('[Nuxt Content : Hot Content Reload]', ...args),
 }
 
 let ws: WebSocket | undefined


### PR DESCRIPTION
Updated the console log prefix from "[Content]" to "[Nuxt Content: Hot Content Reload]"
to make it clear that the messages refer to hot-reloading of Nuxt Content.

My previous PR (https://github.com/nuxt/content/pull/3515) was merged into the v3 branch instead of main. 

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
