### PR TITLE
docs: add `markdown.build.contentHeading` option

### DIFF
--- a/docs/content/docs/1.getting-started/3.configuration.md
+++ b/docs/content/docs/1.getting-started/3.configuration.md
@@ -135,6 +135,20 @@ export default defineNuxtConfig({
 })
 ```
 
+#### `contentHeading`
+
+::code-group
+```ts [Default]
+contentHeading: true
+```
+
+```ts [Signature]
+type ContentHeading = boolean
+```
+::
+
+Setting this option to `false` disables the automatic generation of `title` and `description` fields that are normally extracted from the first H1 heading and the paragraphs that follow it.
+
 #### `highlight`
 
 ::code-group


### PR DESCRIPTION
Add documentation for configuration option.

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
