### PR TITLE
feat(types): add NOT IN to SQLOperator type

### DIFF
--- a/src/types/query.ts
+++ b/src/types/query.ts
@@ -1,4 +1,4 @@
-export type SQLOperator = '=' | '>=' | '<=' | '>' | '<' | '<>' | 'IN' | 'BETWEEN' | 'NOT BETWEEN' | 'IS NULL' | 'IS NOT NULL' | 'LIKE' | 'NOT LIKE'
+export type SQLOperator = '=' | '>=' | '<=' | '>' | '<' | '<>' | 'IN' | 'NOT IN' | 'BETWEEN' | 'NOT BETWEEN' | 'IS NULL' | 'IS NOT NULL' | 'LIKE' | 'NOT LIKE'
 
 export type QueryGroupFunction<T> = (group: CollectionQueryGroup<T>) => CollectionQueryGroup<T>
 


### PR DESCRIPTION
## Description

The query builder already handles `NOT IN` at runtime:

```typescript
case 'IN':
case 'NOT IN':
  if (Array.isArray(value)) {
    const values = value.map(val => singleQuote(val)).join(', ')
    condition = `"${String(field)}" ${operator.toUpperCase()} (${values})`
```

However, the `SQLOperator` type does not include `'NOT IN'`, so TypeScript users cannot use it without type assertions.

## Fix

Add `'NOT IN'` to the `SQLOperator` type union (placed next to `'IN'` for logical grouping).

## Changes

- `src/types/query.ts`: Add `'NOT IN'` to `SQLOperator`

Fixes #3766