### PR TITLE
feat(types): add custom properties on EditorOptions

### DIFF
--- a/docs/content/changelog/studio-customisation.md
+++ b/docs/content/changelog/studio-customisation.md
@@ -111,3 +111,15 @@ This option can be set to avoid the display of a field in the Studio editor.
 ::prose-tip
 Studio inputs are fully extensible. We can create as many input as we want based on our users needs.
 ::
+
+##### `fieldName: String`
+
+You can set the editor input name in Studio editor.
+
+##### `fieldDescription: String`
+
+You can set an extra text under the field name in Studio editor.
+
+##### `tooltip: String`
+
+Display an info-bubble next to the field name in Studio editor.

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -50,6 +50,9 @@ export interface EditorOptions {
   input?: 'media' | 'icon' | 'textarea' // Override the default input for the field
   hidden?: boolean // Do not display the field in the editor
   iconLibraries?: string[] // List of icon libraries to use for the icon input
+  fieldName?: string // Override auto-generated field name with a custom one
+  fieldDescription?: string // When defined, set a description for the field
+  tooltip?: string // When defined, set a tooltip info-bubble next to the field name
 }
 
 export interface ContentStandardSchemaV1<Input = unknown, Output = Input> extends StandardSchemaV1<Input, Output> {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

Nuxt-Studio upstream: https://github.com/nuxt-content/nuxt-studio/issues/400

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

In order to improve Nuxt Studio UI, we need to expose more properties in the Zod schema, from `EditorOptions` type.

These added properties will allow Nuxt Studio UI to improve the editing experience of content-editors.

For this PR:

- `fieldName`: when defined, override the auto-generated field-name on the Nuxt Studio field
- `fieldDescription`: when defined, use Nuxt UI `FormField` description prop to display an extra text under the field name
- `tooltip`: when defined, display an info-bubble next to the field-name with the `tooltip` as text content

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
