### PR TITLE
chore: cleanup deprecated z re-export and editor usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,34 @@
 
 ## [3.7.0](https://github.com/nuxt/content/compare/v3.6.3...v3.7.0) (2025-09-12)
 
+### Deprecations
+
+The following features are deprecated and will be removed in a future release:
+- `z` re-export from `@nuxt/content`
+- Calling `.editor()` directly on zod schemas (e.g. `z.string().editor(...)`)
+
+Migration guide :
+```diff
+- import { defineContentConfig, defineCollection, z } from '@nuxt/content'
++ import { defineContentConfig, defineCollection, property } from '@nuxt/content'
++ import { z } from 'zod' // or 'zod/v3' if your setup exposes this subpath
+
+  export default defineContentConfig({
+    collections: {
+      posts: defineCollection({
+        type: 'page',
+        source: 'blog/*.md',
+        schema: z.object({
+        image: z.object({
+-         src: z.string().editor({ input: 'media' }),
++         src: property(z.string()).editor({ input: 'media' }),
+          alt: z.string(),
+        }),
+      }),
+    },
+  })
+```
+
 ### Features
 
 * adopt standard schema spec and support different validators ([#3524](https://github.com/nuxt/content/issues/3524)) ([46a1004](https://github.com/nuxt/content/commit/46a1004c6eadae00c1c42f6f335b7dd5ac664b33))

--- a/docs/content.config.ts
+++ b/docs/content.config.ts
@@ -1,4 +1,5 @@
-import { defineContentConfig, defineCollection, property, z } from '@nuxt/content'
+import { defineContentConfig, defineCollection, property } from '@nuxt/content'
+import z from 'zod'
 
 const createPricingFeatureSchema = () => z.object({
   title: z.string(),

--- a/docs/content/changelog/frontmatter-form.md
+++ b/docs/content/changelog/frontmatter-form.md
@@ -96,6 +96,10 @@ export const collections = {
 
 ### Built with Nuxt Studio in mind
 
+::warning
+This article was published before v3.7, learn [this guide](https://github.com/nuxt/content/blob/main/CHANGELOG.md#370-2025-09-12) to migrate.
+::
+
 Nuxt Studio was originally developed alongside Nuxt Content v2, but with v3, we're building the module with Nuxt Studio experience in mind. Our goal is to create the best CMS platform for content editing, while still offering the best developers experience.
 
 For example, collection schemas will help us further enhance form generation in Studio. Among other things, you'll be able to set the editor type for a field directly in your schema.

--- a/docs/content/changelog/studio-customisation.md
+++ b/docs/content/changelog/studio-customisation.md
@@ -16,6 +16,10 @@ category: content
 draft: false
 ---
 
+::warning
+This article was published before v3.7, learn [this guide](https://github.com/nuxt/content/blob/main/CHANGELOG.md#370-2025-09-12) to migrate.
+::
+
 The [Studio](https://nuxt.studio) forms are dynamically generated based on the collection schema defined in your content configuration file. This behaviour applies whether you’re editing the [frontmatter](/docs/files/markdown#frontmatter) of a `Markdown` file or a `JSON` / `YAML` file.
 
 :video{autoplay controls poster="https://res.cloudinary.com/nuxt/video/upload/v1739982761/frontmatterform_yjafgt.png" src="https://res.cloudinary.com/nuxt/video/upload/v1739982761/frontmatterform_yjafgt.mp4"}

--- a/docs/content/docs/2.collections/1.define.md
+++ b/docs/content/docs/2.collections/1.define.md
@@ -59,7 +59,8 @@ Schemas enforce data consistency within a collection and serve as the source of 
 On top of the built-in fields, you can define a schema by adding the `schema` property to your collection by using a [`zod`](https://zod.dev) schema:
 
 ```ts [content.config.ts]
-import { defineCollection, defineContentConfig, z } from '@nuxt/content'
+import { defineCollection, defineContentConfig } from '@nuxt/content'
+import { z } from 'zod'
 
 export default defineContentConfig({
   collections: {

--- a/docs/content/docs/2.collections/5.inherit-schema-from-component.md
+++ b/docs/content/docs/2.collections/5.inherit-schema-from-component.md
@@ -18,7 +18,8 @@ Under the hood, Nuxt Content reads the component's props (via `nuxt-component-me
 ## Example
 
 ```ts [content.config.ts]
-import { defineContentConfig, defineCollection, z, property } from '@nuxt/content'
+import { defineContentConfig, defineCollection, property } from '@nuxt/content'
+import { z } from 'zod'
 
 export default defineContentConfig({
   collections: {

--- a/docs/content/docs/3.files/1.markdown.md
+++ b/docs/content/docs/3.files/1.markdown.md
@@ -9,7 +9,8 @@ description: Create and query Markdown files in your Nuxt applications and use
 ### Define a Collection
 
 ```ts [content.config.ts]
-import { defineCollection, defineContentConfig, z } from '@nuxt/content'
+import { defineCollection, defineContentConfig } from '@nuxt/content'
+import { z } from 'zod'
 
 export default defineContentConfig({
   collections: {

--- a/docs/content/docs/3.files/2.yaml.md
+++ b/docs/content/docs/3.files/2.yaml.md
@@ -6,7 +6,8 @@ description: How to define, write and query YAML data.
 ## Define Collection
 
 ```ts [content.config.ts]
-import { defineCollection, defineContentConfig, z } from '@nuxt/content'
+import { defineCollection, defineContentConfig } from '@nuxt/content'
+import { z } from 'zod'
 
 export default defineContentConfig({
   collections: {

--- a/docs/content/docs/3.files/3.json.md
+++ b/docs/content/docs/3.files/3.json.md
@@ -6,7 +6,8 @@ description: How to define, write and query JSON data.
 ## Define Collection
 
 ```ts [content.config.ts]
-import { defineCollection, defineContentConfig, z } from '@nuxt/content'
+import { defineCollection, defineContentConfig } from '@nuxt/content'
+import { z } from 'zod'
 
 export default defineContentConfig({
   collections: {

--- a/docs/content/docs/3.files/4.csv.md
+++ b/docs/content/docs/3.files/4.csv.md
@@ -6,7 +6,8 @@ description: How to define, write and query CSV data.
 ## Define Collection
 
 ```ts [content.config.ts]
-import { defineCollection, defineContentConfig, z } from '@nuxt/content'
+import { defineCollection, defineContentConfig } from '@nuxt/content'
+import { z } from 'zod'
 
 export default defineContentConfig({
   collections: {

--- a/docs/content/docs/8.advanced/2.raw-content.md
+++ b/docs/content/docs/8.advanced/2.raw-content.md
@@ -11,7 +11,8 @@ Nuxt Content will detect this magical field in your schema and fill it with the 
 
 ```ts [content.config.ts]
 
-import { defineCollection, defineContentConfig, z } from '@nuxt/content'
+import { defineCollection, defineContentConfig } from '@nuxt/content'
+import { z } from 'zod'
 
 export default defineContentConfig({
   collections: {

--- a/docs/content/docs/8.advanced/6.custom-source.md
+++ b/docs/content/docs/8.advanced/6.custom-source.md
@@ -27,7 +27,8 @@ const hackernewsSource = defineCollectionSource({
 Then you can use this source in your collections.
 
 ```ts [content.config.ts]
-import { defineContentConfig, defineCollectionSource, defineCollection, z } from '@nuxt/content'
+import { defineContentConfig, defineCollectionSource, defineCollection } from '@nuxt/content'
+import { z } from 'zod'
 
 const hackernewsSource = defineCollectionSource({
   getKeys: () => {

--- a/docs/content/docs/9.studio/3.content.md
+++ b/docs/content/docs/9.studio/3.content.md
@@ -175,11 +175,11 @@ export default defineContentConfig({
         category: z.enum(['Alps', 'Himalaya', 'Pyrenees']).optional(),
         date: z.date(),
         image: z.object({
-          src: z.string().editor({ input: 'media' }),
+          src: property(z.string()).editor({ input: 'media' }),
           alt: z.string(),
         }),
-        slug: z.string().editor({ hidden: true }),
-        icon: z.string().optional().editor({ input: 'icon' }),
+        slug: property(z.string()).editor({ hidden: true }),
+        icon: property(z.string().optional()).editor({ input: 'icon' }),
         authors: z.array(z.object({
           slug: z.string(),
           username: z.string(),
@@ -225,10 +225,10 @@ This allows you to define custom inputs or hide fields.
 
 ```ts [content.config.ts]
 // Icon
-icon: z.string().editor({ input: 'icon', iconLibraries: ['lucide', 'simple-icons'] })
+icon: property(z.string()).editor({ input: 'icon', iconLibraries: ['lucide', 'simple-icons'] })
 
 // Media
-image: z.string().editor({ input: 'media' })
+image: property(z.string()).editor({ input: 'media' })
 ```
 
 #### Options

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -326,7 +326,8 @@ orientation: horizontal
     label: content.config.ts
     ---
     ```ts [content.config.ts]
-    import { defineContentConfig, defineCollection, z } from '@nuxt/content'
+    import { defineContentConfig, defineCollection } from '@nuxt/content'
+    import { z } from 'zod'
 
     export default defineContentConfig({
       collections: {

--- a/examples/blog/content.config.ts
+++ b/examples/blog/content.config.ts
@@ -1,4 +1,5 @@
-import { defineCollection, defineContentConfig, z } from '@nuxt/content'
+import { defineCollection, defineContentConfig } from '@nuxt/content'
+import { z } from 'zod'
 
 export default defineContentConfig({
   collections: {

--- a/examples/i18n/content.config.ts
+++ b/examples/i18n/content.config.ts
@@ -1,4 +1,5 @@
-import { defineCollection, defineContentConfig, z } from '@nuxt/content'
+import { defineCollection, defineContentConfig } from '@nuxt/content'
+import { z } from 'zod'
 
 const commonSchema = z.object({})
 

--- a/playground/content.config.ts
+++ b/playground/content.config.ts
@@ -1,4 +1,5 @@
-import { defineContentConfig, defineCollectionSource, defineCollection, z, property } from '@nuxt/content'
+import { defineContentConfig, defineCollectionSource, defineCollection, property } from '@nuxt/content'
+import { z } from 'zod'
 
 const hackernews = defineCollection({
   type: 'data',


### PR DESCRIPTION
This PR updates the migration guide for the deprecations (`z` re-export and direct `.editor()` usage). It would be good to mention this in the [release notes](https://github.com/nuxt/content/releases/tag/v3.7.0) for the version so users are aware of the changes.

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
