### PR TITLE
docs: Update redirect URI for local studio testing

### DIFF
--- a/docs/content/docs/9.studio/3.providers.md
+++ b/docs/content/docs/9.studio/3.providers.md
@@ -48,7 +48,7 @@ Fill in the required fields:
 - **Authorization callback URL**: `https://yourdomain.com`
 
   :::note
-  If you want to try studio locally, add your local url as redirect URI: `http://localhost:3000/__nuxt_studio/auth/gitlab`
+  If you want to try studio locally, add your local url as redirect URI: `http://localhost:3000/__nuxt_studio/auth/github`
   :::
 
 #### Copy Your GitHub Credentials


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue
Documentation with issue: https://content.nuxt.com/docs/studio/providers#configure-the-github-oauth-application

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
[OAuth Providers](https://content.nuxt.com/docs/studio/providers) page in the [GitHub](https://content.nuxt.com/docs/studio/providers#configure-the-github-oauth-application) section has an improper redirect URL in the note. The redirect URL in the note is set to http://localhost:3000/__nuxt_studio/auth/gitlab, but should be http://localhost:3000/__nuxt_studio/auth/github.

It's a potential confusion point for new developers who are attempting to setup their project. If you are using GitHub OAuth and use the gitlab redirect URL, the application breaks when attempting to redirect.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
