### PR TITLE
fix(navigation): coerce findPageHeadline return value to string

### DIFF
--- a/src/runtime/utils/index.ts
+++ b/src/runtime/utils/index.ts
@@ -65,7 +65,7 @@ export function findPageHeadline(navigation?: ContentNavigationItem[], path?: st
         }
         for (const child of link.children) {
           if (child.path === path) {
-            return link.title
+            return typeof link.title === 'string' ? link.title : String(link.title ?? '')
           }
         }
       }
@@ -75,7 +75,7 @@ export function findPageHeadline(navigation?: ContentNavigationItem[], path?: st
         for (const child of link.children) {
           const isIndex = child.stem?.endsWith('/index')
           if (child.path === path && !isIndex) {
-            return link.title
+            return typeof link.title === 'string' ? link.title : String(link.title ?? '')
           }
         }
         const headline = findPageHeadline(link.children, path, options)


### PR DESCRIPTION
## Description

When a `.navigation.yml` title contains a colon (e.g. `Getting Started: Basics`), YAML parsers may interpret it as an object (`{ "Getting Started": "Basics" }`) instead of a string. `findPageHeadline` returns `link.title` directly, which surfaces as `[object Object]` in consuming components like Docus page headers.

## Reproduction

1. Create a Docus app
2. In `content/1.getting-started/.navigation.yml`:
   ```yaml
   title: Getting Started: Basics
   ```
3. Run `nuxt generate`
4. Any child page in that section shows `[object Object]` as the headline

## Root Cause

`link.title` is typed as `string` but YAML parsing can produce an object at runtime. `findPageHeadline` returns it without validation.

## Fix

Coerce `link.title` to a string before returning, ensuring the function's return type contract is always met:

```typescript
return typeof link.title === 'string' ? link.title : String(link.title ?? '')
```

This is a defensive measure — the ideal fix would be upstream in the YAML-to-navigation pipeline, but this ensures consumers never receive non-string values regardless of input.

## Changes

- `src/runtime/utils/index.ts`: Coerce `link.title` at both return points in `findPageHeadline`

Fixes #3754