### PR TITLE
Fix: Update COPY command in docs to support multiple lock files

### DIFF
--- a/docs/content/docs/6.deploy/9.docker.md
+++ b/docs/content/docs/6.deploy/9.docker.md
@@ -56,7 +56,7 @@ If you like to use Bun, you can use the official Bun image. Here is an example D
 FROM oven/bun:1 AS build
 WORKDIR /app
 
-COPY package.json bun.lockb ./
+COPY package.json bun.lock* ./
 
 # use ignore-scripts to avoid builting node modules like better-sqlite3
 RUN bun install --frozen-lockfile --ignore-scripts


### PR DESCRIPTION
### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

See #3543.  Bun v1.2 changed the default lockfile format to the text-based bun.lock. Existing binary bun.lockb lockfiles can be migrated to the new format by running bun install --save-text-lockfile --frozen-lockfile --lockfile-only and deleting bun.lockb.