### PR TITLE
fix(dev): skip temporary files in content watcher to prevent crashes

### DIFF
--- a/src/utils/dev.ts
+++ b/src/utils/dev.ts
@@ -117,7 +117,7 @@ export function watchContents(nuxt: Nuxt, options: ModuleOptions, manifest: Mani
     const absolutePath = resolve(pathOrError as string)
     const matches = sourceMap.filter(({ source, cwd }) => {
       if (cwd && absolutePath.startsWith(cwd)) {
-        return micromatch.isMatch(absolutePath.substring(cwd.length), source!.include, { ignore: source!.exclude || [], dot: true })
+        return micromatch.isMatch(absolutePath.substring(cwd.length), source!.include, { ignore: getExcludedSourcePaths(source), dot: true })
       }
 
       return false
@@ -181,7 +181,7 @@ export function watchContents(nuxt: Nuxt, options: ModuleOptions, manifest: Mani
     const absolutePath = resolve(pathOrError as string)
     const matches = sourceMap.filter(({ source, cwd }) => {
       if (cwd && absolutePath.startsWith(cwd)) {
-        return micromatch.isMatch(absolutePath.substring(cwd.length), source!.include, { ignore: source!.exclude || [], dot: true })
+        return micromatch.isMatch(absolutePath.substring(cwd.length), source!.include, { ignore: getExcludedSourcePaths(source), dot: true })
       }
 
       return false

--- a/src/utils/source.ts
+++ b/src/utils/source.ts
@@ -13,6 +13,12 @@ export function getExcludedSourcePaths(source: CollectionSource) {
     ...(source!.exclude || []),
     // Ignore OS files
     '**/.DS_Store',
+    // Ignore temporary files created by editors and tools during non-atomic writes
+    '**/*.tmp',
+    '**/*.tmp.*',
+    '**/*~',
+    '**/.#*',
+    '**/~*',
   ]
 }
 

--- a/test/unit/getExcludedSourcePaths.test.ts
+++ b/test/unit/getExcludedSourcePaths.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+import micromatch from 'micromatch'
+import { getExcludedSourcePaths } from '../../src/utils/source'
+import type { CollectionSource } from '../../src/types/collection'
+
+function isIncluded(path: string, source: CollectionSource = { include: '**' }) {
+  return micromatch.isMatch(path, source.include, {
+    ignore: getExcludedSourcePaths(source),
+    dot: true,
+  })
+}
+
+describe('getExcludedSourcePaths', () => {
+  it('includes user excludes and default OS ignore', () => {
+    expect(getExcludedSourcePaths({ include: '**', exclude: ['drafts/**'] })).toEqual([
+      'drafts/**',
+      '**/.DS_Store',
+      '**/*.tmp',
+      '**/*.tmp.*',
+      '**/*~',
+      '**/.#*',
+      '**/~*',
+    ])
+  })
+
+  it('keeps normal content files', () => {
+    expect(isIncluded('index.md')).toBe(true)
+    expect(isIncluded('blog/hello-world.md')).toBe(true)
+    expect(isIncluded('data.json')).toBe(true)
+    expect(isIncluded('config.yaml')).toBe(true)
+  })
+
+  it('ignores temporary editor and tool files', () => {
+    // Common non-atomic write temps (e.g. example.md.tmp.153372)
+    expect(isIncluded('example.md.tmp')).toBe(false)
+    expect(isIncluded('example.md.tmp.153372')).toBe(false)
+    expect(isIncluded('blog/post.md.tmp.1')).toBe(false)
+    expect(isIncluded('foo.tmp.swp')).toBe(false)
+
+    // Vim backup files
+    expect(isIncluded('index.md~')).toBe(false)
+    expect(isIncluded('blog/post.md~')).toBe(false)
+
+    // Emacs lock / autosave files
+    expect(isIncluded('.#index.md')).toBe(false)
+    expect(isIncluded('blog/.#post.md')).toBe(false)
+    expect(isIncluded('~index.md')).toBe(false)
+    expect(isIncluded('blog/~post.md')).toBe(false)
+
+    // OS files
+    expect(isIncluded('.DS_Store')).toBe(false)
+    expect(isIncluded('blog/.DS_Store')).toBe(false)
+  })
+
+  it('respects custom exclude patterns', () => {
+    const source: CollectionSource = {
+      include: '**',
+      exclude: ['drafts/**', '**/*.draft.md'],
+    }
+
+    expect(isIncluded('drafts/wip.md', source)).toBe(false)
+    expect(isIncluded('page.draft.md', source)).toBe(false)
+    expect(isIncluded('page.md', source)).toBe(true)
+  })
+})


### PR DESCRIPTION
## Description

Editors and AI tools that use non-atomic writes create intermediate files like `example.md.tmp.153372` in content directories. The content watcher picks these up and attempts to parse them, throwing an unhandled rejection that crashes the dev server:

```
ERROR [unhandledRejection] .1775487281985 files are not supported.
```

## Reproduction

1. Start dev server: `npm run dev`
2. Create a temporary file inside a content directory: `touch content/example.md.tmp.153372`
3. Dev server crashes

## Root Cause

The `onChange` handler in the dev watcher passes all files that match the collection's glob pattern through to the parser. Since the glob matches broadly (e.g. all files under `content/`), temp files with compound extensions pass through micromatch but fail at the parser which doesn't support the extension.

## Fix

Add an early return in `onChange` for files matching common temporary file patterns before any parsing is attempted:
- `*.tmp`, `*.tmp.*` (most editors/tools)
- Files ending with `~` (Vim swap)
- `.#*` and `~*` (Emacs lock files)

## Changes

- `src/utils/dev.ts`: Skip temp files at the start of `onChange`

Fixes #3759