### PR TITLE
fix(preview): skip collections without source in preview template

### DIFF
--- a/src/utils/templates.ts
+++ b/src/utils/templates.ts
@@ -206,13 +206,7 @@ export const previewTemplate = (collections: ResolvedCollection[], gitInfo: GitI
   filename: moduleTemplates.preview,
   getContents: ({ options }: { options: { collections: ResolvedCollection[] } }) => {
     const collectionsMeta = options.collections.reduce((acc, collection) => {
-      // Skip collections that would be serialized with an empty `source` array,
-      // because downstream consumers (e.g. nuxt-studio) iterate `source[0]` and
-      // crash on empty arrays. This covers two cases:
-      //   1. Collections with no source at all (e.g. the internal `info` collection).
-      //   2. Collections whose sources are all remote repositories — those are
-      //      filtered out below and should not appear in the preview manifest,
-      //      since they cannot be edited from the preview/studio UI either.
+      // Only include non remote collections and collections with at least one local source (remove `info` collection)
       const localSources = collection.source?.filter(source => !source.repository) ?? []
       if (localSources.length === 0) {
         return acc

--- a/src/utils/templates.ts
+++ b/src/utils/templates.ts
@@ -206,6 +206,14 @@ export const previewTemplate = (collections: ResolvedCollection[], gitInfo: GitI
   filename: moduleTemplates.preview,
   getContents: ({ options }: { options: { collections: ResolvedCollection[] } }) => {
     const collectionsMeta = options.collections.reduce((acc, collection) => {
+      // Skip collections without a source (e.g. the internal `info` collection).
+      // They cannot be edited from the preview/studio UI, and serializing them
+      // with an empty `source: []` array breaks downstream consumers that expect
+      // at least one `ResolvedCollectionSource` entry.
+      if (!collection.source) {
+        return acc
+      }
+
       const schemaWithCollectionName = {
         ...collection.extendedSchema,
         definitions: {
@@ -217,7 +225,7 @@ export const previewTemplate = (collections: ResolvedCollection[], gitInfo: GitI
         pascalName: pascalCase(collection.name),
         tableName: collection.tableName,
         // Remove source from collection meta if it's a remote collection
-        source: collection.source?.filter(source => source.repository ? undefined : collection.source) || [],
+        source: collection.source.filter(source => !source.repository),
         type: collection.type,
         fields: collection.fields,
         schema: schemaWithCollectionName,

--- a/src/utils/templates.ts
+++ b/src/utils/templates.ts
@@ -206,11 +206,15 @@ export const previewTemplate = (collections: ResolvedCollection[], gitInfo: GitI
   filename: moduleTemplates.preview,
   getContents: ({ options }: { options: { collections: ResolvedCollection[] } }) => {
     const collectionsMeta = options.collections.reduce((acc, collection) => {
-      // Skip collections without a source (e.g. the internal `info` collection).
-      // They cannot be edited from the preview/studio UI, and serializing them
-      // with an empty `source: []` array breaks downstream consumers that expect
-      // at least one `ResolvedCollectionSource` entry.
-      if (!collection.source) {
+      // Skip collections that would be serialized with an empty `source` array,
+      // because downstream consumers (e.g. nuxt-studio) iterate `source[0]` and
+      // crash on empty arrays. This covers two cases:
+      //   1. Collections with no source at all (e.g. the internal `info` collection).
+      //   2. Collections whose sources are all remote repositories — those are
+      //      filtered out below and should not appear in the preview manifest,
+      //      since they cannot be edited from the preview/studio UI either.
+      const localSources = collection.source?.filter(source => !source.repository) ?? []
+      if (localSources.length === 0) {
         return acc
       }
 
@@ -224,8 +228,7 @@ export const previewTemplate = (collections: ResolvedCollection[], gitInfo: GitI
         name: collection.name,
         pascalName: pascalCase(collection.name),
         tableName: collection.tableName,
-        // Remove source from collection meta if it's a remote collection
-        source: collection.source.filter(source => !source.repository),
+        source: localSources,
         type: collection.type,
         fields: collection.fields,
         schema: schemaWithCollectionName,


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #3767 (and unblocks nuxt-content/nuxt-studio#425)

### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

The internal `info` collection (created by `resolveCollections()` in `src/utils/collection.ts`) has `source: undefined`. When `previewTemplate` serialized this collection it produced `source: []` in the preview manifest:

```ts
// before
source: collection.source?.filter(source => source.repository ? undefined : collection.source) || [],
```

`undefined?.filter(...)` → `undefined`, then the `|| []` fallback kicks in, so the info collection ends up with an empty `source` array — which violates the `ResolvedCollectionSource[]` contract (at least one source is expected) and crashes downstream consumers that read `source[0].include` and `source[0].prefix` (most visibly `nuxt-studio`, see nuxt-content/nuxt-studio#425).

This PR skips source-less collections entirely in the preview manifest, since they cannot be edited from the preview/studio UI anyway. It also simplifies the remote-collection filter to a straightforward `!source.repository` predicate (the previous `? undefined : collection.source` pattern was hard to read and the branch that returned `collection.source` was only truthy by accident).

### Before / After

For a Nuxt 4 project with `@nuxt/content` v3 plus any user-defined collection, `/__preview.json` previously contained:

```json
{
  "info": { "source": [], "type": "data", ... },
  "pages": { "source": [{ "include": "**", "prefix": "/", ... }], ... }
}
```

After this PR the `info` key is omitted entirely. User-visible collections are unaffected.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly. *(no docs change needed — internal behavior only)*