### PR TITLE
fix: do not await nuxt.hook calls

### DIFF
--- a/src/utils/mdc.ts
+++ b/src/utils/mdc.ts
@@ -27,7 +27,7 @@ export async function installMDCModule(contentOptions: ModuleOptions, nuxt: Nuxt
   }, options.mdc) as MDCModuleOptions
 
   // Hook into mdc configs and store them for parser
-  await nuxt.hook('mdc:configSources', async (mdcConfigs) => {
+  nuxt.hook('mdc:configSources', async (mdcConfigs) => {
     if (mdcConfigs.length) {
       const jiti = createJiti(nuxt.options.rootDir)
       const configs = await Promise.all(mdcConfigs.map(path => jiti.import(path).then(m => (m as { default: MdcConfig }).default || m)))


### PR DESCRIPTION
### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`nuxt.hook` is not an async function so we do not need to await it.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
