### PR TITLE
fix: normalize source cwd

### DIFF
--- a/src/utils/source.ts
+++ b/src/utils/source.ts
@@ -1,5 +1,5 @@
 import { readFile } from 'node:fs/promises'
-import { join } from 'pathe'
+import { join, normalize } from 'pathe'
 import { withLeadingSlash, withoutTrailingSlash } from 'ufo'
 import { glob } from 'tinyglobby'
 import type { CollectionSource, ResolvedCollectionSource } from '../types/collection'
@@ -25,7 +25,7 @@ export function defineLocalSource(source: CollectionSource | ResolvedCollectionS
     prefix: withoutTrailingSlash(withLeadingSlash(fixed)),
     prepare: async ({ rootDir }) => {
       resolvedSource.cwd = source.cwd
-        ? String(source.cwd).replace(/^~~\//, rootDir)
+        ? String(normalize(source.cwd)).replace(/^~~\//, rootDir)
         : join(rootDir, 'content')
     },
     getKeys: async () => {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

I tried to customize the cwd, but I found that hot reload does not work after setting. 
```
defineCollection({
  type: 'page',
  source: {
    cwd: path.resolve('./content'),
    // ...
  },
})
```

So I used path.normalize to fix and now it works 😀

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
