### PR TITLE
fix(api): do not forward accept encoding header

### DIFF
--- a/src/runtime/internal/api.ts
+++ b/src/runtime/internal/api.ts
@@ -8,6 +8,8 @@ async function fetchContent<T>(
   options: NonNullable<Parameters<typeof $fetch>[1]>,
 ): Promise<T> {
   const headers = event ? getRequestHeaders(event) : {}
+  headers['accept-encoding'] = undefined // prevent unsupported enconding issue (https://github.com/nuxt/content/pull/3701)
+
   const url = `/__nuxt_content/${collection}/${path}`
   const fetchOptions = {
     ...options,


### PR DESCRIPTION
### 🔗 Linked issue

Resolves https://github.com/nuxt/content/issues/3695

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Forwarding ~~all headers~~ the `Accept-Encoding` header can make the fetch request return data with brotli compression which is not expected at the moment. Simple fix is to revert the change to headers used.

~~I've added an additional change that adds support for Nuxt CSRF protection as provided by the security module which uses the csurf module internally. This was the original reason for allowing more headers. In the future we may add a module option to whitelist a certain set of headers instead, but that's something to discuss in the future. If this feature addition is not wanted, simply remove the second line!~~

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
