### PR TITLE
feat: add explicit `bun` sqlite connector for Bun runtime deployments

### DIFF
--- a/docs/content/docs/1.getting-started/3.configuration.md
+++ b/docs/content/docs/1.getting-started/3.configuration.md
@@ -506,16 +506,41 @@ Experimental features that are not yet stable.
 
 ### `experimental.sqliteConnector`
 
-SQLite connectors have limitations in different environments. Some work in serverless environments, while others do not. Nuxt Content supports three different SQLite connectors to cover all environments:
+SQLite connectors have limitations in different environments. Some work in serverless environments, while others do not. Nuxt Content supports four different SQLite connectors to cover all environments:
 
-- `better-sqlite3`: Works in all Node environments, GitHub CI, Vercel CI and production, Cloudflare CI pipelines, etc. (Does **not** work in WebContainers and StackBlitz)
+- `better-sqlite3`: Works in all Node environments, GitHub CI, Vercel CI and production, Cloudflare CI pipelines, etc. (Does **not** work in WebContainers, StackBlitz, or Bun runtime)
 - `sqlite3`: Works in Node environments, GitHub CI, and StackBlitz. (Does **not** work in Vercel or Cloudflare)
 - `native`: As of Node.js v22.5.0, the `node:sqlite` module is available natively in Node.js. This connector works in all Node environments with Node.js version 22.5.0 or newer.
+- `bun`: Uses Bun's built-in `bun:sqlite` module. Required when deploying to Bun runtime (e.g., Vercel with `bun1.x` runtime). Automatically selected when building with Bun, but must be explicitly set when building with Node.js for a Bun runtime target.
 
 ```ts [nuxt.config.ts]
 export default defineNuxtConfig({
   content: {
     experimental: { sqliteConnector: 'native' },
+  },
+});
+```
+
+When deploying to Vercel with Bun runtime, the connector is auto-detected if you configure the runtime via Nitro:
+
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  nitro: {
+    vercel: {
+      functions: {
+        runtime: 'bun1.x',
+      },
+    },
+  },
+});
+```
+
+Alternatively, you can explicitly set the connector:
+
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  content: {
+    experimental: { sqliteConnector: 'bun' },
   },
 });
 ```

--- a/docs/content/docs/1.getting-started/3.configuration.md
+++ b/docs/content/docs/1.getting-started/3.configuration.md
@@ -545,6 +545,10 @@ export default defineNuxtConfig({
 });
 ```
 
+::prose-note
+When `sqliteConnector: 'bun'` is set but the build runs on Node.js (common in CI/CD pipelines like Vercel), the build-time content processing will automatically fall back to a Node.js-compatible connector (e.g., `better-sqlite3`). Only the deployed server runtime will use `bun:sqlite`. No additional configuration is needed.
+::
+
 ### `experimental.nativeSqlite` (deprecated, use `sqliteConnector`)
 
 As of Node.js v22.5.0, the `node:sqlite` module is available natively in Node.js.

--- a/src/module.ts
+++ b/src/module.ts
@@ -192,10 +192,14 @@ export default defineNuxtModule<ModuleOptions>({
       const preset = findPreset(nuxt)
       await preset.setupNitro(config, { manifest, resolver, moduleOptions: options, nuxt })
 
-      const resolveOptions = { resolver, sqliteConnector: options.experimental?.sqliteConnector || (options.experimental?.nativeSqlite ? 'native' : undefined) }
+      const sqliteConnector = options.experimental?.sqliteConnector || (options.experimental?.nativeSqlite ? 'native' : undefined)
+      const resolveOptions = { resolver, sqliteConnector }
       config.alias ||= {}
       config.alias['#content/adapter'] = await resolveDatabaseAdapter(config.runtimeConfig!.content!.database?.type || options.database.type, resolveOptions)
-      config.alias['#content/local-adapter'] = await resolveDatabaseAdapter(options._localDatabase!.type || 'sqlite', resolveOptions)
+      // Build-time local adapter must use a connector compatible with the build environment.
+      // When targeting Bun but building on Node.js, fall back to a Node.js-compatible connector.
+      const localSqliteConnector = (sqliteConnector === 'bun' && !process.versions.bun) ? undefined : sqliteConnector
+      config.alias['#content/local-adapter'] = await resolveDatabaseAdapter(options._localDatabase!.type || 'sqlite', { resolver, sqliteConnector: localSqliteConnector })
 
       config.handlers ||= []
       manifest.collections.forEach((collection) => {
@@ -282,8 +286,10 @@ async function processCollectionItems(nuxt: Nuxt, collections: ResolvedCollectio
   const collectionDump: Record<string, string[]> = {}
   const collectionChecksum: Record<string, string> = {}
   const collectionChecksumStructure: Record<string, string> = {}
+  const requestedConnector = options.experimental?.sqliteConnector || (options.experimental?.nativeSqlite ? 'native' : undefined)
+  const buildConnector = (requestedConnector === 'bun' && !process.versions.bun) ? undefined : requestedConnector
   const db = await getLocalDatabase(options._localDatabase, {
-    sqliteConnector: options.experimental?.sqliteConnector || (options.experimental?.nativeSqlite ? 'native' : undefined),
+    sqliteConnector: buildConnector,
   })
   const databaseContents = await db.fetchDevelopmentCache()
 

--- a/src/presets/vercel.ts
+++ b/src/presets/vercel.ts
@@ -5,8 +5,14 @@ import nodePreset from './node'
 export default definePreset({
   name: 'vercel',
   parent: nodePreset,
-  async setup(options) {
+  async setup(options, nuxt) {
     options.database ||= { type: 'sqlite', filename: '/tmp/contents.sqlite' }
+
+    const vercelRuntime = (nuxt.options.nitro as Record<string, unknown>)?.vercel as { functions?: { runtime?: string } } | undefined
+    if (typeof vercelRuntime?.functions?.runtime === 'string' && vercelRuntime.functions.runtime.startsWith('bun')) {
+      options.experimental ||= {}
+      options.experimental.sqliteConnector ||= 'bun'
+    }
   },
   async setupNitro(nitroConfig) {
     const database = nitroConfig.runtimeConfig?.content?.database

--- a/src/runtime/internal/database.server.ts
+++ b/src/runtime/internal/database.server.ts
@@ -1,7 +1,6 @@
 import type { H3Event } from 'h3'
 import { isAbsolute } from 'pathe'
 import type { Connector } from 'db0'
-import type { ConnectorOptions as SqliteConnectorOptions } from 'db0/connectors/better-sqlite3'
 import { decompressSQLDump } from './dump'
 import { fetchDatabase } from './api'
 import { refineContentFields } from './collection'
@@ -210,7 +209,7 @@ function refineDatabaseConfig(config: RuntimeConfig['content']['database']) {
   }
 
   if (config.type === 'sqlite') {
-    const _config = { ...config } as SqliteConnectorOptions
+    const _config = { ...config } as { path?: string, name?: string }
     if (config.filename === ':memory:') {
       return { name: ':memory:' }
     }

--- a/src/types/module.ts
+++ b/src/types/module.ts
@@ -209,6 +209,11 @@ export interface ModuleOptions {
     /**
      * Use given SQLite connector instead of `better-sqlite3` if available
      *
+     * - `better-sqlite3`: Default for Node.js environments
+     * - `native`: Use Node.js built-in `node:sqlite` (requires Node.js >= 22.5.0)
+     * - `sqlite3`: Use `sqlite3` package (works in StackBlitz/WebContainers)
+     * - `bun`: Use Bun's built-in `bun:sqlite` (for Bun runtime targets, e.g. Vercel with bun1.x)
+     *
      * @default undefined
      */
     sqliteConnector?: SQLiteConnector
@@ -232,4 +237,4 @@ export interface PublicRuntimeConfig {
   }
 }
 
-export type SQLiteConnector = 'native' | 'sqlite3' | 'better-sqlite3'
+export type SQLiteConnector = 'native' | 'sqlite3' | 'better-sqlite3' | 'bun'

--- a/src/utils/database.ts
+++ b/src/utils/database.ts
@@ -166,7 +166,7 @@ export async function getLocalDatabase(database: SqliteDatabaseConfig | D1Databa
 async function findBestSqliteAdapter(opts: { sqliteConnector?: SQLiteConnector, resolver?: Resolver }) {
   if (opts.sqliteConnector === 'bun') {
     if (!process.versions.bun) {
-      console.warn('[nuxt/content] `sqliteConnector: \'bun\'` is set but the build is running on Node.js. Ensure the deployment target supports `bun:sqlite`.')
+      console.warn('[nuxt/content] `sqliteConnector: \'bun\'` targets Bun runtime — the build-time database will use a Node.js-compatible fallback.')
     }
     return opts.resolver ? opts.resolver.resolve('./runtime/internal/connectors/bun-sqlite') : 'db0/connectors/bun-sqlite'
   }

--- a/src/utils/database.ts
+++ b/src/utils/database.ts
@@ -47,10 +47,6 @@ export async function resolveDatabaseAdapter(adapter: 'sqlite' | 'bunsqlite' | '
   }
 
   adapter = adapter || 'sqlite'
-  if (adapter === 'sqlite' && process.versions.bun) {
-    return databaseConnectors.bunsqlite
-  }
-
   if (adapter === 'sqlite') {
     return await findBestSqliteAdapter({ sqliteConnector: opts.sqliteConnector, resolver: opts.resolver })
   }
@@ -168,11 +164,13 @@ export async function getLocalDatabase(database: SqliteDatabaseConfig | D1Databa
 }
 
 async function findBestSqliteAdapter(opts: { sqliteConnector?: SQLiteConnector, resolver?: Resolver }) {
-  if (process.versions.bun) {
+  if (opts.sqliteConnector === 'bun') {
+    if (!process.versions.bun) {
+      console.warn('[nuxt/content] `sqliteConnector: \'bun\'` is set but the build is running on Node.js. Ensure the deployment target supports `bun:sqlite`.')
+    }
     return opts.resolver ? opts.resolver.resolve('./runtime/internal/connectors/bun-sqlite') : 'db0/connectors/bun-sqlite'
   }
 
-  // if node:sqlite is available, use it
   if (opts.sqliteConnector === 'native' && isNodeSqliteAvailable()) {
     return opts.resolver ? opts.resolver.resolve('./runtime/internal/connectors/node-sqlite') : 'db0/connectors/node-sqlite'
   }
@@ -185,6 +183,11 @@ async function findBestSqliteAdapter(opts: { sqliteConnector?: SQLiteConnector, 
     await ensurePackageInstalled('better-sqlite3')
 
     return 'db0/connectors/better-sqlite3'
+  }
+
+  // Auto-detect Bun runtime when no explicit connector is set
+  if (process.versions.bun) {
+    return opts.resolver ? opts.resolver.resolve('./runtime/internal/connectors/bun-sqlite') : 'db0/connectors/bun-sqlite'
   }
 
   if (isWebContainer()) {

--- a/test/unit/resolveDatabaseAdapter.test.ts
+++ b/test/unit/resolveDatabaseAdapter.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import type { Resolver } from '@nuxt/kit'
+import { resolveDatabaseAdapter } from '../../src/utils/database'
+import { isNodeSqliteAvailable } from '../../src/utils/dependencies'
+
+// A minimal resolver that echoes the path it is asked to resolve so we can
+// assert which runtime connector module was selected.
+const resolver = { resolve: (p: string) => p } as unknown as Resolver
+
+describe('resolveDatabaseAdapter', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  test('resolves the bun connector when sqliteConnector is "bun"', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const adapter = await resolveDatabaseAdapter('sqlite', { resolver, sqliteConnector: 'bun' })
+    expect(adapter).toBe('./runtime/internal/connectors/bun-sqlite')
+  })
+
+  test('warns about the build-time fallback when targeting bun outside of a Bun runtime', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    await resolveDatabaseAdapter('sqlite', { resolver, sqliteConnector: 'bun' })
+
+    if (process.versions.bun) {
+      // Running inside Bun: no fallback needed, so no warning.
+      expect(warn).not.toHaveBeenCalled()
+    }
+    else {
+      expect(warn).toHaveBeenCalledOnce()
+      expect(warn.mock.calls[0]![0]).toContain('Bun runtime')
+    }
+  })
+
+  test('resolves the sqlite3 connector', async () => {
+    const adapter = await resolveDatabaseAdapter('sqlite', { resolver, sqliteConnector: 'sqlite3' })
+    expect(adapter).toBe('db0/connectors/sqlite3')
+  })
+
+  test('resolves the native connector when node:sqlite is available', async () => {
+    if (!isNodeSqliteAvailable()) {
+      return
+    }
+    const adapter = await resolveDatabaseAdapter('sqlite', { resolver, sqliteConnector: 'native' })
+    expect(adapter).toBe('./runtime/internal/connectors/node-sqlite')
+  })
+
+  test('resolves non-sqlite adapters directly without touching the sqlite connector logic', async () => {
+    expect(await resolveDatabaseAdapter('postgresql', { resolver })).toBe('db0/connectors/postgresql')
+    expect(await resolveDatabaseAdapter('postgres', { resolver })).toBe('db0/connectors/postgresql')
+    expect(await resolveDatabaseAdapter('d1', { resolver })).toBe('db0/connectors/cloudflare-d1')
+    expect(await resolveDatabaseAdapter('libsql', { resolver })).toBe('db0/connectors/libsql/node')
+    expect(await resolveDatabaseAdapter('pglite', { resolver })).toBe('db0/connectors/pglite')
+  })
+})

--- a/test/unit/vercelPreset.test.ts
+++ b/test/unit/vercelPreset.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from 'vitest'
+import type { Nuxt } from '@nuxt/schema'
+import type { Resolver } from '@nuxt/kit'
+import vercelPreset from '../../src/presets/vercel'
+import type { ModuleOptions } from '../../src/types/module'
+
+const resolver = { resolve: (p: string) => p } as unknown as Resolver
+// Empty manifest so the inherited node preset doesn't register server handlers
+// (which would require a live Nuxt context).
+const opts = { resolver, manifest: { collections: [] } as never }
+
+function createNuxt(nitro: Record<string, unknown>): Nuxt {
+  return { options: { nitro } } as unknown as Nuxt
+}
+
+describe('vercel preset bun runtime detection', () => {
+  test('auto-selects the bun connector when the Vercel function runtime is bun', async () => {
+    const options = {} as ModuleOptions
+    await vercelPreset.setup!(options, createNuxt({ vercel: { functions: { runtime: 'bun1.x' } } }), opts)
+
+    expect(options.experimental?.sqliteConnector).toBe('bun')
+    expect(options.database).toEqual({ type: 'sqlite', filename: '/tmp/contents.sqlite' })
+  })
+
+  test('matches any bun-prefixed runtime version', async () => {
+    const options = {} as ModuleOptions
+    await vercelPreset.setup!(options, createNuxt({ vercel: { functions: { runtime: 'bun' } } }), opts)
+
+    expect(options.experimental?.sqliteConnector).toBe('bun')
+  })
+
+  test('does not set the bun connector for a Node.js runtime', async () => {
+    const options = {} as ModuleOptions
+    await vercelPreset.setup!(options, createNuxt({ vercel: { functions: { runtime: 'nodejs20.x' } } }), opts)
+
+    expect(options.experimental?.sqliteConnector).toBeUndefined()
+  })
+
+  test('does not set the bun connector when no Vercel runtime is configured', async () => {
+    const options = {} as ModuleOptions
+    await vercelPreset.setup!(options, createNuxt({}), opts)
+
+    expect(options.experimental?.sqliteConnector).toBeUndefined()
+  })
+
+  test('does not override an explicitly configured connector', async () => {
+    const options = { experimental: { sqliteConnector: 'better-sqlite3' } } as ModuleOptions
+    await vercelPreset.setup!(options, createNuxt({ vercel: { functions: { runtime: 'bun1.x' } } }), opts)
+
+    expect(options.experimental?.sqliteConnector).toBe('better-sqlite3')
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

Related: https://github.com/oven-sh/bun/issues/4290 (`better-sqlite3` not supported in Bun)

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When building on Node.js but deploying to a Bun runtime (e.g. Vercel with `bun1.x`), `process.versions.bun` is absent at build time. This causes `findBestSqliteAdapter()` to fall back to `better-sqlite3`, which fails at runtime because Bun doesn't support it:

```
'better-sqlite3' is not yet supported in Bun.
Track the status in https://github.com/oven-sh/bun/issues/4290
In the meantime, you could try bun:sqlite which has a similar API.
```

The `bun:sqlite` connector already exists in the codebase (`src/runtime/internal/connectors/bun-sqlite.ts`), but there was no way to explicitly select it when cross-compiling from Node.js to Bun.

**Changes:**

- Add `'bun'` to the `SQLiteConnector` type (`'native' | 'sqlite3' | 'better-sqlite3' | 'bun'`)
- Handle `sqliteConnector: 'bun'` in `findBestSqliteAdapter()`
- Auto-detect Bun runtime in the Vercel preset when `nitro.vercel.functions.runtime` starts with `'bun'`
- Remove `better-sqlite3` type import from `database.server.ts` (replaced with inline type to make runtime code connector-agnostic)
- Reorder auto-detection so explicit user choices always take priority over `process.versions.bun` sniffing
- Add a build-time warning when `'bun'` connector is set but the build runs on Node.js

**Usage:**

```ts
// Explicit (for cross-compilation: build on Node, deploy to Bun)
export default defineNuxtConfig({
  content: {
    experimental: { sqliteConnector: 'bun' },
  },
})
```

```ts
// Zero-config for Vercel with Bun runtime
export default defineNuxtConfig({
  nitro: {
    vercel: {
      functions: { runtime: 'bun1.x' },
    },
  },
})
```

### 🧪 Testing

**Automated:**
- `pnpm test` — full vitest suite passes (24 files, 181+ tests, 0 regressions)
- `pnpm test:bun` — all 6 bun-specific tests pass

**Manual (Bun 1.3.9):**
- Auto-detect: `getLocalDatabase()` with no config on Bun correctly routes to `bun:sqlite`
- Explicit: `sqliteConnector: 'bun'` correctly routes to `bun:sqlite`
- Override respected: `sqliteConnector: 'better-sqlite3'` on Bun correctly attempts `better-sqlite3` (not overridden by Bun auto-detect)
- Full CRUD cycle through `bun:sqlite`: CREATE TABLE, INSERT, SELECT, UPDATE, DROP — all work with the exact `_content_info` and `_content_docs` table schemas from the original error
- Vercel preset: auto-detects `bun1.x` runtime from nitro config, sets `sqliteConnector: 'bun'`
- Vercel preset: does NOT override explicit user-set `sqliteConnector` value
- Vercel preset: does NOT trigger for `nodejs20.x` runtime

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.