### PR TITLE
fix(preview): fallback to server fetch when WASM query returns empty

### DIFF
--- a/src/runtime/client.ts
+++ b/src/runtime/client.ts
@@ -34,15 +34,16 @@ export function queryCollectionSearchSections<T extends keyof PageCollections>(c
 /**
  * Execute a content query using either the client-side WASM SQLite database
  * or the server-side fetch API. In preview mode, falls back to server fetch
- * when the WASM query returns empty (e.g. for newly created drafts).
+ * when the WASM query returns empty (e.g. for newly created drafts not yet
+ * synced to the client-side database).
  */
 async function executeContentQuery<T extends keyof Collections, Result = Collections[T]>(event: H3Event | undefined, collection: T, sql: string) {
   if (import.meta.client && window.WebAssembly) {
     if (window.sessionStorage?.getItem('previewToken')) {
       try {
         const result = await queryContentSqlClientWasm<T, Result>(collection, sql)
-        if (result && (Array.isArray(result) ? result.length > 0 : true)) {
-          return result as Result[]
+        if (result?.length) {
+          return result
         }
       }
       catch {

--- a/src/runtime/client.ts
+++ b/src/runtime/client.ts
@@ -31,6 +31,11 @@ export function queryCollectionSearchSections<T extends keyof PageCollections>(c
   return chainablePromise(collection, qb => generateSearchSections(qb, opts))
 }
 
+/**
+ * Execute a content query using either the client-side WASM SQLite database
+ * or the server-side fetch API. In preview mode, falls back to server fetch
+ * when the WASM query returns empty (e.g. for newly created drafts).
+ */
 async function executeContentQuery<T extends keyof Collections, Result = Collections[T]>(event: H3Event | undefined, collection: T, sql: string) {
   if (import.meta.client && window.WebAssembly) {
     if (window.sessionStorage?.getItem('previewToken')) {

--- a/src/runtime/client.ts
+++ b/src/runtime/client.ts
@@ -33,6 +33,16 @@ export function queryCollectionSearchSections<T extends keyof PageCollections>(c
 
 async function executeContentQuery<T extends keyof Collections, Result = Collections[T]>(event: H3Event | undefined, collection: T, sql: string) {
   if (import.meta.client && window.WebAssembly) {
+    if (window.sessionStorage?.getItem('previewToken')) {
+      try {
+        const result = await queryContentSqlClientWasm<T, Result>(collection, sql)
+        if (result && (Array.isArray(result) ? result.length > 0 : true)) {
+          return result as Result[]
+        }
+      }
+      catch {}
+      return fetchQuery(event, String(collection), sql) as Promise<Result[]>
+    }
     return queryContentSqlClientWasm<T, Result>(collection, sql) as Promise<Result[]>
   }
   else {

--- a/src/runtime/client.ts
+++ b/src/runtime/client.ts
@@ -40,7 +40,9 @@ async function executeContentQuery<T extends keyof Collections, Result = Collect
           return result as Result[]
         }
       }
-      catch {}
+      catch {
+        // WASM query failed — fall through to server fetch
+      }
       return fetchQuery(event, String(collection), sql) as Promise<Result[]>
     }
     return queryContentSqlClientWasm<T, Result>(collection, sql) as Promise<Result[]>


### PR DESCRIPTION
## Description

In preview mode (when `sessionStorage.previewToken` is set), the client exclusively uses the WASM SQLite query. If the local database doesn't have content yet (e.g. a newly created draft that hasn't been synced to the client-side DB), the query returns empty results and the page shows nothing.

This adds a fallback: in preview mode, try the WASM query first; if it returns empty or throws, fall back to `fetchQuery` which hits the server and can return the draft content.

Outside preview mode, behavior is unchanged — the WASM path is used exclusively as before.

## Reproduction

1. Set up Nuxt Content with Studio preview
2. Create a new draft document in Studio
3. Navigate to the draft page before the client WASM DB has synced
4. Page shows no content (empty)

With this fix, the page correctly falls back to the server query and displays the draft.

## Changes

- `src/runtime/client.ts`: When `previewToken` exists in sessionStorage, try WASM query first. If result is empty array or query throws, fall back to `fetchQuery`.