### PR TITLE
docs: clarify directory navigation metadata nesting

### DIFF
--- a/docs/content/docs/2.collections/2.types.md
+++ b/docs/content/docs/2.collections/2.types.md
@@ -90,6 +90,8 @@ Here is the corresponding schema applied:
 You can override any of these fields by defining them in the collection’s schema.
 ::
 
+The `navigation` object is also the place for custom metadata consumed by [`queryCollectionNavigation`](/docs/utils/query-collection-navigation). In page frontmatter or `.navigation.yml`, fields such as `section`, `group`, or `badge` should be nested under `navigation`, and they will be exposed on the generated `ContentNavigationItem`.
+
 ## Data type
 
 ```ts

--- a/docs/content/docs/4.utils/2.query-collection-navigation.md
+++ b/docs/content/docs/4.utils/2.query-collection-navigation.md
@@ -30,8 +30,21 @@ You can add metadata to a directory using a `.navigation.yml` file.
 
 ```yml [.navigation.yml]
 title: Getting Started
-icon: i-lucide-square-play
+navigation:
+  icon: i-lucide-square-play
 ```
+
+Directory-level navigation fields should be defined under `navigation:`. These values are merged into the returned `ContentNavigationItem`, so custom flags can live there as well.
+
+```yml [.navigation.yml]
+title: Getting Started
+navigation:
+  icon: i-lucide-square-play
+  section: true
+  badge: New
+```
+
+With that config, `queryCollectionNavigation()` returns a navigation item for the directory with `icon`, `section`, and `badge` available on the item object.
 
 ## Type
 


### PR DESCRIPTION
## Summary
- document that directory-level navigation metadata in `.navigation.yml` should live under `navigation:`
- show that custom flags like `section`, `group`, and `badge` are exposed on `ContentNavigationItem`
- add the same clarification to the page type docs for the `navigation` field

## Validation
- not run in the fork because dependencies are not installed locally (`node_modules` missing)
- behavior was verified against the Nuxt Content source implementation in `src/runtime/internal/navigation.ts`