### PR TITLE
docs(i18n): Handle slug as array in computed property

### DIFF
--- a/docs/content/docs/7.integrations/01.i18n.md
+++ b/docs/content/docs/7.integrations/01.i18n.md
@@ -88,7 +88,7 @@ import type { Collections } from '@nuxt/content'
 
 const route = useRoute()
 const { locale } = useI18n()
-const slug = computed(() => withLeadingSlash(String(route.params.slug)))
+const slug = computed(() => Array.isArray(route.params.slug) ? withLeadingSlash(String(route.params.slug.join('/'))) : withLeadingSlash(String(route.params.slug)))
 
 const { data: page } = await useAsyncData('page-' + slug.value, async () => {
   // Build collection name based on current locale


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The example in the code for i18n only handles slugs that have a single level, for slugs with multiple levels like `/nl/foo/bar`, `route.params.slug` will be `['foo', 'bar']` resulting in foo,bar when transforming it to a string.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
