### PR TITLE
perf: replace internal object records with maps

### DIFF
--- a/src/runtime/internal/database.client.ts
+++ b/src/runtime/internal/database.client.ts
@@ -10,20 +10,22 @@ const loadedCollections = new Map<string, string>()
 const dbPromises = new Map<string, Promise<Database>>()
 export function loadDatabaseAdapter<T>(collection: T): DatabaseAdapter {
   async function loadAdapter(collection: T) {
+    const collectionKey = String(collection)
     if (!db) {
       if (!dbPromises.has('_')) {
         dbPromises.set('_', initializeDatabase())
       }
       db = await dbPromises.get('_')!
-      Reflect.deleteProperty(dbPromises, '_')
+      dbPromises.delete('_')
     }
-    if (!loadedCollections.has(String(collection))) {
-      if (!dbPromises.has(String(collection))) {
-        dbPromises.set(String(collection), loadCollectionDatabase(collection))
+    if (!loadedCollections.has(collectionKey)) {
+      if (!dbPromises.has(collectionKey)) {
+        dbPromises.set(collectionKey, loadCollectionDatabase(collection))
       }
-      await dbPromises.get(String(collection))
-      loadedCollections.set(String(collection), 'loaded')
-      dbPromises.delete(String(collection))
+
+      await dbPromises.get(collectionKey)
+      loadedCollections.set(collectionKey, 'loaded')
+      dbPromises.delete(collectionKey)
     }
 
     return db


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

I was actually looking for other things and came across these improvements. In some places, you could certainly use a map instead of an object record, but that would then affect some exported APIs.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
