### PR TITLE
fix(docs): update Nuxt version from 3 to 4 in template features

### DIFF
--- a/docs/content/templates/docs.md
+++ b/docs/content/templates/docs.md
@@ -32,8 +32,8 @@ The Nuxt UI team is dedicated to deliver the best integration and customization 
   :::template-features
   ---
   features:
-    - label: Nuxt 3
-      content: Powered by Nuxt 3 for optimal performances and SEO.
+    - label: Nuxt 4
+      content: Powered by Nuxt 4 for optimal performances and SEO.
     - label: Markdown
       content: Write your pages with MDC thanks to Nuxt Content.
     - label: Nuxt UI

--- a/docs/content/templates/docus.md
+++ b/docs/content/templates/docus.md
@@ -90,8 +90,8 @@ The built files will be in the `.output` directory, ready for deployment to any 
   :::template-features
   ---
   features:
-    - label: Nuxt 3
-      content: Powered by Nuxt 3 for optimal performances and SEO.
+    - label: Nuxt 4
+      content: Powered by Nuxt 4 for optimal performances and SEO.
     - label: Markdown
       content: Write your pages with MDC thanks to Nuxt Content.
     - label: Nuxt UI


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

In the Features panel of the "Docs" and "Docus" templates, the mentionned Nuxt version `3` does not match the actual Nuxt version of the template which is `4`.

* [Docs Template](https://content.nuxt.com/templates/docs)
* [Docus Template](https://content.nuxt.com/templates/docus)
### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
