### PR TITLE
docs: clarify pnpm v10 setup for better-sqlite3 and sqlite3

### DIFF
--- a/docs/content/docs/1.getting-started/2.installation.md
+++ b/docs/content/docs/1.getting-started/2.installation.md
@@ -71,6 +71,44 @@ If you don't want to install any package, you can use native SQLite from Node.js
 Checkout [`experimental.nativeSqlite` configuration](/docs/getting-started/configuration#experimentalnativesqlite-deprecated-use-sqliteconnector).
 ::
 
+::note{color="warning"}
+If you use **pnpm v10+**, dependency build scripts are not executed by default.
+
+:br
+
+Since `better-sqlite3` and `sqlite3` rely on a postinstall/build step to generate native bindings,
+you may encounter errors such as:
+
+:br
+
+`Could not locate the bindings file`
+
+:br
+
+To resolve this, you can approve the required build scripts by running:
+
+::code-group
+```bash [pnpm]
+pnpm approve-builds
+```
+::
+
+Alternatively, if you need a non-interactive setup (for example in CI),
+you can explicitly allow native builds by adding the following configuration
+to your project root `package.json`:
+
+```json [package.json]
+{
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "better-sqlite3",
+      "sqlite3"
+    ]
+  }
+}
+```
+::
+
 ## Create your First Collection
 
 Create a `content.config.ts` file in your project root directory:


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
Describe your changes in detail
pnpm v10+ disables dependency build scripts by default, which can cause missing
native bindings for better-sqlite3.

This PR documents the issue and provides two supported solutions:
- pnpm approve-builds
- pnpm.onlyBuiltDependencies in the project root

No code changes.

<!-- Why is this change required? What problem does it solve? -->
Why is this change required? What problem does it solve? 
pnpm v10+ changed its default behavior and no longer runs dependency build scripts automatically.
As a result, native dependencies such as `better-sqlite3` and `sqlite3` may fail to generate
bindings, leading to runtime errors when using Nuxt Content.

Documenting this behavior helps users quickly identify the cause and apply the correct setup,
reducing installation friction and repeated support questions.
this allow people to quickly find a solution for the issue instead of spending time to figure it out themselves, they can use their time to: develop new features, going to the beach 🏖️, dancing in the sun💃🕺☀️, making love♥️ etc... more productive activities 
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
If it resolves an open issue, please link to the issue here:
https://github.com/nuxt/content/issues/3249
### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.


<img width="1919" height="927" alt="{242A88FE-92C8-4218-9340-FF9D4CD8183E}" src="https://github.com/user-attachments/assets/cd1e7593-6c4d-42e1-a119-60e96104677a" />


