### PR TITLE
perf: wrap SQL queries in transaction

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -414,8 +414,28 @@ async function processCollectionItems(nuxt: Nuxt, collections: ResolvedCollectio
 
   // Drop info table and recreate it
   db.exec(`DROP TABLE IF EXISTS ${infoCollection.tableName}`)
-  for (const sql of sqlDumpList) {
-    db.exec(sql)
+  // Use transaction for faster execution (SQLite only)
+  try {
+    if (db.supportsTransactions) {
+      db.exec('BEGIN TRANSACTION')
+    }
+    for (const sql of sqlDumpList) {
+      db.exec(sql)
+    }
+    if (db.supportsTransactions) {
+      db.exec('COMMIT')
+    }
+  }
+  catch (error) {
+    if (db.supportsTransactions) {
+      try {
+        db.exec('ROLLBACK')
+      }
+      catch {
+        // Ignore rollback errors, original error takes precedence
+      }
+    }
+    throw error
   }
 
   const tags = sqlDumpList.flatMap((sql: string): RegExpMatchArray | [] => sql.match(/(?<=(^|,|\[)\[")[^"]+(?=")/g) || [])

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -23,4 +23,9 @@ export interface LocalDevelopmentDatabase {
   exec(sql: string): void
   close(): void
   database?: Connector
+  /**
+   * Whether the database supports BEGIN/COMMIT SQL statements.
+   * D1 uses batch() instead: https://developers.cloudflare.com/d1/worker-api/d1-database/#batch
+   */
+  supportsTransactions: boolean
 }

--- a/src/utils/database.ts
+++ b/src/utils/database.ts
@@ -163,6 +163,7 @@ export async function getLocalDatabase(database: SqliteDatabaseConfig | D1Databa
     insertDevelopmentCache,
     deleteDevelopmentCache,
     dropContentTables,
+    supportsTransactions: database.type !== 'd1', // D1 uses batch() instead
   }
 }
 


### PR DESCRIPTION
Fixes #3669

## Problem

During development, `processCollectionItems` executes SQL INSERT queries one at a time in a loop. SQLite by default wraps each statement in an implicit transaction with fsync to disk. With 300+ queries, this causes ~3.8 seconds of overhead.

## Solution

Wrap the SQL execution loop in an explicit transaction (`BEGIN TRANSACTION` / `COMMIT`). This batches all queries into a single transaction with one fsync at the end.

**Important:** D1 doesn't support transactions, so we conditionally skip the transaction wrapper for D1 databases by adding a `supportsTransactions` flag to the database interface.

## Benchmark

| Metric | Before | After |
|--------|--------|-------|
| SQL exec (323 queries) | 3864ms | **51ms** |
| Content processing total | 4681ms | **~1000ms** |

## StackBlitz

| | Link | Expected |
|---|---|---|
| Bug | [content-3669](https://stackblitz.com/github/onmax/repros/tree/repro/content-3669/content-3669?startScript=dev) | ❌ Slow processing (~3-4s) |
| Fix | [content-3669-fixed](https://stackblitz.com/github/onmax/repros/tree/repro/content-3669/content-3669-fixed?startScript=dev) | ✅ Fast processing (~200ms) |

## CLI Reproduction

```bash
git clone --depth 1 --filter=blob:none --sparse --branch repro/content-3669 https://github.com/onmax/repros.git
cd repros && git sparse-checkout set content-3669
cd content-3669 && pnpm i && pnpm dev
```

## Verify fix

```bash
git sparse-checkout add content-3669-fixed
cd ../content-3669-fixed && pnpm i && pnpm dev
```

The `-fixed` folder uses [pnpm patch](https://pnpm.io/cli/patch) to apply the fix locally.

## Changes

- Added `supportsTransactions` property to `LocalDevelopmentDatabase` interface
- Set `supportsTransactions: database.type === 'sqlite'` in `getLocalDatabase`
- Wrap SQL execution in transaction when `supportsTransactions` is true

## Why this works

SQLite by default wraps each statement in an implicit transaction. When you run 323 INSERT statements individually, SQLite does 323 separate transactions (with fsync to disk each time). Wrapping them in a single explicit transaction does one fsync at the end.

Discovered in: https://github.com/nimiq/nimiq-website/tree/nuxt-content
