### PR TITLE
fix(path-meta): apply path meta fields if they exists in schema

### DIFF
--- a/playground/content.config.ts
+++ b/playground/content.config.ts
@@ -40,7 +40,7 @@ const content = defineCollection({
 })
 
 const data = defineCollection({
-  type: 'page',
+  type: 'data',
   source: 'data/**',
   schema: z.object({
     path: z.string(),

--- a/src/utils/content/index.ts
+++ b/src/utils/content/index.ts
@@ -14,6 +14,7 @@ import type { FileAfterParseHook, FileBeforeParseHook, ModuleOptions, ContentFil
 import { logger } from '../dev'
 import { getOrderedSchemaKeys } from '../../runtime/internal/schema'
 import { transformContent } from './transformers'
+import pathMetaTransformer from './transformers/path-meta'
 
 let parserOptions = {
   mdcConfigs: [] as MdcConfig[],
@@ -169,11 +170,13 @@ export async function createParser(collection: ResolvedCollection, nuxt?: Nuxt) 
       ...beforeParseCtx.parserOptions,
       transformers: extraTransformers,
     })
+
+    const collectionKeys = getOrderedSchemaKeys(collection.extendedSchema)
+
     const { id: id, __metadata, ...parsedContentFields } = parsedContent
     const result = { id } as ParsedContentFile
     const meta = {} as Record<string, unknown>
 
-    const collectionKeys = getOrderedSchemaKeys(collection.extendedSchema)
     for (const key of Object.keys(parsedContentFields)) {
       if (collectionKeys.includes(key)) {
         result[key] = parsedContent[key]
@@ -196,6 +199,14 @@ export async function createParser(collection: ResolvedCollection, nuxt?: Nuxt) 
       const seo = result.seo = (result.seo || {}) as Record<string, unknown>
       seo.title = seo.title || result.title
       seo.description = seo.description || result.description
+    }
+
+    const pathMetaFields = await pathMetaTransformer.transform!(parsedContent, {})
+    const metaFields = ['path', 'title', 'stem', 'extension']
+    for (const key of metaFields) {
+      if (collectionKeys.includes(key) && result[key] === undefined) {
+        result[key] = pathMetaFields[key]
+      }
     }
 
     const afterParseCtx: FileAfterParseHook = { file: hookedFile, content: result as ParsedContentFile, collection }

--- a/src/utils/content/transformers/index.ts
+++ b/src/utils/content/transformers/index.ts
@@ -4,7 +4,6 @@ import type { ContentTransformer, TransformContentOptions, ContentFile } from '.
 import csv from './csv'
 import markdown from './markdown'
 import yaml from './yaml'
-import pathMeta from './path-meta'
 import json from './json'
 
 const TRANSFORMERS = [
@@ -12,7 +11,6 @@ const TRANSFORMERS = [
   markdown,
   json,
   yaml,
-  pathMeta,
 ]
 
 function getParser(ext: string, additionalTransformers: ContentTransformer[] = []): ContentTransformer | undefined {

--- a/src/utils/content/transformers/json.ts
+++ b/src/utils/content/transformers/json.ts
@@ -25,7 +25,6 @@ export default defineTransformer({
 
     return {
       ...parsed,
-      body: parsed.body || parsed,
       id,
     }
   },

--- a/src/utils/content/transformers/markdown.ts
+++ b/src/utils/content/transformers/markdown.ts
@@ -49,6 +49,7 @@ export default defineTransformer({
           toc: parsed.toc,
         },
         id: file.id,
+        title: parsed.data?.title || undefined,
       }
     }
 
@@ -60,6 +61,7 @@ export default defineTransformer({
         toc: parsed.toc,
       },
       id: file.id,
+      title: parsed.data?.title || undefined,
     }
   },
 })

--- a/src/utils/content/transformers/yaml.ts
+++ b/src/utils/content/transformers/yaml.ts
@@ -17,7 +17,6 @@ export default defineTransformer({
 
     return {
       ...parsed,
-      body: parsed.body || parsed,
       id,
     }
   },


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Path meta transformer is not a mandatory transformer for all file formats. This PR improves the behavior and only apply path meta fields if they are defined in collection schema. By default path-meta fields are defined in `page` collections and will be added to pages by default.

!! This PR cleans up the data collections and reduce the bundle size by removing unwanted auto-generated fields.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
