### PR TITLE
fix: stop data changing from refreshing the ContentRenderer

### DIFF
--- a/src/runtime/components/ContentRenderer.vue
+++ b/src/runtime/components/ContentRenderer.vue
@@ -101,10 +101,11 @@ const data = computed(() => {
 const proseComponentMap = Object.fromEntries(['p', 'a', 'blockquote', 'code', 'pre', 'code', 'em', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'hr', 'img', 'ul', 'ol', 'li', 'strong', 'table', 'thead', 'tbody', 'td', 'th', 'tr', 'script'].map(t => [t, `prose-${t}`]))
 
 const { mdc } = useRuntimeConfig().public || {}
+const propsDataMDC = computed(() => props.data.mdc)
 const tags = computed(() => ({
   ...mdc?.components?.prose && props.prose !== false ? proseComponentMap : {},
   ...mdc?.components?.map || {},
-  ...toRaw(props.data?.mdc?.components || {}),
+  ...toRaw(propsDataMDC.value?.components || {}),
   ...props.components,
 }))
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue
fixes [#3466](https://github.com/nuxt/content/issues/3466)

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Any change in the data props will trigger the computed tags to be recomputed, extracting the props.data.MDC should scope Vue's reactivity to track only the props.data.mdc instead of props.data. Resolves [#3466](https://github.com/nuxt/content/issues/3466).
props.data is doing an optional check, which I removed as the props seem to default this to an empty object, the typing indicates it's a `Record<string, any>` type, is there a reason for the optional chaining?

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
