### PR TITLE
feat: add support for abort signals in async data fetching

### DIFF
--- a/docs/app/components/PostPage.vue
+++ b/docs/app/components/PostPage.vue
@@ -11,9 +11,9 @@ const { type } = defineProps({
 const route = useRoute()
 const siteConfig = useSiteConfig()
 
-const { data } = await useAsyncData(route.path, () => Promise.all([
-  queryCollection('posts').path(route.path).first(),
-  queryCollectionItemSurroundings('posts', route.path, { fields: ['title', 'description'] })
+const { data } = await useAsyncData(route.path, (_nuxtApp, { signal }) => Promise.all([
+  queryCollection('posts').path(route.path).first({ signal }),
+  queryCollectionItemSurroundings('posts', route.path, { fields: ['title', 'description'] }, { signal })
     .where('path', 'LIKE', `/${type}%`)
     .where('draft', '=', 0)
     .order('date', 'DESC'),

--- a/docs/app/components/example/ExampleFulltextFusejs.vue
+++ b/docs/app/components/example/ExampleFulltextFusejs.vue
@@ -2,7 +2,7 @@
 import Fuse from 'fuse.js'
 
 const query = ref('')
-const { data } = await useAsyncData('search-data', () => queryCollectionSearchSections('docs'))
+const { data } = await useAsyncData('search-data', (_nuxtApp, { signal }) => queryCollectionSearchSections('docs', { signal }))
 
 const fuse = new Fuse(data.value || [], {
   keys: [

--- a/docs/app/components/example/ExampleFulltextMiniSearch.vue
+++ b/docs/app/components/example/ExampleFulltextMiniSearch.vue
@@ -2,7 +2,7 @@
 import MiniSearch from 'minisearch'
 
 const query = ref('')
-const { data } = await useAsyncData('search-data', () => queryCollectionSearchSections('docs'))
+const { data } = await useAsyncData('search-data', (_nuxtApp, { signal }) => queryCollectionSearchSections('docs', { signal }))
 
 const miniSearch = new MiniSearch({
   fields: ['title', 'content'],

--- a/docs/app/pages/blog/index.vue
+++ b/docs/app/pages/blog/index.vue
@@ -3,16 +3,16 @@ import { titleCase } from 'scule'
 
 const siteConfig = useSiteConfig()
 
-const { data: page } = await useAsyncData('blog-landing', () => queryCollection('landing').path('/blog').first())
+const { data: page } = await useAsyncData('blog-landing', (_nuxtApp, { signal }) => queryCollection('landing').path('/blog').first({ signal }))
 if (!page.value) {
   throw createError({ statusCode: 404, statusMessage: 'Page not found', fatal: true })
 }
 
-const { data: posts } = await useAsyncData('blog-posts', () => queryCollection('posts')
+const { data: posts } = await useAsyncData('blog-posts', (_nuxtApp, { signal }) => queryCollection('posts')
   .where('path', 'LIKE', '/blog%')
   .where('draft', '=', 0)
   .order('date', 'DESC')
-  .all(),
+  .all({ signal }),
 )
 
 useSeoMeta({

--- a/docs/app/pages/changelog/index.vue
+++ b/docs/app/pages/changelog/index.vue
@@ -11,16 +11,16 @@ const { isScrolling, arrivedState } = useScroll(document)
 
 const siteConfig = useSiteConfig()
 
-const { data: page } = await useAsyncData('changelog-landing', () => queryCollection('landing').path('/changelog').first())
+const { data: page } = await useAsyncData('changelog-landing', (_nuxtApp, { signal }) => queryCollection('landing').path('/changelog').first({ signal }))
 if (!page.value) {
   throw createError({ statusCode: 404, statusMessage: 'Page not found', fatal: true })
 }
 
-const { data: posts } = await useAsyncData('changelog-posts', () => queryCollection('posts')
+const { data: posts } = await useAsyncData('changelog-posts', (_nuxtApp, { signal }) => queryCollection('posts')
   .where('path', 'LIKE', '/changelog%')
   .where('draft', '=', 0)
   .order('date', 'DESC')
-  .all(),
+  .all({ signal }),
 )
 
 useSeoMeta({

--- a/docs/app/pages/studio/index.vue
+++ b/docs/app/pages/studio/index.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 const siteConfig = useSiteConfig()
 
-const { data: page } = await useAsyncData('studio-landing', () => queryCollection('landing').path('/studio').first())
+const { data: page } = await useAsyncData('studio-landing', (_nuxtApp, { signal }) => queryCollection('landing').path('/studio').first({ signal }))
 if (!page.value) {
   throw createError({ statusCode: 404, statusMessage: 'Page not found', fatal: true })
 }

--- a/docs/app/pages/studio/pricing.vue
+++ b/docs/app/pages/studio/pricing.vue
@@ -4,7 +4,7 @@ import type { TableColumn } from '@nuxt/ui'
 const siteConfig = useSiteConfig()
 const UIcon = resolveComponent('UIcon')
 
-const { data: page } = await useAsyncData('pricing-landing', () => queryCollection('pricing').path('/studio/pricing').first())
+const { data: page } = await useAsyncData('pricing-landing', (_nuxtApp, { signal }) => queryCollection('pricing').path('/studio/pricing').first({ signal }))
 if (!page.value) {
   throw createError({ statusCode: 404, statusMessage: 'Page not found', fatal: true })
 }

--- a/docs/app/pages/templates/[slug].vue
+++ b/docs/app/pages/templates/[slug].vue
@@ -2,7 +2,7 @@
 const route = useRoute()
 const siteConfig = useSiteConfig()
 
-const { data: template } = await useAsyncData(`template-${route.params.slug}`, () => queryCollection('templates').path(route.path).first())
+const { data: template } = await useAsyncData(`template-${route.params.slug}`, (_nuxtApp, { signal }) => queryCollection('templates').path(route.path).first({ signal }))
 if (!template.value) {
   showError({ statusCode: 404, statusMessage: 'Template Not Found' })
 }

--- a/docs/app/pages/templates/index.vue
+++ b/docs/app/pages/templates/index.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
 const siteConfig = useSiteConfig()
 
-const { data: page } = await useAsyncData('templates-landing', () => queryCollection('landing').path('/templates').first())
+const { data: page } = await useAsyncData('templates-landing', (_nuxtApp, { signal }) => queryCollection('landing').path('/templates').first({ signal }))
 if (!page.value) {
   throw createError({ statusCode: 404, statusMessage: 'Page not found', fatal: true })
 }
 
-const { data: templates } = await useAsyncData('templates', () => queryCollection('templates').where('draft', '=', 0).all())
+const { data: templates } = await useAsyncData('templates', (_nuxtApp, { signal }) => queryCollection('templates').where('draft', '=', 0).all({ signal }))
 
 useSeoMeta({
   title: page.value.seo?.title,

--- a/examples/basic/app/pages/[...slug].vue
+++ b/examples/basic/app/pages/[...slug].vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 const route = useRoute()
 
-const { data: page } = await useAsyncData('page-' + route.path, () => {
-  return queryCollection('content').path(route.path).first()
+const { data: page } = await useAsyncData('page-' + route.path, (_nuxtApp, { signal }) => {
+  return queryCollection('content').path(route.path).first({ signal })
 })
 if (!page.value) {
   throw createError({ statusCode: 404, statusMessage: 'Page not found', fatal: true })

--- a/examples/blog/app/pages/[...slug].vue
+++ b/examples/blog/app/pages/[...slug].vue
@@ -1,10 +1,10 @@
 <script lang="ts" setup>
 const route = useRoute()
 const pageId = computed(() => 'blog-' + route.path)
-const { data: post } = await useAsyncData(pageId, () => {
+const { data: post } = await useAsyncData(pageId, (_nuxtApp, { signal }) => {
   return queryCollection('blog')
     .path(route.path)
-    .first()
+    .first({ signal })
 })
 </script>
 

--- a/examples/i18n/app/pages/[...slug].vue
+++ b/examples/i18n/app/pages/[...slug].vue
@@ -6,9 +6,9 @@ const route = useRoute()
 const { locale, localeProperties } = useI18n()
 const slug = computed(() => withLeadingSlash(String(route.params.slug)))
 
-const { data: page } = await useAsyncData('page-' + slug.value, async () => {
+const { data: page } = await useAsyncData('page-' + slug.value, async (_nuxtApp, { signal }) => {
   const collection = ('content_' + locale.value) as keyof Collections
-  const content = await queryCollection(collection).path(slug.value).first()
+  const content = await queryCollection(collection).path(slug.value).first({ signal })
 
   // Possibly fallback to default locale if content is missing in non-default locale
 

--- a/examples/ui/app/pages/[...slug].vue
+++ b/examples/ui/app/pages/[...slug].vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 const route = useRoute()
 
-const { data: page } = await useAsyncData('page-' + route.path, () => {
-  return queryCollection('content').path(route.path).first()
+const { data: page } = await useAsyncData('page-' + route.path, (_nuxtApp, { signal }) => {
+  return queryCollection('content').path(route.path).first({ signal })
 })
 if (!page.value) {
   throw createError({ statusCode: 404, statusMessage: 'Page not found', fatal: true })

--- a/playground/pages/[...slug].vue
+++ b/playground/pages/[...slug].vue
@@ -1,16 +1,17 @@
 <script setup lang="ts">
 const route = useRoute()
 
-const { data: navigation } = await useAsyncData('contents-list', () => queryCollectionNavigation('content'))
-const { data } = await useAsyncData(() => 'posts' + route.path, async () => {
-  return await queryCollection('content').path(route.path).first()
+const { data: navigation } = await useAsyncData('contents-list', (_nuxtApp, { signal }) => queryCollectionNavigation('content', [], { signal }))
+const { data } = await useAsyncData(() => 'posts' + route.path, async (_nuxtApp, { signal }) => {
+  return await queryCollection('content').path(route.path).first({ signal })
 })
 
-const { data: surround } = await useAsyncData(() => 'content-surround' + route.path, () => {
+const { data: surround } = await useAsyncData(() => 'content-surround' + route.path, (_nuxtApp, { signal }) => {
   return queryCollectionItemSurroundings('content', route.path, {
     before: 1,
     after: 1,
     fields: ['title', 'description'],
+    signal,
   })
 })
 </script>

--- a/playground/pages/content-v2/[...slug].vue
+++ b/playground/pages/content-v2/[...slug].vue
@@ -1,16 +1,17 @@
 <script setup lang="ts">
 const route = useRoute()
 
-const { data: navigation } = await useAsyncData('contents-v2-list', () => queryCollectionNavigation('contentV2'))
-const { data } = await useAsyncData('posts' + route.path, async () => {
-  return await queryCollection('contentV2').path(route.path).first()
+const { data: navigation } = await useAsyncData('contents-v2-list', (_nuxtApp, { signal }) => queryCollectionNavigation('contentV2', { signal }))
+const { data } = await useAsyncData('posts' + route.path, async (_nuxtApp, { signal }) => {
+  return await queryCollection('contentV2').path(route.path).first({ signal })
 })
 
-const { data: surround } = await useAsyncData('content-v2-docs-surround' + route.path, () => {
+const { data: surround } = await useAsyncData('content-v2-docs-surround' + route.path, (_nuxtApp, { signal }) => {
   return queryCollectionItemSurroundings('contentV2', route.path, {
     before: 1,
     after: 1,
     fields: ['title', 'description'],
+    signal,
   })
 })
 

--- a/playground/pages/data/[...slug].vue
+++ b/playground/pages/data/[...slug].vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
 const route = useRoute()
-const { data } = await useAsyncData('data', () => queryCollection('data').path(route.path).first())
+const { data } = await useAsyncData('data', (_nuxtApp, { signal }) => queryCollection('data').path(route.path).first({ signal }))
 </script>
 
 <template>

--- a/playground/pages/hackernews/[...slug].vue
+++ b/playground/pages/hackernews/[...slug].vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
 const route = useRoute()
 
-const { data } = await useAsyncData('news' + route.path, async () => {
+const { data } = await useAsyncData('news' + route.path, async (_nuxtApp, { signal }) => {
   if (route.path === '/hackernews') {
-    return await queryCollection('hackernews').all()
+    return await queryCollection('hackernews').all({ signal })
   }
 
-  return await queryCollection('hackernews').where('id', '=', route.params.slug).first()
+  return await queryCollection('hackernews').where('id', '=', route.params.slug).first({ signal })
 })
 </script>
 

--- a/playground/pages/nuxt/[...slug].vue
+++ b/playground/pages/nuxt/[...slug].vue
@@ -1,16 +1,17 @@
 <script setup lang="ts">
 const route = useRoute()
 
-const { data: navigation } = await useAsyncData('nuxt-contents-list', () => queryCollectionNavigation('nuxt'))
-const { data } = await useAsyncData('posts' + route.path, async () => {
-  return await queryCollection('nuxt').path(route.path).first()
+const { data: navigation } = await useAsyncData('nuxt-contents-list', (_nuxtApp, { signal }) => queryCollectionNavigation('nuxt', [], { signal }))
+const { data } = await useAsyncData('posts' + route.path, async (_nuxtApp, { signal }) => {
+  return await queryCollection('nuxt').path(route.path).first({ signal })
 })
 
-const { data: surround } = await useAsyncData('nuxt-docs-surround' + route.path, () => {
+const { data: surround } = await useAsyncData('nuxt-docs-surround' + route.path, (_nuxtApp, { signal }) => {
   return queryCollectionItemSurroundings('nuxt', route.path, {
     before: 1,
     after: 1,
     fields: ['title', 'description'],
+    signal,
   })
 })
 </script>

--- a/playground/pages/vue/[...slug].vue
+++ b/playground/pages/vue/[...slug].vue
@@ -1,16 +1,17 @@
 <script setup lang="ts">
 const route = useRoute()
 
-const { data: navigation } = await useAsyncData('vue-contents-list', () => queryCollectionNavigation('vue'))
-const { data } = await useAsyncData('posts' + route.path, async () => {
-  return await queryCollection('vue').path(route.path).first()
+const { data: navigation } = await useAsyncData('vue-contents-list', (_nuxtApp, { signal }) => queryCollectionNavigation('vue', [], { signal }))
+const { data } = await useAsyncData('posts' + route.path, async (_nuxtApp, { signal }) => {
+  return await queryCollection('vue').path(route.path).first({ signal })
 })
 
-const { data: surround } = await useAsyncData('vue-docs-surround' + route.path, () => {
+const { data: surround } = await useAsyncData('vue-docs-surround' + route.path, (_nuxtApp, { signal }) => {
   return queryCollectionItemSurroundings('vue', route.path, {
     before: 1,
     after: 1,
     fields: ['title', 'description'],
+    signal,
   })
 })
 </script>

--- a/src/runtime/client.ts
+++ b/src/runtime/client.ts
@@ -16,36 +16,55 @@ interface ChainablePromise<T extends keyof PageCollections, R> extends Promise<R
 
 export const queryCollection = <T extends keyof Collections>(collection: T): CollectionQueryBuilder<Collections[T]> => {
   const event = tryUseNuxtApp()?.ssrContext?.event
-  return collectionQueryBuilder<T>(collection, (collection, sql) => executeContentQuery(event, collection, sql))
+  return collectionQueryBuilder<T>(collection, (collection, sql, opts) => executeContentQuery(event, collection, sql, { signal: opts?.signal }))
 }
 
-export function queryCollectionNavigation<T extends keyof PageCollections>(collection: T, fields?: Array<keyof PageCollections[T]>): ChainablePromise<T, ContentNavigationItem[]> {
-  return chainablePromise(collection, qb => generateNavigationTree(qb, fields))
+export interface QueryCollectionNavigationOptions {
+  signal?: AbortSignal
 }
 
-export function queryCollectionItemSurroundings<T extends keyof PageCollections>(collection: T, path: string, opts?: SurroundOptions<keyof PageCollections[T]>): ChainablePromise<T, ContentNavigationItem[]> {
+export function queryCollectionNavigation<T extends keyof PageCollections>(collection: T, fields?: Array<keyof PageCollections[T]>, { signal }: QueryCollectionNavigationOptions = {}): ChainablePromise<T, ContentNavigationItem[]> {
+  return chainablePromise(collection, qb => generateNavigationTree(qb, fields, { signal }))
+}
+
+export interface QueryCollectionItemSurroundingsOptions<F> extends SurroundOptions<F> {
+  signal?: AbortSignal
+}
+
+export function queryCollectionItemSurroundings<T extends keyof PageCollections>(collection: T, path: string, opts?: QueryCollectionItemSurroundingsOptions<keyof PageCollections[T]>): ChainablePromise<T, ContentNavigationItem[]> {
   return chainablePromise(collection, qb => generateItemSurround(qb, path, opts))
 }
 
-export function queryCollectionSearchSections(collection: keyof Collections, opts?: { ignoredTags: string[] }) {
+export interface QueryCollectionSearchSectionsOptions {
+  ignoredTags?: string[]
+  signal?: AbortSignal
+}
+
+export function queryCollectionSearchSections(collection: keyof Collections, opts?: QueryCollectionSearchSectionsOptions) {
   return chainablePromise(collection, qb => generateSearchSections(qb, opts))
 }
 
-async function executeContentQuery<T extends keyof Collections, Result = Collections[T]>(event: H3Event | undefined, collection: T, sql: string) {
+async function executeContentQuery<T extends keyof Collections, Result = Collections[T]>(event: H3Event | undefined, collection: T, sql: string, { signal }: { signal?: AbortSignal } = {}): Promise<Result[]> {
   if (import.meta.client && window.WebAssembly) {
-    return queryContentSqlClientWasm<T, Result>(collection, sql) as Promise<Result[]>
+    return queryContentSqlClientWasm<T, Result>(collection, sql, { signal }) as Promise<Result[]>
   }
   else {
-    return fetchQuery(event, String(collection), sql) as Promise<Result[]>
+    return fetchQuery(event, String(collection), sql, { signal })
   }
 }
 
-async function queryContentSqlClientWasm<T extends keyof Collections, Result = Collections[T]>(collection: T, sql: string) {
-  const rows = await import('./internal/database.client')
-    .then(m => m.loadDatabaseAdapter(collection))
-    .then(db => db.all<Result>(sql))
-
-  return rows as Result[]
+async function queryContentSqlClientWasm<T extends keyof Collections, Result = Collections[T]>(collection: T, sql: string, { signal }: { signal?: AbortSignal } = {}): Promise<Result[]> {
+  return new Promise<Result[]>((resolve, reject) => {
+    // todo: explore aborting wasm queries with signal
+    signal?.addEventListener('abort', () => {
+      reject(new DOMException('Aborted', 'AbortError'))
+    })
+    import('./internal/database.client')
+      .then(m => m.loadDatabaseAdapter(collection))
+      .then(db => db.all<Result>(sql))
+      .then(resolve)
+      .catch(reject)
+  })
 }
 
 function chainablePromise<T extends keyof PageCollections, Result>(collection: T, fn: (qb: CollectionQueryBuilder<PageCollections[T]>) => Promise<Result>) {

--- a/src/runtime/internal/api.ts
+++ b/src/runtime/internal/api.ts
@@ -13,7 +13,11 @@ export async function fetchDatabase(event: H3Event | undefined, collection: stri
   })
 }
 
-export async function fetchQuery<Item>(event: H3Event | undefined, collection: string, sql: string): Promise<Item[]> {
+export interface FetchQueryOptions {
+  signal?: AbortSignal
+}
+
+export async function fetchQuery<Item>(event: H3Event | undefined, collection: string, sql: string, { signal }: FetchQueryOptions = {}): Promise<Item[]> {
   return await $fetch(`/__nuxt_content/${collection}/query`, {
     context: event ? { cloudflare: event.context.cloudflare } : {},
     headers: {
@@ -25,5 +29,6 @@ export async function fetchQuery<Item>(event: H3Event | undefined, collection: s
     body: {
       sql,
     },
+    signal,
   })
 }

--- a/src/runtime/internal/navigation.ts
+++ b/src/runtime/internal/navigation.ts
@@ -5,22 +5,22 @@ import type { ContentNavigationItem, PageCollectionItemBase, CollectionQueryBuil
 /**
  * Create NavItem array to be consumed from runtime plugin.
  */
-export async function generateNavigationTree<T extends PageCollectionItemBase>(queryBuilder: CollectionQueryBuilder<T>, extraFields: Array<keyof T> = []) {
+export async function generateNavigationTree<T extends PageCollectionItemBase>(queryBuilder: CollectionQueryBuilder<T>, extraFields: Array<keyof T> = [], { signal }: { signal?: AbortSignal } = {}): Promise<ContentNavigationItem[]> {
   // @ts-expect-error -- internal
   const params = queryBuilder.__params
   if (!params?.orderBy?.length) {
     queryBuilder = queryBuilder.order('stem', 'ASC')
   }
 
-  const collecitonItems = await queryBuilder
+  const collectionItems = await queryBuilder
     .orWhere(group => group
       .where('navigation', '<>', 'false')
       .where('navigation', 'IS NULL'),
     )
     .select('navigation', 'stem', 'path', 'title', 'meta', ...(extraFields || []))
-    .all() as unknown as PageCollectionItemBase[]
+    .all({ signal }) as unknown as PageCollectionItemBase[]
 
-  const { contents, configs } = collecitonItems.reduce((acc, c) => {
+  const { contents, configs } = collectionItems.reduce((acc, c) => {
     if (String(c.stem).split('/').pop() === '.navigation') {
       c.title = c.title?.toLowerCase() === 'navigation' ? '' : c.title
       const key = c.path!.split('/').slice(0, -1).join('/') || '/'

--- a/src/runtime/internal/query.ts
+++ b/src/runtime/internal/query.ts
@@ -69,7 +69,7 @@ export const collectionQueryGroup = <T extends keyof Collections>(collection: T)
   return query
 }
 
-export const collectionQueryBuilder = <T extends keyof Collections>(collection: T, fetch: (collection: T, sql: string) => Promise<Collections[T][]>): CollectionQueryBuilder<Collections[T]> => {
+export const collectionQueryBuilder = <T extends keyof Collections>(collection: T, fetch: (collection: T, sql: string, opts: { signal?: AbortSignal }) => Promise<Collections[T][]>): CollectionQueryBuilder<Collections[T]> => {
   const params = {
     conditions: [] as Array<string>,
     selectedFields: [] as Array<keyof Collections[T]>,
@@ -121,16 +121,16 @@ export const collectionQueryBuilder = <T extends keyof Collections>(collection: 
       params.orderBy.push(`"${String(field)}" ${direction}`)
       return query
     },
-    async all(): Promise<Collections[T][]> {
-      return fetch(collection, buildQuery()).then(res => (res || []) as Collections[T][])
+    async all({ signal }: { signal?: AbortSignal } = {}): Promise<Collections[T][]> {
+      return fetch(collection, buildQuery(), { signal }).then(res => (res || []) as Collections[T][])
     },
-    async first(): Promise<Collections[T] | null> {
-      return fetch(collection, buildQuery({ limit: 1 })).then(res => res[0] || null)
+    async first({ signal }: { signal?: AbortSignal } = {}): Promise<Collections[T] | null> {
+      return fetch(collection, buildQuery({ limit: 1 }), { signal }).then(res => res[0] || null)
     },
-    async count(field: keyof Collections[T] | '*' = '*', distinct: boolean = false) {
+    async count(field: keyof Collections[T] | '*' = '*', distinct: boolean = false, { signal }: { signal?: AbortSignal } = {}) {
       return fetch(collection, buildQuery({
         count: { field: String(field), distinct },
-      })).then(m => (m[0] as { count: number }).count)
+      }), { signal }).then(m => (m[0] as { count: number }).count)
     },
   }
 

--- a/src/runtime/internal/search.ts
+++ b/src/runtime/internal/search.ts
@@ -27,13 +27,19 @@ interface SectionablePage {
   body: MDCRoot | MinimarkTree
 }
 
-export async function generateSearchSections<T extends PageCollectionItemBase>(queryBuilder: CollectionQueryBuilder<T>, opts?: { ignoredTags?: string[], extraFields?: Array<keyof T> }) {
-  const { ignoredTags = [], extraFields = [] } = opts || {}
+export interface GenerateSearchSectionsOptions<F> {
+  ignoredTags?: string[]
+  extraFields?: Array<F>
+  signal?: AbortSignal
+}
+
+export async function generateSearchSections<T extends PageCollectionItemBase>(queryBuilder: CollectionQueryBuilder<T>, opts?: GenerateSearchSectionsOptions<keyof T>) {
+  const { ignoredTags = [], extraFields = [], signal } = opts || {}
 
   const documents = await queryBuilder
     .where('extension', '=', 'md')
     .select('path', 'body', 'description', 'title', ...(extraFields || []))
-    .all()
+    .all({ signal })
 
   return documents.flatMap(doc => splitPageIntoSections(doc, { ignoredTags, extraFields: extraFields as string[] }))
 }

--- a/src/runtime/internal/surround.ts
+++ b/src/runtime/internal/surround.ts
@@ -2,9 +2,13 @@ import { generateNavigationTree } from './navigation'
 import type { ContentNavigationItem, PageCollectionItemBase, SurroundOptions } from '@nuxt/content'
 import type { CollectionQueryBuilder } from '~/src/types'
 
-export async function generateItemSurround<T extends PageCollectionItemBase>(queryBuilder: CollectionQueryBuilder<T>, path: string, opts?: SurroundOptions<keyof T>) {
+export interface GenerateItemSurroundOptions<F> extends SurroundOptions<F> {
+  signal?: AbortSignal
+}
+
+export async function generateItemSurround<T extends PageCollectionItemBase>(queryBuilder: CollectionQueryBuilder<T>, path: string, opts?: GenerateItemSurroundOptions<keyof T>) {
   const { before = 1, after = 1, fields = [] } = opts || {}
-  const navigation = await generateNavigationTree(queryBuilder, fields)
+  const navigation = await generateNavigationTree(queryBuilder, fields, { signal: opts?.signal })
 
   const flatData = flattedData(navigation)
   const index = flatData.findIndex(item => item.path === path)

--- a/src/types/query.ts
+++ b/src/types/query.ts
@@ -8,9 +8,9 @@ export interface CollectionQueryBuilder<T> {
   order(field: keyof T, direction: 'ASC' | 'DESC'): CollectionQueryBuilder<T>
   skip(skip: number): CollectionQueryBuilder<T>
   limit(limit: number): CollectionQueryBuilder<T>
-  all(): Promise<T[]>
-  first(): Promise<T | null>
-  count(field?: keyof T | '*', distinct?: boolean): Promise<number>
+  all(opts?: { signal?: AbortSignal }): Promise<T[]>
+  first(opts?: { signal?: AbortSignal }): Promise<T | null>
+  count(field?: keyof T | '*', distinct?: boolean, opts?: { signal?: AbortSignal }): Promise<number>
   where(field: string, operator: SQLOperator, value?: unknown): CollectionQueryBuilder<T>
   andWhere(groupFactory: QueryGroupFunction<T>): CollectionQueryBuilder<T>
   orWhere(groupFactory: QueryGroupFunction<T>): CollectionQueryBuilder<T>

--- a/test/unit/collectionQueryBuilder.test.ts
+++ b/test/unit/collectionQueryBuilder.test.ts
@@ -12,7 +12,7 @@ vi.mock('#content/manifest', () => ({
 const mockFetch = vi.fn().mockResolvedValue(Promise.resolve([{}]))
 const mockCollection = 'articles' as never
 
-describe('collectionQueryBuilder', () => {
+describe.only('collectionQueryBuilder', () => {
   beforeEach(() => {
     mockFetch.mockClear()
   })
@@ -21,17 +21,34 @@ describe('collectionQueryBuilder', () => {
     const query = collectionQueryBuilder(mockCollection, mockFetch)
     await query.all()
 
-    expect(mockFetch).toHaveBeenCalledWith('articles', 'SELECT * FROM _articles ORDER BY stem ASC')
+    expect(mockFetch.mock.calls).toMatchInlineSnapshot(`
+      [
+        [
+          "articles",
+          "SELECT * FROM _articles ORDER BY stem ASC",
+          {
+            "signal": undefined,
+          },
+        ],
+      ]
+    `)
   })
 
   it('builds query with where clause', async () => {
     const query = collectionQueryBuilder(mockCollection, mockFetch)
     await query.where('title', '=', 'Test Article').all()
 
-    expect(mockFetch).toHaveBeenCalledWith(
-      'articles',
-      'SELECT * FROM _articles WHERE ("title" = \'Test Article\') ORDER BY stem ASC',
-    )
+    expect(mockFetch.mock.calls).toMatchInlineSnapshot(`
+      [
+        [
+          "articles",
+          "SELECT * FROM _articles WHERE ("title" = 'Test Article') ORDER BY stem ASC",
+          {
+            "signal": undefined,
+          },
+        ],
+      ]
+    `)
   })
 
   it('builds query with multiple where clauses', async () => {
@@ -41,10 +58,17 @@ describe('collectionQueryBuilder', () => {
       .where('published', '=', true)
       .all()
 
-    expect(mockFetch).toHaveBeenCalledWith(
-      'articles',
-      'SELECT * FROM _articles WHERE ("title" = \'Test Article\') AND ("published" = \'1\') ORDER BY stem ASC',
-    )
+    expect(mockFetch.mock.calls).toMatchInlineSnapshot(`
+      [
+        [
+          "articles",
+          "SELECT * FROM _articles WHERE ("title" = 'Test Article') AND ("published" = '1') ORDER BY stem ASC",
+          {
+            "signal": undefined,
+          },
+        ],
+      ]
+    `)
   })
 
   it('builds query with IN operator', async () => {
@@ -53,10 +77,17 @@ describe('collectionQueryBuilder', () => {
       .where('category', 'IN', ['news', 'tech'])
       .all()
 
-    expect(mockFetch).toHaveBeenCalledWith(
-      'articles',
-      'SELECT * FROM _articles WHERE ("category" IN (\'news\', \'tech\')) ORDER BY stem ASC',
-    )
+    expect(mockFetch.mock.calls).toMatchInlineSnapshot(`
+      [
+        [
+          "articles",
+          "SELECT * FROM _articles WHERE ("category" IN ('news', 'tech')) ORDER BY stem ASC",
+          {
+            "signal": undefined,
+          },
+        ],
+      ]
+    `)
   })
 
   it('builds query with BETWEEN operator', async () => {
@@ -65,10 +96,17 @@ describe('collectionQueryBuilder', () => {
       .where('date', 'BETWEEN', ['2023-01-01', '2023-12-31'])
       .all()
 
-    expect(mockFetch).toHaveBeenCalledWith(
-      'articles',
-      'SELECT * FROM _articles WHERE ("date" BETWEEN \'2023-01-01\' AND \'2023-12-31\') ORDER BY stem ASC',
-    )
+    expect(mockFetch.mock.calls).toMatchInlineSnapshot(`
+      [
+        [
+          "articles",
+          "SELECT * FROM _articles WHERE ("date" BETWEEN '2023-01-01' AND '2023-12-31') ORDER BY stem ASC",
+          {
+            "signal": undefined,
+          },
+        ],
+      ]
+    `)
   })
 
   it('builds query with selected fields', async () => {
@@ -77,10 +115,17 @@ describe('collectionQueryBuilder', () => {
       .select('title', 'date', 'author')
       .all()
 
-    expect(mockFetch).toHaveBeenCalledWith(
-      'articles',
-      'SELECT "title", "date", "author" FROM _articles ORDER BY stem ASC',
-    )
+    expect(mockFetch.mock.calls).toMatchInlineSnapshot(`
+      [
+        [
+          "articles",
+          "SELECT "title", "date", "author" FROM _articles ORDER BY stem ASC",
+          {
+            "signal": undefined,
+          },
+        ],
+      ]
+    `)
   })
 
   it('builds query with order by', async () => {
@@ -89,10 +134,17 @@ describe('collectionQueryBuilder', () => {
       .order('date', 'DESC')
       .all()
 
-    expect(mockFetch).toHaveBeenCalledWith(
-      'articles',
-      'SELECT * FROM _articles ORDER BY "date" DESC',
-    )
+    expect(mockFetch.mock.calls).toMatchInlineSnapshot(`
+      [
+        [
+          "articles",
+          "SELECT * FROM _articles ORDER BY "date" DESC",
+          {
+            "signal": undefined,
+          },
+        ],
+      ]
+    `)
   })
 
   it('builds query with limit without skip', async () => {
@@ -101,10 +153,17 @@ describe('collectionQueryBuilder', () => {
       .limit(5)
       .all()
 
-    expect(mockFetch).toHaveBeenCalledWith(
-      'articles',
-      'SELECT * FROM _articles ORDER BY stem ASC LIMIT 5',
-    )
+    expect(mockFetch.mock.calls).toMatchInlineSnapshot(`
+      [
+        [
+          "articles",
+          "SELECT * FROM _articles ORDER BY stem ASC LIMIT 5",
+          {
+            "signal": undefined,
+          },
+        ],
+      ]
+    `)
   })
 
   it('builds query with limit and offset', async () => {
@@ -114,40 +173,68 @@ describe('collectionQueryBuilder', () => {
       .skip(20)
       .all()
 
-    expect(mockFetch).toHaveBeenCalledWith(
-      'articles',
-      'SELECT * FROM _articles ORDER BY stem ASC LIMIT 10 OFFSET 20',
-    )
+    expect(mockFetch.mock.calls).toMatchInlineSnapshot(`
+      [
+        [
+          "articles",
+          "SELECT * FROM _articles ORDER BY stem ASC LIMIT 10 OFFSET 20",
+          {
+            "signal": undefined,
+          },
+        ],
+      ]
+    `)
   })
 
   it('builds query with first()', async () => {
     const query = collectionQueryBuilder(mockCollection, mockFetch)
     await query.first()
 
-    expect(mockFetch).toHaveBeenCalledWith(
-      'articles',
-      'SELECT * FROM _articles ORDER BY stem ASC LIMIT 1',
-    )
+    expect(mockFetch.mock.calls).toMatchInlineSnapshot(`
+      [
+        [
+          "articles",
+          "SELECT * FROM _articles ORDER BY stem ASC LIMIT 1",
+          {
+            "signal": undefined,
+          },
+        ],
+      ]
+    `)
   })
 
   it('builds count query', async () => {
     const query = collectionQueryBuilder(mockCollection, mockFetch)
     await query.count()
 
-    expect(mockFetch).toHaveBeenCalledWith(
-      'articles',
-      'SELECT COUNT(*) as count FROM _articles ORDER BY stem ASC',
-    )
+    expect(mockFetch.mock.calls).toMatchInlineSnapshot(`
+      [
+        [
+          "articles",
+          "SELECT COUNT(*) as count FROM _articles ORDER BY stem ASC",
+          {
+            "signal": undefined,
+          },
+        ],
+      ]
+    `)
   })
 
   it('builds distinct count query', async () => {
     const query = collectionQueryBuilder(mockCollection, mockFetch)
     await query.count('author', true)
 
-    expect(mockFetch).toHaveBeenCalledWith(
-      'articles',
-      'SELECT COUNT(DISTINCT author) as count FROM _articles ORDER BY stem ASC',
-    )
+    expect(mockFetch.mock.calls).toMatchInlineSnapshot(`
+      [
+        [
+          "articles",
+          "SELECT COUNT(DISTINCT author) as count FROM _articles ORDER BY stem ASC",
+          {
+            "signal": undefined,
+          },
+        ],
+      ]
+    `)
   })
 
   it('builds query with complex where conditions using andWhere', async () => {
@@ -163,10 +250,17 @@ describe('collectionQueryBuilder', () => {
       )
       .all()
 
-    expect(mockFetch).toHaveBeenCalledWith(
-      'articles',
-      'SELECT * FROM _articles WHERE ("published" = \'1\') AND ("category" = \'tech\' AND ("tags" LIKE \'%javascript%\' OR "tags" LIKE \'%typescript%\')) ORDER BY stem ASC',
-    )
+    expect(mockFetch.mock.calls).toMatchInlineSnapshot(`
+      [
+        [
+          "articles",
+          "SELECT * FROM _articles WHERE ("published" = '1') AND ("category" = 'tech' AND ("tags" LIKE '%javascript%' OR "tags" LIKE '%typescript%')) ORDER BY stem ASC",
+          {
+            "signal": undefined,
+          },
+        ],
+      ]
+    `)
   })
 
   it('builds query with path', async () => {
@@ -175,9 +269,44 @@ describe('collectionQueryBuilder', () => {
       .path('/blog/my-article')
       .all()
 
-    expect(mockFetch).toHaveBeenCalledWith(
-      'articles',
-      'SELECT * FROM _articles WHERE ("path" = \'/blog/my-article\') ORDER BY stem ASC',
-    )
+    expect(mockFetch.mock.calls).toMatchInlineSnapshot(`
+      [
+        [
+          "articles",
+          "SELECT * FROM _articles WHERE ("path" = '/blog/my-article') ORDER BY stem ASC",
+          {
+            "signal": undefined,
+          },
+        ],
+      ]
+    `)
+  })
+
+  it.only('builds query with signal', async () => {
+    const query = collectionQueryBuilder(mockCollection, mockFetch)
+    const abortController = new AbortController()
+    await query
+      .where('title', '=', 'Test Article')
+      .all({ signal: abortController.signal })
+
+    expect(mockFetch.mock.calls).toMatchInlineSnapshot(`
+      [
+        [
+          "articles",
+          "SELECT * FROM _articles WHERE ("title" = 'Test Article') ORDER BY stem ASC",
+          {
+            "signal": AbortSignal {
+              Symbol(kEvents): Map {},
+              Symbol(events.maxEventTargetListeners): 0,
+              Symbol(events.maxEventTargetListenersWarned): false,
+              Symbol(kHandlers): Map {},
+              Symbol(kAborted): false,
+              Symbol(kReason): undefined,
+              Symbol(kComposite): false,
+            },
+          },
+        ],
+      ]
+    `)
   })
 })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

With [Nuxt 4.2.0](https://github.com/nuxt/nuxt/releases/tag/v4.2.0) it is possible to abort asyncData handlers. 

If this approach is approved, I will update the documentation.

> [!NOTE]
> This will benefit all remote queries, because WASM queries are not (yet?) cancellable.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
