### PR TITLE
docs: Clarify Cloudflare Pages and D1

### DIFF
--- a/docs/content/docs/6.deploy/4.cloudflare-pages.md
+++ b/docs/content/docs/6.deploy/4.cloudflare-pages.md
@@ -28,11 +28,13 @@ export default defineNuxtConfig({
 ```
 
 ## D1 Database
+
 A D1 database connected to the app is **required** for the Nuxt Content module to work. By default the module uses the binding name **`DB`**. You can override the [database configuration](/docs/getting-started/configuration#d1) by providing your own in `nuxt.config.ts`.
 
 After creating a new Cloudflare Pages project, you need to create a new D1 database and connect it to the project. Make sure to use the same binding name as the module is using.
 
 ### Local Preview
+
 While `nuxi dev` and `nuxi build` don't require any extra configuration, testing a build locally with `nuxi preview` requires Cloudflare's Wrangler to be configured to provide a temporary, local database for Nuxt Content to bind. This can be done with a `wrangler.jsonc` or `wrangler.toml` file. Because Wrangler creates a local database, `database_name` and `database_id` can safely, but don't need to, match the values in production.
 
 ```jsonc [wrangler.jsonc]
@@ -53,5 +55,5 @@ Relevant resources:
 
 - [Nuxt Deploy documentation](https://nuxt.com/deploy/cloudflare)
 - [Cloudflare D1 documentation](https://developers.cloudflare.com/d1/)
-  - [Create and bind a D1 database](https://developers.cloudflare.com/d1/get-started/)
+- [Create and bind a D1 database](https://developers.cloudflare.com/d1/get-started/)
 - [Cloudflare Pages documentation](https://developers.cloudflare.com/pages/)


### PR DESCRIPTION
Emphasize the necessity of creating a D1 database and how to configure wrangler so `nuxi preview` works.

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

#### Changes
<!-- Describe your changes in detail -->
- Places more emphasis on a D1 database being required
- Provides a minimal example wrangler config for running preview locally
- Explains what this example config does
- Links to Nuxt Content's docs section for D1 configuration
- Links more directly to Cloudflare's documentation about creating and binding a D1 database

#### Why
<!-- Why is this change required? What problem does it solve? -->
My initial reading of the statement that the module will "prepare the necessary configuration" caused me to misunderstand the importance of D1 being required. I think the new emphasis should help prevent that misreading.

I also had trouble running `nuxi preview` locally to check a mismatch between local and prod behavior. I no longer recall if `nuxi preview` actually helped me solve my problems, but I suspect other people probably don't want to be stuck configuring preview when they think it will help debugging something else.

For context, the issues I was debugging (and have since resolved) were:
- Some content not loading correctly. This was likely because another source told me to use generate instead of build, and I then also didn't have D1 set up.
- An infinite 404 loop. This was likely caused by the fact that I didn't have an error.vue file and the fact that my default slug was throwing a 404 when content was missing. But local dev was ok because it provides an error page.
- A file I created postbuild wasn't being added to _routes, because _routes is created during build and I didn't understand that part of Cloudflare enough to expect the issue.

<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
