### PR TITLE
fix: align queryCollectionSearchSections opts type

### DIFF
--- a/src/runtime/client.ts
+++ b/src/runtime/client.ts
@@ -27,7 +27,7 @@ export function queryCollectionItemSurroundings<T extends keyof PageCollections>
   return chainablePromise(collection, qb => generateItemSurround(qb, path, opts))
 }
 
-export function queryCollectionSearchSections(collection: keyof Collections, opts?: { ignoredTags?: string[], separators?: string[] }) {
+export function queryCollectionSearchSections(collection: keyof Collections, opts?: { ignoredTags?: string[], minHeading?: `h${1 | 2 | 3 | 4 | 5 | 6}`, maxHeading?: `h${1 | 2 | 3 | 4 | 5 | 6}` }) {
   return chainablePromise(collection, qb => generateSearchSections(qb, opts))
 }
 

--- a/src/runtime/server.ts
+++ b/src/runtime/server.ts
@@ -25,7 +25,7 @@ export function queryCollectionItemSurroundings<T extends keyof PageCollections>
   return chainablePromise(event, collection, qb => generateItemSurround(qb, path, opts))
 }
 
-export function queryCollectionSearchSections(event: H3Event, collection: keyof Collections, opts?: { ignoredTags?: string[], separators?: string[] }) {
+export function queryCollectionSearchSections(event: H3Event, collection: keyof Collections, opts?: { ignoredTags?: string[], minHeading?: `h${1 | 2 | 3 | 4 | 5 | 6}`, maxHeading?: `h${1 | 2 | 3 | 4 | 5 | 6}` }) {
   return chainablePromise(event, collection, qb => generateSearchSections(qb, opts))
 }
 


### PR DESCRIPTION
PR #3636 added `minHeading`/`maxHeading` to `generateSearchSections` but forgot to update the public API types.

Removes stale `separators` option, adds `minHeading`/`maxHeading` to match internal implementation.