### PR TITLE
fix: preserve null for optional booleans and strip empty JSON objects in refineContentFields

### DIFF
--- a/src/runtime/internal/collection.ts
+++ b/src/runtime/internal/collection.ts
@@ -1,6 +1,11 @@
 import type { CollectionInfo } from '@nuxt/content'
 import contentManifest from '#content/manifest'
 
+/**
+ * Refine raw fields from D1/SQLite query results into their proper JS types.
+ * Handles JSON parsing, boolean coercion (preserving null for absent fields),
+ * and removes empty JSON objects that arise from D1 column defaults.
+ */
 export function refineContentFields<T>(sql: string, doc: T) {
   const fields = findCollectionFields(sql)
   const item = { ...doc } as T
@@ -32,6 +37,7 @@ export function refineContentFields<T>(sql: string, doc: T) {
   return item
 }
 
+/** Extract the field type map for the collection referenced in the SQL query. */
 function findCollectionFields(sql: string): Record<string, 'string' | 'number' | 'boolean' | 'date' | 'json'> {
   const table = sql.match(/FROM\s+(\w+)/)
   if (!table) {
@@ -42,6 +48,7 @@ function findCollectionFields(sql: string): Record<string, 'string' | 'number' |
   return info?.fields || {}
 }
 
+/** Strip the `_content_` prefix from a D1 table name to get the collection name. */
 function getCollectionName(table: string) {
   return table.replace(/^_content_/, '')
 }

--- a/src/runtime/internal/collection.ts
+++ b/src/runtime/internal/collection.ts
@@ -8,7 +8,7 @@ export function refineContentFields<T>(sql: string, doc: T) {
     if (fields[key as string] === 'json' && item[key] && item[key] !== 'undefined') {
       const parsed = JSON.parse(item[key] as string)
       if (key !== 'meta' && parsed && typeof parsed === 'object' && !Array.isArray(parsed) && Object.keys(parsed).length === 0) {
-        Reflect.deleteProperty(item, key)
+        Reflect.deleteProperty(item as object, key)
       }
       else {
         item[key] = parsed
@@ -16,7 +16,7 @@ export function refineContentFields<T>(sql: string, doc: T) {
     }
     if (fields[key as string] === 'boolean' && item[key] !== 'undefined') {
       if (item[key] == null) {
-        Reflect.deleteProperty(item, key)
+        Reflect.deleteProperty(item as object, key)
       }
       else {
         item[key] = Boolean(item[key]) as never

--- a/src/runtime/internal/collection.ts
+++ b/src/runtime/internal/collection.ts
@@ -8,7 +8,7 @@ export function refineContentFields<T>(sql: string, doc: T) {
     if (fields[key as string] === 'json' && item[key] && item[key] !== 'undefined') {
       const parsed = JSON.parse(item[key] as string)
       if (key !== 'meta' && parsed && typeof parsed === 'object' && !Array.isArray(parsed) && Object.keys(parsed).length === 0) {
-        delete item[key]
+        Reflect.deleteProperty(item, key)
       }
       else {
         item[key] = parsed
@@ -16,7 +16,7 @@ export function refineContentFields<T>(sql: string, doc: T) {
     }
     if (fields[key as string] === 'boolean' && item[key] !== 'undefined') {
       if (item[key] == null) {
-        delete item[key]
+        Reflect.deleteProperty(item, key)
       }
       else {
         item[key] = Boolean(item[key]) as never

--- a/src/runtime/internal/collection.ts
+++ b/src/runtime/internal/collection.ts
@@ -6,10 +6,21 @@ export function refineContentFields<T>(sql: string, doc: T) {
   const item = { ...doc } as T
   for (const key in item) {
     if (fields[key as string] === 'json' && item[key] && item[key] !== 'undefined') {
-      item[key] = JSON.parse(item[key] as string)
+      const parsed = JSON.parse(item[key] as string)
+      if (key !== 'meta' && parsed && typeof parsed === 'object' && !Array.isArray(parsed) && Object.keys(parsed).length === 0) {
+        delete item[key]
+      }
+      else {
+        item[key] = parsed
+      }
     }
     if (fields[key as string] === 'boolean' && item[key] !== 'undefined') {
-      item[key] = Boolean(item[key]) as never
+      if (item[key] == null) {
+        delete item[key]
+      }
+      else {
+        item[key] = Boolean(item[key]) as never
+      }
     }
   }
 


### PR DESCRIPTION
## Description

Two issues with `refineContentFields` when processing D1/SQLite query results:

### 1. Optional boolean fields get incorrectly set to `false`

`Boolean(item[key])` is called unconditionally for boolean-typed fields. When a field is absent in the source document, SQLite stores NULL. After query: NULL → JS `null` → `Boolean(null) === false`.

This means truly-absent optional boolean fields get injected as `false` in the returned document, causing:
- Spurious diffs when comparing with the original YAML/markdown source
- Incorrect semantics (absence ≠ false for optional fields)

### 2. Empty JSON objects pollute the document

Optional JSON columns (e.g. `seo`) default to `'{}'` in D1. After parsing, this produces an empty `{}` on the document. The YAML source has no such key — this causes false change detection in Studio and inflates the document.

## Changes

`src/runtime/internal/collection.ts`:
- For booleans: if value is null/undefined, `delete item[key]` instead of coercing to false
- For JSON: after parsing, if the result is an empty object (and key is not `meta`), delete it

The `meta` field is exempted because `applyCollectionSchema` uses it as a catch-all bucket for unrecognized fields.

## Test Plan

- Documents with absent optional boolean fields should no longer show `field: false`
- Documents with empty JSON columns should not have `seo: {}` or similar empty objects
- The `meta` field continues to work as a catch-all (not stripped even when empty)