### PR TITLE
feat: cast date field from datetime to date string format

### DIFF
--- a/src/runtime/internal/schema.ts
+++ b/src/runtime/internal/schema.ts
@@ -5,6 +5,7 @@ const propertyTypes = {
   number: 'INT',
   boolean: 'BOOLEAN',
   date: 'DATE',
+  datetime: 'DATETIME',
   enum: 'VARCHAR',
   object: 'TEXT',
 }
@@ -33,8 +34,12 @@ function getPropertyType(property: Draft07DefinitionProperty | Draft07Definition
   const propertyType = (property as Draft07DefinitionProperty).type
   let type = propertyTypes[propertyType as keyof typeof propertyTypes] || 'TEXT'
 
-  if ((property as Draft07DefinitionProperty).format === 'date-time') {
+  if ((property as Draft07DefinitionProperty).format === 'date') {
     type = 'DATE'
+  }
+
+  if ((property as Draft07DefinitionProperty).format === 'date-time') {
+    type = 'DATETIME'
   }
 
   if ((property as Draft07DefinitionPropertyAllOf).allOf) {

--- a/src/utils/schema/valibot.ts
+++ b/src/utils/schema/valibot.ts
@@ -6,7 +6,7 @@ export function toJSONSchema(schema: unknown, name: string): Draft07 {
   const definitions = valibotToJsonSchema(schema as any, {
     overrideSchema(context) {
       if (context.valibotSchema.type === 'date') {
-        return { type: 'string', format: 'date-time' }
+        return { type: 'string', format: 'date' }
       }
       if ((context.valibotSchema as unknown as { $content: Record<string, unknown> }).$content) {
         return {

--- a/src/utils/schema/zod3.ts
+++ b/src/utils/schema/zod3.ts
@@ -30,12 +30,13 @@ export const z = zod
 
 export function toJSONSchema(_schema: unknown, name: string): Draft07 {
   const schema = _schema as zod.ZodSchema
-  const jsonSchema = zodToJsonSchema(schema, { name, $refStrategy: 'none' }) as Draft07
+  const jsonSchema = zodToJsonSchema(schema, { name, $refStrategy: 'none', dateStrategy: 'format:date' }) as Draft07
   const jsonSchemaWithEditorMeta = zodToJsonSchema(
     schema,
     {
       name,
       $refStrategy: 'none',
+      dateStrategy: 'format:date',
       override: (_def) => {
         const def = _def as unknown as Record<string, unknown>
         if (def.editor) {

--- a/src/utils/schema/zod4.ts
+++ b/src/utils/schema/zod4.ts
@@ -14,7 +14,7 @@ export function toJSONSchema(
         const def = ctx.zodSchema._zod?.def as unknown as Record<string, unknown>
         if (def?.type === 'date') {
           ctx.jsonSchema.type = 'string'
-          ctx.jsonSchema.format = 'date-time'
+          ctx.jsonSchema.format = 'date'
         }
         if (def?.$content) {
           ctx.jsonSchema.$content = def.$content


### PR DESCRIPTION
This change was made **in anticipation of https://github.com/nuxt-content/nuxt-studio/issues/163**, which will introduce proper support for `datetime` inputs.
Until then, the affected field is now **cast to a `date` string format** to avoid ambiguity and ensure compatibility with the current behavior.

Testing this change was **fairly cumbersome**, especially when validating the expected **JSON Schema format**.
It would be very helpful to be able to **easily retrieve or inspect the generated schema** to simplify this process.
I’ve opened a **dedicated issue** about this here: https://github.com/nuxt/content/issues/3672.

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
