### PR TITLE
docs(markdown): add info to the complete MDC docs

### DIFF
--- a/docs/content/docs/3.files/1.markdown.md
+++ b/docs/content/docs/3.files/1.markdown.md
@@ -134,6 +134,13 @@ Additional parameters that you have defined in your frontmatter block need to be
 
 We created the MDC syntax to supercharge Markdown and give you the ability to integrate Vue components with slots and props inside your Markdown.
 
+::info
+---
+to: https://remark-mdc.nuxt.space/#syntax
+---
+Explore the full MDC documentation.
+::
+
 ::callout
 ---
 icon: i-simple-icons-visualstudiocode


### PR DESCRIPTION
Every time, I look for this link to find the full MDC syntax documentation 😅

For example, the current content markdown page doesn’t explain inline blocks, nested blocks, etc.

And it’s this page that is currently given as the MDC doc here: https://github.com/nuxt-content/mdc?tab=readme-ov-file#features

Maybe it would be better to create a dedicated documentation page for the MDC syntax on the Nuxt Content site, which would be as complete as possible, rather than spreading the documentation across multiple places as it is currently.

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
