### PR TITLE
docs(studio): add Korean to i18n supported languages list

### DIFF
--- a/docs/content/docs/9.studio/2.setup.md
+++ b/docs/content/docs/9.studio/2.setup.md
@@ -193,6 +193,7 @@ Nuxt Studio includes built-in internationalization support with the following la
 - 🇧🇷 **Portuguese (Brazil)**
 - 🇺🇦 **Ukrainian**
 - 🇨🇳 **Chinese**
+- 🇰🇷 **Korean**
 
 Set your preferred language using the `i18n` option:
 


### PR DESCRIPTION
Add Korean to the list of supported languages in Studio i18n documentation

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

- Added Korean to the internationalization support languages list in `docs/content/docs/9.studio/2.setup.md`
- Korean is now documented as a supported language option for Studio's i18n configuration

Nuxt Studio module supports multiple languages for its interface, and Korean was missing from the documentation despite being a widely used language. This change makes it clear to Korean-speaking users that they can use `defaultLocale: 'ko'` in their Studio configuration.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
