### PR TITLE
perf: use `moduleDependencies` to install mdc module

### DIFF
--- a/src/utils/mdc.ts
+++ b/src/utils/mdc.ts
@@ -1,33 +1,13 @@
-import type { ModuleOptions as MDCModuleOptions, MdcConfig } from '@nuxtjs/mdc'
-import { defu } from 'defu'
+import type { MdcConfig } from '@nuxtjs/mdc'
 import type { Nuxt } from '@nuxt/schema'
-import { extendViteConfig, installModule } from '@nuxt/kit'
+import { extendViteConfig } from '@nuxt/kit'
 import { createJiti } from 'jiti'
 import type { ModuleOptions } from '../types'
 import { setParserOptions } from './content'
 
-export async function installMDCModule(contentOptions: ModuleOptions, nuxt: Nuxt) {
-  const options = nuxt.options as unknown as { mdc: MDCModuleOptions }
-  // Install mdc module
-  const highlight = contentOptions.build?.markdown?.highlight as unknown as MDCModuleOptions['highlight']
-
-  options.mdc = defu({
-    highlight: highlight !== false
-      ? { ...highlight, noApiRoute: (options.mdc?.highlight as { noApiRoute: boolean })?.noApiRoute ?? true }
-      : highlight,
-    components: {
-      prose: true,
-      map: contentOptions.renderer.alias,
-    },
-    headings: {
-      anchorLinks: contentOptions.renderer.anchorLinks,
-    },
-    remarkPlugins: contentOptions.build?.markdown?.remarkPlugins,
-    rehypePlugins: contentOptions.build?.markdown?.rehypePlugins,
-  }, options.mdc) as MDCModuleOptions
-
+export async function configureMDCModule(contentOptions: ModuleOptions, nuxt: Nuxt) {
   // Hook into mdc configs and store them for parser
-  await nuxt.hook('mdc:configSources', async (mdcConfigs) => {
+  nuxt.hook('mdc:configSources', async (mdcConfigs) => {
     if (mdcConfigs.length) {
       const jiti = createJiti(nuxt.options.rootDir)
       const configs = await Promise.all(mdcConfigs.map(path => jiti.import(path).then(m => (m as { default: MdcConfig }).default || m)))
@@ -37,8 +17,6 @@ export async function installMDCModule(contentOptions: ModuleOptions, nuxt: Nuxt
       })
     }
   })
-
-  await installModule('@nuxtjs/mdc')
 
   // Update mdc optimizeDeps options
   extendViteConfig((config) => {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

this uses the new module dependencies feature in https://github.com/nuxt/nuxt/releases/tag/v4.1.0 to specify options for other modules (and require them).

without this, the `installModule` call will overwrite any module dependencies that are specified by other modules - so this PR is needed for https://github.com/nuxt/ui/pull/5384.

**Note**: I would recommend instead of passing options from content -> mdc, that we have a single place to define them (ie. just use mdc instead), as it can otherwise create non-optimal dependency chains... and I worry bugs will appear

could we move/document `content.renderer.alias` -> `mdc.components.map` instead, and so on?

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
