### PR TITLE
feat(search): add `useSearchCollection` composable with FTS5 full-text search

### DIFF
--- a/docs/app/assets/css/main.css
+++ b/docs/app/assets/css/main.css
@@ -5,6 +5,8 @@
 @source "../../../node_modules/docus/app/**/*";
 
 @theme static {
+  --container-8xl: 90rem;
+
   --font-sans: 'Public Sans', sans-serif;
 
   --color-green-50: #EFFDF5;
@@ -18,4 +20,8 @@
   --color-green-800: #016538;
   --color-green-900: #0A5331;
   --color-green-950: #052E16;
+}
+
+:root {
+  --ui-container: var(--container-8xl);
 }

--- a/docs/app/assets/css/main.css
+++ b/docs/app/assets/css/main.css
@@ -5,8 +5,6 @@
 @source "../../../node_modules/docus/app/**/*";
 
 @theme static {
-  --container-8xl: 90rem;
-
   --font-sans: 'Public Sans', sans-serif;
 
   --color-green-50: #EFFDF5;
@@ -20,8 +18,4 @@
   --color-green-800: #016538;
   --color-green-900: #0A5331;
   --color-green-950: #052E16;
-}
-
-:root {
-  --ui-container: var(--container-8xl);
 }

--- a/docs/content/blog/studio-oss.md
+++ b/docs/content/blog/studio-oss.md
@@ -68,7 +68,7 @@ This stable release includes everything you need to edit content in production:
 
 ### TipTap Visual Editor
 
-The modern Notion-like editing experience for Markdown content is back with a improved version, powered by [TipTap](https://tiptap.dev/) integrated through the [Nuxt UI Editor](https://ui.nuxt.com/components/editor) component:
+The modern Notion-like editing experience for Markdown content is back with an improved version, powered by [TipTap](https://tiptap.dev/) integrated through the [Nuxt UI Editor](https://ui.nuxt.com/components/editor) component:
 
 - Rich text editing with headings, formatting, links, and more
 - MDC component support for inserting Vue components

--- a/docs/content/blog/studio-oss.md
+++ b/docs/content/blog/studio-oss.md
@@ -68,7 +68,7 @@ This stable release includes everything you need to edit content in production:
 
 ### TipTap Visual Editor
 
-The modern Notion-like editing experience for Markdown content is back with a improved version, powered by [TipTap](https://tiptap.dev/) integrated through the [Nuxt UI Editor](https://ui.nuxt.com/pro/components/editor) component:
+The modern Notion-like editing experience for Markdown content is back with a improved version, powered by [TipTap](https://tiptap.dev/) integrated through the [Nuxt UI Editor](https://ui.nuxt.com/components/editor) component:
 
 - Rich text editing with headings, formatting, links, and more
 - MDC component support for inserting Vue components

--- a/docs/content/docs/4.utils/5.use-search-collection.md
+++ b/docs/content/docs/4.utils/5.use-search-collection.md
@@ -33,7 +33,7 @@ function useSearchCollection<T extends keyof PageCollections>(
 ): {
   status: Ref<'idle' | 'loading' | 'ready' | 'error'>
   search: (query: string, opts?: SearchCollectionOptions) => Promise<SearchResult[]>
-  addToIndex: (name: string, sections: SearchSection[]) => Promise<void>
+  add: (name: string, sections: SearchSection[]) => Promise<void>
   init: () => Promise<DatabaseAdapter>
 }
 ```
@@ -67,9 +67,10 @@ function useSearchCollection<T extends keyof PageCollections>(
       - `columns`: Which columns to snippet (`['title']`, `['content']`, or both). Default is `['content']`.
       - `around`: Number of tokens around the match. Default is `30`.
       - `tag`: HTML tag for highlighting. Default is `'mark'`.
-- `addToIndex(name, sections)`: Add custom data to the FTS index. Useful for indexing non-collection data (e.g., modules, API references).
+- `add(name, sections)`: Add custom data to the FTS index. Useful for indexing non-collection data (e.g., modules, API references).
   - `name`: A collection name for filtering.
   - `sections`: Array of `{ id, title, content, titles?, level? }` objects.
+- `reset()`: Drop the FTS index and clear all data (including custom sections). Status returns to `'idle'`.
 - `init()`: Manually trigger index building. Useful when `immediate: false`.
 
 ### Result Type
@@ -176,13 +177,13 @@ When the collection value changes, the FTS index is dropped and rebuilt for the 
 
 ```vue [CustomDataSearch.vue]
 <script setup lang="ts">
-const { status, search, addToIndex } = useSearchCollection('docs')
+const { status, search, add } = useSearchCollection('docs')
 
 const { data: modules } = await useFetch('/api/modules')
 
 watch(modules, async (data) => {
   if (data) {
-    await addToIndex('modules', data.map(m => ({
+    await add('modules', data.map(m => ({
       id: m.url,
       title: m.name,
       content: m.description,

--- a/docs/content/docs/4.utils/5.use-search-collection.md
+++ b/docs/content/docs/4.utils/5.use-search-collection.md
@@ -57,6 +57,11 @@ function useSearchCollection<T extends keyof PageCollections>(
     - `limit`: Maximum results. Default is `50`.
     - `fields`: Restrict search to specific columns (`'title'`, `'content'`, `'titles'`).
     - `minMatchCharLength`: Skip terms shorter than this value. Default is `1`.
+    - `weights`: Control ranking behavior.
+      - `title`: Boost factor for title matches. Default is `10`.
+      - `content`: Boost factor for content matches. Default is `5`.
+      - `titles`: Boost factor for breadcrumb matches. Default is `1`.
+      - `heading`: Whether higher-level sections (h1 > h2 > h3) rank higher. Default is `true`.
     - `snippet`: Return a highlighted text excerpt.
       - `column`: Which column to snippet (`'title'` or `'content'`). Default is `'content'`.
       - `around`: Number of tokens around the match. Default is `30`.

--- a/docs/content/docs/4.utils/5.use-search-collection.md
+++ b/docs/content/docs/4.utils/5.use-search-collection.md
@@ -33,7 +33,6 @@ function useSearchCollection<T extends keyof PageCollections>(
 ): {
   status: Ref<'idle' | 'loading' | 'ready' | 'error'>
   search: (query: string, opts?: SearchCollectionOptions) => Promise<SearchResult[]>
-  add: (name: string, sections: SearchSection[]) => Promise<void>
   init: () => Promise<DatabaseAdapter>
 }
 ```
@@ -56,7 +55,6 @@ function useSearchCollection<T extends keyof PageCollections>(
   - `query`: The search string. Supports prefix matching automatically (typing `compo` matches "composable").
   - `opts`: (Optional) Search options:
     - `limit`: Maximum results. Default is `50`.
-    - `collections`: Filter results to specific collections. Searches all indexed collections when omitted.
     - `fields`: Restrict search to specific columns (`'title'` or `'content'`).
     - `minTermLength`: Skip terms shorter than this value. Default is `1`.
     - `weights`: Control ranking behavior.
@@ -67,10 +65,6 @@ function useSearchCollection<T extends keyof PageCollections>(
       - `columns`: Which columns to snippet (`['title']`, `['content']`, or both). Default is `['content']`.
       - `around`: Number of tokens around the match. Default is `30`.
       - `tag`: HTML tag for highlighting. Default is `'mark'`.
-- `add(name, sections)`: Add custom data to the FTS index. Useful for indexing non-collection data (e.g., modules, API references).
-  - `name`: A collection name for filtering.
-  - `sections`: Array of `{ id, title, content, titles?, level? }` objects.
-- `reset()`: Drop the FTS index and clear all data (including custom sections). Status returns to `'idle'`.
 - `init()`: Manually trigger index building. Useful when `immediate: false`.
 
 ### Result Type
@@ -172,28 +166,6 @@ const { status, search } = useSearchCollection(collection)
 ```
 
 When the collection value changes, the FTS index is dropped and rebuilt for the new collections.
-
-### Custom Data
-
-```vue [CustomDataSearch.vue]
-<script setup lang="ts">
-const { status, search, add } = useSearchCollection('docs')
-
-const { data: modules } = await useFetch('/api/modules')
-
-watch(modules, async (data) => {
-  if (data) {
-    await add('modules', data.map(m => ({
-      id: m.url,
-      title: m.name,
-      content: m.description,
-    })))
-  }
-}, { immediate: true })
-</script>
-```
-
-Use `addToIndex` to include non-collection data in the search index. Filter results by collection at search time with `{ collections: ['docs'] }` or `{ collections: ['modules'] }`.
 
 ## Compared to queryCollectionSearchSections
 

--- a/docs/content/docs/4.utils/5.use-search-collection.md
+++ b/docs/content/docs/4.utils/5.use-search-collection.md
@@ -33,7 +33,7 @@ function useSearchCollection<T extends keyof PageCollections>(
 ): {
   status: Ref<'idle' | 'loading' | 'ready' | 'error'>
   search: (query: string, opts?: SearchCollectionOptions) => Promise<SearchResult[]>
-  init: () => Promise<void>
+  init: () => Promise<DatabaseAdapter>
 }
 ```
 

--- a/docs/content/docs/4.utils/5.use-search-collection.md
+++ b/docs/content/docs/4.utils/5.use-search-collection.md
@@ -28,7 +28,7 @@ watch(query, async (value) => {
 
 ```ts
 function useSearchCollection<T extends keyof PageCollections>(
-  collection: T | T[],
+  collection: MaybeRefOrGetter<T | T[]>,
   opts?: GenerateSearchSectionsOptions & { immediate?: boolean }
 ): {
   status: Ref<'idle' | 'loading' | 'ready' | 'error'>
@@ -41,7 +41,7 @@ function useSearchCollection<T extends keyof PageCollections>(
 
 ### Parameters
 
-- `collection`: A single collection key or an array of collection keys to search across.
+- `collection`: A single collection key, an array of collection keys, or a reactive ref/getter. When the value changes, the FTS index is rebuilt for the new collections.
 - `opts`: (Optional) Index-building options:
   - `immediate`: Whether to start building the index immediately. Default is `true`. Set to `false` to defer until the first `search()` call or explicit `init()`.
   - `ignoredTags`: Tags to ignore when extracting section content (e.g., `['code']`).
@@ -145,6 +145,27 @@ async function onFocus() {
 }
 </script>
 ```
+
+### Reactive Collections
+
+```vue [VersionedSearch.vue]
+<script setup lang="ts">
+const version = ref('v4')
+const collection = computed(() => `nuxt-${version.value}`)
+
+const { status, search } = useSearchCollection(collection)
+</script>
+
+<template>
+  <select v-model="version">
+    <option>v3</option>
+    <option>v4</option>
+    <option>v5</option>
+  </select>
+</template>
+```
+
+When the collection value changes, the FTS index is dropped and rebuilt for the new collections.
 
 ## Compared to queryCollectionSearchSections
 

--- a/docs/content/docs/4.utils/5.use-search-collection.md
+++ b/docs/content/docs/4.utils/5.use-search-collection.md
@@ -1,0 +1,156 @@
+---
+title: useSearchCollection
+description: The useSearchCollection composable provides full-text search powered by SQLite FTS5, with prefix matching, BM25 ranking, and snippets.
+---
+
+## Usage
+
+Use the auto-imported `useSearchCollection` composable to search across one or more collections. It builds an FTS5 index from content sections and provides instant ranked search results.
+
+```vue [app.vue]
+<script setup lang="ts">
+const { status, search } = useSearchCollection('docs')
+
+const query = ref('')
+const results = ref([])
+
+watch(query, async (value) => {
+  results.value = value ? await search(value) : []
+})
+</script>
+```
+
+::note
+`useSearchCollection` is client-only. The FTS5 index is built in the browser using SQLite WASM.
+::
+
+## Type
+
+```ts
+function useSearchCollection<T extends keyof PageCollections>(
+  collection: T | T[],
+  opts?: GenerateSearchSectionsOptions & { immediate?: boolean }
+): {
+  status: Ref<'idle' | 'loading' | 'ready' | 'error'>
+  search: (query: string, opts?: SearchCollectionOptions) => Promise<SearchResult[]>
+  init: () => Promise<void>
+}
+```
+
+## API
+
+### Parameters
+
+- `collection`: A single collection key or an array of collection keys to search across.
+- `opts`: (Optional) Index-building options:
+  - `immediate`: Whether to start building the index immediately. Default is `true`. Set to `false` to defer until the first `search()` call or explicit `init()`.
+  - `ignoredTags`: Tags to ignore when extracting section content (e.g., `['code']`).
+  - `minHeading`: Minimum heading level to split sections on (e.g., `'h2'`). Default is `'h1'`.
+  - `maxHeading`: Maximum heading level to split sections on (e.g., `'h4'`). Default is `'h6'`.
+
+### Return Values
+
+- `status`: A reactive ref indicating the index state: `'idle'`, `'loading'`, `'ready'`, or `'error'`.
+- `search(query, opts?)`: Execute a search query. Returns a promise with ranked results.
+  - `query`: The search string. Supports prefix matching automatically (typing `compo` matches "composable").
+  - `opts`: (Optional) Search options:
+    - `limit`: Maximum results. Default is `50`.
+    - `fields`: Restrict search to specific columns (`'title'`, `'content'`, `'titles'`).
+    - `minMatchCharLength`: Skip terms shorter than this value. Default is `1`.
+    - `snippet`: Return a highlighted text excerpt.
+      - `column`: Which column to snippet (`'title'` or `'content'`). Default is `'content'`.
+      - `around`: Number of tokens around the match. Default is `30`.
+      - `tag`: HTML tag for highlighting. Default is `'mark'`.
+- `init()`: Manually trigger index building. Useful when `immediate: false`.
+
+### Result Type
+
+```ts
+interface SearchResult {
+  collection: string
+  id: string
+  title: string
+  titles: string[]
+  level: number
+  content: string
+  rank: number
+  snippet?: string
+}
+```
+
+## Examples
+
+### Basic Search
+
+```vue [SearchPage.vue]
+<script setup lang="ts">
+const { status, search } = useSearchCollection('docs')
+
+const query = ref('')
+const results = ref([])
+
+async function onSearch() {
+  results.value = query.value
+    ? await search(query.value, { limit: 20 })
+    : []
+}
+</script>
+
+<template>
+  <UInput v-model="query" :disabled="status !== 'ready'" @input="onSearch" />
+  <ul>
+    <li v-for="result in results" :key="result.id">
+      <NuxtLink :to="result.id">{{ result.title }}</NuxtLink>
+    </li>
+  </ul>
+</template>
+```
+
+### Multi-Collection Search
+
+```vue [GlobalSearch.vue]
+<script setup lang="ts">
+const { status, search } = useSearchCollection(['docs', 'blog'])
+
+const results = ref([])
+const query = ref('')
+
+watch(query, async (value) => {
+  results.value = value
+    ? await search(value, {
+        limit: 20,
+        snippet: { column: 'content', around: 40 },
+      })
+    : []
+})
+</script>
+```
+
+### Deferred Initialization
+
+```vue [LazySearch.vue]
+<script setup lang="ts">
+const { status, search, init } = useSearchCollection('docs', {
+  immediate: false,
+})
+
+async function onFocus() {
+  if (status.value === 'idle') {
+    await init()
+  }
+}
+</script>
+```
+
+## Compared to queryCollectionSearchSections
+
+| | `useSearchCollection` | `queryCollectionSearchSections` + Fuse.js |
+|---|---|---|
+| **Dependencies** | None (built-in FTS5) | Requires external library |
+| **Index** | SQLite inverted index | In-memory JS scan |
+| **Speed** | O(1) lookup | O(n) per query |
+| **Snippets** | Built-in | Manual |
+| **Typo tolerance** | Prefix only | Full fuzzy (edit distance) |
+| **Multi-collection** | Native | Manual merging |
+
+Use `useSearchCollection` when you need fast, zero-dependency search. Use `queryCollectionSearchSections` with Fuse.js or MiniSearch when you need typo-tolerant fuzzy matching.

--- a/docs/content/docs/4.utils/5.use-search-collection.md
+++ b/docs/content/docs/4.utils/5.use-search-collection.md
@@ -173,7 +173,7 @@ When the collection value changes, the FTS index is dropped and rebuilt for the 
 |---|---|---|
 | **Dependencies** | None (built-in FTS5) | Requires external library |
 | **Index** | SQLite inverted index | In-memory JS scan |
-| **Speed** | O(1) lookup | O(n) per query |
+| **Speed** | O(log n) indexed lookup | O(n) per query |
 | **Snippets** | Built-in | Manual |
 | **Typo tolerance** | Prefix only | Full fuzzy (edit distance) |
 | **Multi-collection** | Native | Manual merging |

--- a/docs/content/docs/4.utils/5.use-search-collection.md
+++ b/docs/content/docs/4.utils/5.use-search-collection.md
@@ -33,6 +33,7 @@ function useSearchCollection<T extends keyof PageCollections>(
 ): {
   status: Ref<'idle' | 'loading' | 'ready' | 'error'>
   search: (query: string, opts?: SearchCollectionOptions) => Promise<SearchResult[]>
+  addToIndex: (name: string, sections: SearchSection[]) => Promise<void>
   init: () => Promise<DatabaseAdapter>
 }
 ```
@@ -55,6 +56,7 @@ function useSearchCollection<T extends keyof PageCollections>(
   - `query`: The search string. Supports prefix matching automatically (typing `compo` matches "composable").
   - `opts`: (Optional) Search options:
     - `limit`: Maximum results. Default is `50`.
+    - `collections`: Filter results to specific collections. Searches all indexed collections when omitted.
     - `fields`: Restrict search to specific columns (`'title'` or `'content'`).
     - `minTermLength`: Skip terms shorter than this value. Default is `1`.
     - `weights`: Control ranking behavior.
@@ -65,6 +67,9 @@ function useSearchCollection<T extends keyof PageCollections>(
       - `columns`: Which columns to snippet (`['title']`, `['content']`, or both). Default is `['content']`.
       - `around`: Number of tokens around the match. Default is `30`.
       - `tag`: HTML tag for highlighting. Default is `'mark'`.
+- `addToIndex(name, sections)`: Add custom data to the FTS index. Useful for indexing non-collection data (e.g., modules, API references).
+  - `name`: A collection name for filtering.
+  - `sections`: Array of `{ id, title, content, titles?, level? }` objects.
 - `init()`: Manually trigger index building. Useful when `immediate: false`.
 
 ### Result Type
@@ -166,6 +171,28 @@ const { status, search } = useSearchCollection(collection)
 ```
 
 When the collection value changes, the FTS index is dropped and rebuilt for the new collections.
+
+### Custom Data
+
+```vue [CustomDataSearch.vue]
+<script setup lang="ts">
+const { status, search, addToIndex } = useSearchCollection('docs')
+
+const { data: modules } = await useFetch('/api/modules')
+
+watch(modules, async (data) => {
+  if (data) {
+    await addToIndex('modules', data.map(m => ({
+      id: m.url,
+      title: m.name,
+      content: m.description,
+    })))
+  }
+}, { immediate: true })
+</script>
+```
+
+Use `addToIndex` to include non-collection data in the search index. Filter results by collection at search time with `{ collections: ['docs'] }` or `{ collections: ['modules'] }`.
 
 ## Compared to queryCollectionSearchSections
 

--- a/docs/content/docs/4.utils/5.use-search-collection.md
+++ b/docs/content/docs/4.utils/5.use-search-collection.md
@@ -55,15 +55,14 @@ function useSearchCollection<T extends keyof PageCollections>(
   - `query`: The search string. Supports prefix matching automatically (typing `compo` matches "composable").
   - `opts`: (Optional) Search options:
     - `limit`: Maximum results. Default is `50`.
-    - `fields`: Restrict search to specific columns (`'title'`, `'content'`, `'titles'`).
-    - `minMatchCharLength`: Skip terms shorter than this value. Default is `1`.
+    - `fields`: Restrict search to specific columns (`'title'` or `'content'`).
+    - `minTermLength`: Skip terms shorter than this value. Default is `1`.
     - `weights`: Control ranking behavior.
       - `title`: Boost factor for title matches. Default is `10`.
       - `content`: Boost factor for content matches. Default is `5`.
-      - `titles`: Boost factor for breadcrumb matches. Default is `1`.
       - `heading`: Whether higher-level sections (h1 > h2 > h3) rank higher. Default is `true`.
-    - `snippet`: Return a highlighted text excerpt.
-      - `column`: Which column to snippet (`'title'` or `'content'`). Default is `'content'`.
+    - `snippet`: Return highlighted text excerpts.
+      - `columns`: Which columns to snippet (`['title']`, `['content']`, or both). Default is `['content']`.
       - `around`: Number of tokens around the match. Default is `30`.
       - `tag`: HTML tag for highlighting. Default is `'mark'`.
 - `init()`: Manually trigger index building. Useful when `immediate: false`.
@@ -79,7 +78,7 @@ interface SearchResult {
   level: number
   content: string
   rank: number
-  snippet?: string
+  snippets?: { title?: string, content?: string }
 }
 ```
 
@@ -124,7 +123,7 @@ watch(query, async (value) => {
   results.value = value
     ? await search(value, {
         limit: 20,
-        snippet: { column: 'content', around: 40 },
+        snippet: { columns: ['content'], around: 40 },
       })
     : []
 })

--- a/docs/content/docs/8.advanced/1.fulltext-search.md
+++ b/docs/content/docs/8.advanced/1.fulltext-search.md
@@ -1,44 +1,47 @@
 ---
 title: Full-Text Search
-description: Implement full-text search in your website using Nuxt Content
+description: Implement full-text search in your website using Nuxt Content.
 ---
 
-Content module exposes a handy utility [`queryCollectionSearchSections`](/docs/utils/query-collection-search-sections) to break down content files into searchable sections. This is useful for implementing full-text search in your website. You can use the result of this utility in combination with [Nuxt UI Content Search](https://ui.nuxt.com/pro/components/content-search) or other search libraries like [Fuse.js](https://fusejs.io/), [minisearch](https://lucaong.github.io/minisearch), etc.
+## Built-in FTS5 Search
 
-## Nuxt UI
+Content module provides [`useSearchCollection`](/docs/utils/use-search-collection), a zero-dependency composable powered by SQLite FTS5. It builds an inverted index from your content sections and provides instant ranked search with prefix matching and snippets.
 
-Nuxt UI provides a ready to use component for full-text search. You can use it by passing the result of `queryCollectionSearchSections` to the `files` prop of the component.
-
-Read more about [Nuxt UI Content Search](https://ui.nuxt.com/pro/components/content-search).
-
-::code-group
-```vue [UContentSearchExample.vue]
+```vue [SearchExample.vue]
 <script setup lang="ts">
-const { data: navigation } = await useAsyncData('navigation', () => queryCollectionNavigation('docs'))
-const { data: files } = await useAsyncData('search', () => queryCollectionSearchSections('docs'))
+const { status, search } = useSearchCollection('docs')
+const query = ref('')
+const results = ref([])
 
-const searchTerm = ref('')
+watch(query, async (value) => {
+  results.value = value
+    ? await search(value, { snippet: { column: 'content', around: 40 } })
+    : []
+})
 </script>
 
 <template>
-  <UContentSearch
-    v-model:search-term="searchTerm"
-    :files="files"
-    :navigation="navigation"
-    :fuse="{ resultLimit: 42 }"
-  />
+  <UInput v-model="query" :disabled="status !== 'ready'" placeholder="Search..." />
+  <ul>
+    <li v-for="result in results" :key="result.id">
+      <NuxtLink :to="result.id">{{ result.title }}</NuxtLink>
+      <p v-if="result.snippet" v-html="result.snippet" />
+    </li>
+  </ul>
 </template>
 ```
 
-  :::code-preview{label="Preview" icon="i-lucide-eye"}
-    ::::example-fulltext-content-search
-    ::::
-  :::
+::tip{to="/docs/utils/use-search-collection"}
+Read more about `useSearchCollection` composable.
 ::
 
-## MiniSearch example
+## External Libraries
 
-Read more about [minisearch](https://lucaong.github.io/minisearch).
+You can also use [`queryCollectionSearchSections`](/docs/utils/query-collection-search-sections) to get raw section data and pass it to search libraries like [Fuse.js](https://fusejs.io/) or [MiniSearch](https://lucaong.github.io/minisearch). This approach gives you typo-tolerant fuzzy matching at the cost of loading all sections into memory.
+
+### MiniSearch
+
+[MiniSearch](https://lucaong.github.io/minisearch) is a lightweight full-text search library with prefix matching, fuzzy search, and field boosting.
 
 ::code-group
 ```vue [MiniSearchExample.vue]
@@ -83,12 +86,12 @@ const result = computed(() => miniSearch.search(toValue(query)))
   :::
 ::
 
-## Fuse.js example
+### Fuse.js
 
-Read more about [Fuse.js](https://fusejs.io).
+[Fuse.js](https://fusejs.io) is a fuzzy search library that uses the Bitap algorithm for typo-tolerant matching with configurable thresholds.
 
 ::code-group
-```vue [FusejsExample.vue]
+```vue [FuseJSExample.vue]
 <script setup lang="ts">
 import Fuse from 'fuse.js'
 
@@ -123,6 +126,35 @@ const result = computed(() => fuse.search(toValue(query)).slice(0, 10))
 
   :::code-preview{label="Preview" icon="i-lucide-eye"}
     ::::example-fulltext-fusejs
+    ::::
+  :::
+::
+
+## Nuxt UI
+
+Nuxt UI provides a [ContentSearch](https://ui.nuxt.com/components/content-search) component that is powered by `fuse.js` and accepts the output of `queryCollectionSearchSections` directly.
+
+::code-group
+```vue [ContentSearchExample.vue]
+<script setup lang="ts">
+const { data: navigation } = await useAsyncData('navigation', () => queryCollectionNavigation('docs'))
+const { data: files } = await useAsyncData('search', () => queryCollectionSearchSections('docs'))
+
+const searchTerm = ref('')
+</script>
+
+<template>
+  <UContentSearch
+    v-model:search-term="searchTerm"
+    :files="files"
+    :navigation="navigation"
+    :fuse="{ resultLimit: 42 }"
+  />
+</template>
+```
+
+  :::code-preview{label="Preview" icon="i-lucide-eye"}
+    ::::example-fulltext-content-search
     ::::
   :::
 ::

--- a/docs/content/docs/8.advanced/1.fulltext-search.md
+++ b/docs/content/docs/8.advanced/1.fulltext-search.md
@@ -15,7 +15,7 @@ const results = ref([])
 
 watch(query, async (value) => {
   results.value = value
-    ? await search(value, { snippet: { column: 'content', around: 40 } })
+    ? await search(value, { snippet: { columns: ['content'], around: 40 } })
     : []
 })
 </script>
@@ -25,7 +25,7 @@ watch(query, async (value) => {
   <ul>
     <li v-for="result in results" :key="result.id">
       <NuxtLink :to="result.id">{{ result.title }}</NuxtLink>
-      <p v-if="result.snippet" v-html="result.snippet" />
+      <p v-if="result.snippets?.content" v-html="result.snippets.content" />
     </li>
   </ul>
 </template>

--- a/docs/package.json
+++ b/docs/package.json
@@ -14,6 +14,7 @@
     "@vueuse/nuxt": "^14.2.1",
     "better-sqlite3": "^12.8.0",
     "docus": "^5.8.1",
+    "drizzle-kit": "^0.31.10",
     "drizzle-orm": "^0.45.1",
     "minisearch": "^7.2.0",
     "nuxt": "^4.4.2",

--- a/playground/app.vue
+++ b/playground/app.vue
@@ -40,6 +40,11 @@ const items = ref([
     icon: 'i-lucide-folder-open',
     to: '/data/foo',
   },
+  {
+    label: 'Search',
+    icon: 'i-lucide-search',
+    to: '/search',
+  },
 ])
 </script>
 

--- a/playground/content.config.ts
+++ b/playground/content.config.ts
@@ -128,6 +128,17 @@ const collections = {
       prefix: '/vue',
     },
   }),
+  ui: defineCollection({
+    type: 'page',
+    source: {
+      repository: {
+        url: 'https://github.com/nuxt/ui',
+        branch: 'v4',
+      },
+      include: 'docs/content/**/*.md',
+      prefix: '',
+    },
+  }),
 }
 
 export default defineContentConfig({ collections })

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -1,7 +1,6 @@
 export default defineNuxtConfig({
   modules: [
     '@nuxt/ui',
-    '@nuxthub/core',
     '@nuxt/content',
     'nuxt-llms',
   ],
@@ -38,11 +37,6 @@ export default defineNuxtConfig({
     },
   },
   compatibilityDate: '2025-10-15',
-  hub: {
-    db: 'sqlite',
-    // Or use PGlite with NuxtHub:
-    // db: 'postgresql',
-  },
   llms: {
     domain: 'http://localhost:3000',
     title: 'Content Playground',

--- a/playground/package.json
+++ b/playground/package.json
@@ -9,16 +9,10 @@
     "dev:prepare": "nuxt prepare"
   },
   "devDependencies": {
-    "@electric-sql/pglite": "^0.4.2",
-    "@libsql/client": "^0.17.2",
     "@nuxt/content": "latest",
     "@nuxt/ui": "^4.6.0",
-    "@nuxthub/core": "^0.10.7",
-    "better-sqlite3": "^12.8.0",
-    "drizzle-orm": "^0.45.1",
     "nuxt": "^4.4.2",
     "nuxt-llms": "^0.2.0",
-    "pg": "^8.20.0",
     "remark-code-import": "^1.2.0",
     "shiki-transformer-color-highlight": "^1.1.0"
   }

--- a/playground/pages/search.vue
+++ b/playground/pages/search.vue
@@ -49,39 +49,77 @@ watch(query, debouncedSearch)
     </div>
 
     <div class="flex items-center gap-2">
-      <UInput v-model="query" placeholder="Search content..." icon="i-lucide-search" size="lg" autofocus />
+      <UInput
+        v-model="query"
+        placeholder="Search content..."
+        icon="i-lucide-search"
+        size="lg"
+        autofocus
+      />
 
-      <div v-if="status === 'loading'" class="text-sm text-dimmed">
+      <div
+        v-if="status === 'loading'"
+        class="text-sm text-dimmed"
+      >
         Building search index...
       </div>
 
-      <div v-else-if="searchTime > 0" class="text-sm text-dimmed">
+      <div
+        v-else-if="searchTime > 0"
+        class="text-sm text-dimmed"
+      >
         {{ results.length }} results in {{ searchTime }}ms
       </div>
     </div>
 
-    <div v-if="loading" class="text-dimmed">
+    <div
+      v-if="loading"
+      class="text-dimmed"
+    >
       Searching...
     </div>
 
-    <div v-else-if="results.length" class="space-y-3">
-      <UCard v-for="result in results" :key="result.id">
+    <div
+      v-else-if="results.length"
+      class="space-y-3"
+    >
+      <UCard
+        v-for="result in results"
+        :key="result.id"
+      >
         <div class="space-y-1">
           <div class="flex items-center gap-2">
-            <NuxtLink :to="result.id" class="font-semibold text-primary hover:underline">
+            <NuxtLink
+              :to="result.id"
+              class="font-semibold text-primary hover:underline"
+            >
               {{ result.title }}
             </NuxtLink>
-            <UBadge variant="subtle" size="xs">
+            <UBadge
+              variant="subtle"
+              size="xs"
+            >
               h{{ result.level }}
             </UBadge>
           </div>
 
-          <div v-if="result.titles.length" class="text-sm text-muted">
+          <div
+            v-if="result.titles.length"
+            class="text-sm text-muted"
+          >
             {{ result.titles.join(' > ') }}
           </div>
 
-          <p v-if="result.snippet" class="text-sm text-dimmed" v-html="result.snippet" />
-          <p v-else class="text-sm text-dimmed">
+          <!-- eslint-disable-next-line vue/no-v-html -->
+          <p
+            v-if="result.snippet"
+            class="text-sm text-dimmed"
+            v-html="result.snippet"
+          />
+          <p
+            v-else
+            class="text-sm text-dimmed"
+          >
             {{ result.content?.slice(0, 150) }}
           </p>
 
@@ -92,7 +130,10 @@ watch(query, debouncedSearch)
       </UCard>
     </div>
 
-    <div v-else-if="query && !loading" class="text-dimmed">
+    <div
+      v-else-if="query && !loading"
+      class="text-dimmed"
+    >
       No results found.
     </div>
   </div>

--- a/playground/pages/search.vue
+++ b/playground/pages/search.vue
@@ -24,7 +24,6 @@ async function onSearch() {
       limit: 30,
       snippet: { columns: ['title', 'content'], around: 40 },
     })
-    console.log(results.value)
   }
   catch (e) {
     console.error('Search error:', e)

--- a/playground/pages/search.vue
+++ b/playground/pages/search.vue
@@ -1,0 +1,103 @@
+<script setup lang="ts">
+import { useDebounceFn } from '@vueuse/core'
+
+const { status, search } = useSearchCollection(['nuxt', 'vue'])
+
+const query = ref('')
+const results = ref<Awaited<ReturnType<typeof search>>>([])
+const searchTime = ref(0)
+const loading = ref(false)
+
+async function onSearch() {
+  if (!query.value.trim()) {
+    results.value = []
+    return
+  }
+
+  loading.value = true
+  const start = performance.now()
+
+  try {
+    results.value = await search(query.value, {
+      limit: 20,
+      snippet: { column: 'content', around: 40 },
+    })
+  }
+  catch (e) {
+    console.error('Search error:', e)
+    results.value = []
+  }
+
+  searchTime.value = Math.round(performance.now() - start)
+  loading.value = false
+}
+
+const debouncedSearch = useDebounceFn(onSearch, 200)
+
+watch(query, debouncedSearch)
+</script>
+
+<template>
+  <div class="py-8 space-y-6">
+    <div>
+      <h1 class="text-2xl font-bold mb-2">
+        FTS5 Search
+      </h1>
+      <p class="text-gray-500">
+        Full-text search powered by SQLite FTS5. Supports prefix queries (word*), phrase matching ("exact phrase"), and boolean operators (word1 OR word2).
+      </p>
+    </div>
+
+    <UInput
+      v-model="query"
+      placeholder="Search content..."
+      icon="i-lucide-search"
+      size="lg"
+      autofocus
+    />
+
+    <div v-if="status === 'loading'" class="text-sm text-gray-400">
+      Building search index...
+    </div>
+
+    <div v-else-if="searchTime > 0" class="text-sm text-gray-400">
+      {{ results.length }} results in {{ searchTime }}ms
+    </div>
+
+    <div v-if="loading" class="text-gray-400">
+      Searching...
+    </div>
+
+    <div v-else-if="results.length" class="space-y-3">
+      <UCard v-for="result in results" :key="result.id">
+        <div class="space-y-1">
+          <div class="flex items-center gap-2">
+            <NuxtLink :to="result.id" class="font-semibold text-primary hover:underline">
+              {{ result.title }}
+            </NuxtLink>
+            <UBadge variant="subtle" size="xs">
+              h{{ result.level }}
+            </UBadge>
+          </div>
+
+          <div v-if="result.titles.length" class="text-xs text-gray-400">
+            {{ result.titles.join(' > ') }}
+          </div>
+
+          <p v-if="result.snippet" class="text-sm text-gray-500" v-html="result.snippet" />
+          <p v-else class="text-sm text-gray-500">
+            {{ result.content?.slice(0, 150) }}
+          </p>
+
+          <div class="text-xs text-gray-400">
+            rank: {{ result.rank.toFixed(3) }}
+          </div>
+        </div>
+      </UCard>
+    </div>
+
+    <div v-else-if="query && !loading" class="text-gray-400">
+      No results found.
+    </div>
+  </div>
+</template>

--- a/playground/pages/search.vue
+++ b/playground/pages/search.vue
@@ -104,10 +104,9 @@ watch(query, debouncedSearch)
 
             <NuxtLink
               :to="`https://ui.nuxt.com${result.id}`"
-              class="font-semibold text-primary hover:underline"
-            >
-              {{ result.title }}
-            </NuxtLink>
+              class="font-semibold text-highlighted [&_mark]:text-primary [&_mark]:bg-transparent"
+              v-html="result.snippets?.title || result.title"
+            />
 
             <UBadge
               :label="`h${result.level}`"
@@ -123,7 +122,7 @@ watch(query, debouncedSearch)
 
           <p
             v-if="result.snippets?.content"
-            class="text-sm text-muted [&_mark]:underline [&_mark]:text-highlighted [&_mark]:bg-transparent mt-1"
+            class="text-sm text-muted [&_mark]:text-primary [&_mark]:bg-transparent mt-1"
             v-html="result.snippets.content"
           />
           <p

--- a/playground/pages/search.vue
+++ b/playground/pages/search.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
 import { useDebounceFn } from '@vueuse/core'
 
-const { status, search } = useSearchCollection(['nuxt', 'vue'])
+const { status, search } = useSearchCollection('ui', {
+  ignoredTags: ['style'],
+})
 
 const query = ref('')
 const results = ref<Awaited<ReturnType<typeof search>>>([])
@@ -19,9 +21,10 @@ async function onSearch() {
 
   try {
     results.value = await search(query.value, {
-      limit: 20,
+      limit: 30,
       snippet: { column: 'content', around: 40 },
     })
+    console.log(results.value)
   }
   catch (e) {
     console.error('Search error:', e)
@@ -87,45 +90,48 @@ watch(query, debouncedSearch)
       <UCard
         v-for="result in results"
         :key="result.id"
+        :ui="{ body: 'sm:p-4' }"
       >
-        <div class="space-y-1">
-          <div class="flex items-center gap-2">
+        <div>
+          <div class="flex items-center gap-1 text-sm">
+            <div
+              v-if="result.titles.length"
+              class="text-dimmed"
+            >
+              {{ result.titles.join(' > ') }}
+              >
+            </div>
+
             <NuxtLink
-              :to="result.id"
+              :to="`https://ui.nuxt.com${result.id}`"
               class="font-semibold text-primary hover:underline"
             >
               {{ result.title }}
             </NuxtLink>
-            <UBadge
-              variant="subtle"
-              size="xs"
-            >
-              h{{ result.level }}
-            </UBadge>
-          </div>
 
-          <div
-            v-if="result.titles.length"
-            class="text-sm text-muted"
-          >
-            {{ result.titles.join(' > ') }}
+            <UBadge
+              :label="`h${result.level}`"
+              variant="subtle"
+              size="sm"
+              class="ms-1"
+            />
+
+            <div class="text-sm text-dimmed ms-auto">
+              rank: {{ result.rank.toFixed(3) }}
+            </div>
           </div>
 
           <p
             v-if="result.snippet"
-            class="text-sm text-dimmed"
+            class="text-sm text-muted [&_mark]:underline [&_mark]:text-highlighted [&_mark]:bg-transparent mt-1"
             v-html="result.snippet"
           />
           <p
-            v-else
-            class="text-sm text-dimmed"
+            v-else-if="result.content"
+            class="text-sm text-muted mt-1"
           >
             {{ result.content?.slice(0, 150) }}
           </p>
-
-          <div class="text-xs text-muted">
-            rank: {{ result.rank.toFixed(3) }}
-          </div>
         </div>
       </UCard>
     </div>

--- a/playground/pages/search.vue
+++ b/playground/pages/search.vue
@@ -105,8 +105,9 @@ watch(query, debouncedSearch)
             <NuxtLink
               :to="`https://ui.nuxt.com${result.id}`"
               class="font-semibold text-highlighted [&_mark]:text-primary [&_mark]:bg-transparent"
-              v-html="result.snippets?.title || result.title"
-            />
+            >
+              <span v-html="result.snippets?.title || result.title" />
+            </NuxtLink>
 
             <UBadge
               :label="`h${result.level}`"

--- a/playground/pages/search.vue
+++ b/playground/pages/search.vue
@@ -43,28 +43,24 @@ watch(query, debouncedSearch)
       <h1 class="text-2xl font-bold mb-2">
         FTS5 Search
       </h1>
-      <p class="text-gray-500">
+      <p class="text-muted">
         Full-text search powered by SQLite FTS5. Supports prefix queries (word*), phrase matching ("exact phrase"), and boolean operators (word1 OR word2).
       </p>
     </div>
 
-    <UInput
-      v-model="query"
-      placeholder="Search content..."
-      icon="i-lucide-search"
-      size="lg"
-      autofocus
-    />
+    <div class="flex items-center gap-2">
+      <UInput v-model="query" placeholder="Search content..." icon="i-lucide-search" size="lg" autofocus />
 
-    <div v-if="status === 'loading'" class="text-sm text-gray-400">
-      Building search index...
+      <div v-if="status === 'loading'" class="text-sm text-dimmed">
+        Building search index...
+      </div>
+
+      <div v-else-if="searchTime > 0" class="text-sm text-dimmed">
+        {{ results.length }} results in {{ searchTime }}ms
+      </div>
     </div>
 
-    <div v-else-if="searchTime > 0" class="text-sm text-gray-400">
-      {{ results.length }} results in {{ searchTime }}ms
-    </div>
-
-    <div v-if="loading" class="text-gray-400">
+    <div v-if="loading" class="text-dimmed">
       Searching...
     </div>
 
@@ -80,23 +76,23 @@ watch(query, debouncedSearch)
             </UBadge>
           </div>
 
-          <div v-if="result.titles.length" class="text-xs text-gray-400">
+          <div v-if="result.titles.length" class="text-sm text-muted">
             {{ result.titles.join(' > ') }}
           </div>
 
-          <p v-if="result.snippet" class="text-sm text-gray-500" v-html="result.snippet" />
-          <p v-else class="text-sm text-gray-500">
+          <p v-if="result.snippet" class="text-sm text-dimmed" v-html="result.snippet" />
+          <p v-else class="text-sm text-dimmed">
             {{ result.content?.slice(0, 150) }}
           </p>
 
-          <div class="text-xs text-gray-400">
+          <div class="text-xs text-muted">
             rank: {{ result.rank.toFixed(3) }}
           </div>
         </div>
       </UCard>
     </div>
 
-    <div v-else-if="query && !loading" class="text-gray-400">
+    <div v-else-if="query && !loading" class="text-dimmed">
       No results found.
     </div>
   </div>

--- a/playground/pages/search.vue
+++ b/playground/pages/search.vue
@@ -22,7 +22,7 @@ async function onSearch() {
   try {
     results.value = await search(query.value, {
       limit: 30,
-      snippet: { column: 'content', around: 40 },
+      snippet: { columns: ['title', 'content'], around: 40 },
     })
     console.log(results.value)
   }
@@ -122,9 +122,9 @@ watch(query, debouncedSearch)
           </div>
 
           <p
-            v-if="result.snippet"
+            v-if="result.snippets?.content"
             class="text-sm text-muted [&_mark]:underline [&_mark]:text-highlighted [&_mark]:bg-transparent mt-1"
-            v-html="result.snippet"
+            v-html="result.snippets.content"
           />
           <p
             v-else-if="result.content"

--- a/playground/pages/search.vue
+++ b/playground/pages/search.vue
@@ -37,6 +37,7 @@ const debouncedSearch = useDebounceFn(onSearch, 200)
 watch(query, debouncedSearch)
 </script>
 
+<!-- eslint-disable vue/no-v-html -->
 <template>
   <div class="py-8 space-y-6">
     <div>
@@ -110,7 +111,6 @@ watch(query, debouncedSearch)
             {{ result.titles.join(' > ') }}
           </div>
 
-          <!-- eslint-disable-next-line vue/no-v-html -->
           <p
             v-if="result.snippet"
             class="text-sm text-dimmed"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -178,7 +178,7 @@ importers:
         version: 'link:'
       '@nuxt/devtools':
         specifier: ^3.2.4
-        version: 3.2.4(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2))(vue@3.5.31(typescript@5.9.3))
+        version: 3.2.4(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.31(typescript@5.9.3))
       '@nuxt/eslint-config':
         specifier: ^1.15.2
         version: 1.15.2(@typescript-eslint/utils@8.57.2(eslint@10.2.0(jiti@2.6.1))(typescript@5.9.3))(@vue/compiler-sfc@3.5.31)(eslint@10.2.0(jiti@2.6.1))(typescript@5.9.3)
@@ -190,7 +190,7 @@ importers:
         version: 4.4.2
       '@nuxt/test-utils':
         specifier: ^4.0.0
-        version: 4.0.0(@vue/test-utils@2.4.6)(happy-dom@20.8.9)(magicast@0.5.2)(playwright-core@1.57.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2))(vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(happy-dom@20.8.9)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2)))
+        version: 4.0.0(@vue/test-utils@2.4.6)(happy-dom@20.8.9)(magicast@0.5.2)(playwright-core@1.57.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(happy-dom@20.8.9)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2)))
       '@release-it/conventional-changelog':
         specifier: ^10.0.6
         version: 10.0.6(conventional-commits-filter@5.0.0)(conventional-commits-parser@6.3.0)(release-it@19.2.4(@types/node@25.5.0)(magicast@0.5.2))
@@ -235,7 +235,7 @@ importers:
         version: 2.0.2
       nuxt:
         specifier: ^4.4.2
-        version: 4.4.2(74ca77075a51a4f968a455dc6a9733ca)
+        version: 4.4.2(689f37f0d1815aef70ee617de16836a1)
       release-it:
         specifier: ^19.2.4
         version: 19.2.4(@types/node@25.5.0)(magicast@0.5.2)
@@ -247,7 +247,7 @@ importers:
         version: 1.3.1(typescript@5.9.3)
       vitest:
         specifier: ^4.1.2
-        version: 4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(happy-dom@20.8.9)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2))
+        version: 4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(happy-dom@20.8.9)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))
       vue-tsc:
         specifier: ^3.2.6
         version: 3.2.6(typescript@5.9.3)
@@ -271,19 +271,22 @@ importers:
         version: 3.0.2(magicast@0.5.2)
       '@vercel/analytics':
         specifier: ^2.0.1
-        version: 2.0.1(nuxt@4.4.2(7be7cf16033bc8e0ea270e2ef8ce91a0))(vue-router@4.6.4(vue@3.5.31(typescript@5.9.3)))(vue@3.5.31(typescript@5.9.3))
+        version: 2.0.1(nuxt@4.4.2(910e22d445e98b1636c763310179f6e7))(vue-router@4.6.4(vue@3.5.31(typescript@5.9.3)))(vue@3.5.31(typescript@5.9.3))
       '@vercel/speed-insights':
         specifier: ^2.0.0
-        version: 2.0.0(nuxt@4.4.2(7be7cf16033bc8e0ea270e2ef8ce91a0))(vue-router@4.6.4(vue@3.5.31(typescript@5.9.3)))(vue@3.5.31(typescript@5.9.3))
+        version: 2.0.0(nuxt@4.4.2(910e22d445e98b1636c763310179f6e7))(vue-router@4.6.4(vue@3.5.31(typescript@5.9.3)))(vue@3.5.31(typescript@5.9.3))
       '@vueuse/nuxt':
         specifier: ^14.2.1
-        version: 14.2.1(magicast@0.5.2)(nuxt@4.4.2(7be7cf16033bc8e0ea270e2ef8ce91a0))(vue@3.5.31(typescript@5.9.3))
+        version: 14.2.1(magicast@0.5.2)(nuxt@4.4.2(910e22d445e98b1636c763310179f6e7))(vue@3.5.31(typescript@5.9.3))
       better-sqlite3:
         specifier: ^12.8.0
         version: 12.8.0
       docus:
         specifier: ^5.8.1
-        version: 5.8.1(04cfad179a9a0be44e826fef42864c61)
+        version: 5.8.1(19215eb0f5756d496aad7f2b1d12f74c)
+      drizzle-kit:
+        specifier: ^0.31.10
+        version: 0.31.10
       drizzle-orm:
         specifier: ^0.45.1
         version: 0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(bun-types@1.3.11)(pg@8.20.0)(sqlite3@5.1.7)
@@ -292,7 +295,7 @@ importers:
         version: 7.2.0
       nuxt:
         specifier: ^4.4.2
-        version: 4.4.2(7be7cf16033bc8e0ea270e2ef8ce91a0)
+        version: 4.4.2(910e22d445e98b1636c763310179f6e7)
       nuxt-studio:
         specifier: ^1.5.1
         version: 1.5.1(db0@0.3.4(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(better-sqlite3@12.8.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(bun-types@1.3.11)(pg@8.20.0)(sqlite3@5.1.7))(sqlite3@5.1.7))(ioredis@5.9.2)(magicast@0.5.2)(vue@3.5.31(typescript@5.9.3))
@@ -304,7 +307,7 @@ importers:
         version: link:../..
       nuxt:
         specifier: ^4.4.2
-        version: 4.4.2(74ca77075a51a4f968a455dc6a9733ca)
+        version: 4.4.2(689f37f0d1815aef70ee617de16836a1)
 
   examples/blog:
     dependencies:
@@ -313,7 +316,7 @@ importers:
         version: link:../..
       nuxt:
         specifier: ^4.4.2
-        version: 4.4.2(74ca77075a51a4f968a455dc6a9733ca)
+        version: 4.4.2(689f37f0d1815aef70ee617de16836a1)
 
   examples/i18n:
     dependencies:
@@ -322,7 +325,7 @@ importers:
         version: link:../..
       '@nuxt/ui':
         specifier: ^4.6.0
-        version: 4.6.0(@nuxt/content@)(@tiptap/extensions@3.20.5(@tiptap/core@3.20.5(@tiptap/pm@3.20.5))(@tiptap/pm@3.20.5))(@tiptap/y-tiptap@3.0.1(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.5)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29))(change-case@5.4.4)(db0@0.3.4(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(better-sqlite3@12.8.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(bun-types@1.3.11)(pg@8.20.0)(sqlite3@5.1.7))(sqlite3@5.1.7))(embla-carousel@8.6.0)(ioredis@5.9.2)(magicast@0.5.2)(tailwindcss@4.2.2)(typescript@5.9.3)(valibot@1.3.1(typescript@5.9.3))(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2))(vue-router@5.0.4(@vue/compiler-sfc@3.5.31)(vue@3.5.31(typescript@5.9.3)))(vue@3.5.31(typescript@5.9.3))(yjs@13.6.29)(zod@4.3.6)
+        version: 4.6.0(4c785400c9e9821a05d84841d06203de)
       '@nuxthub/core':
         specifier: ^0.10.7
         version: 0.10.7(db0@0.3.4(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(better-sqlite3@12.8.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(bun-types@1.3.11)(pg@8.20.0)(sqlite3@5.1.7))(sqlite3@5.1.7))(ioredis@5.9.2)(magicast@0.5.2)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))
@@ -331,7 +334,7 @@ importers:
         version: 10.2.4(@vue/compiler-dom@3.5.31)(db0@0.3.4(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(better-sqlite3@12.8.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(bun-types@1.3.11)(pg@8.20.0)(sqlite3@5.1.7))(sqlite3@5.1.7))(eslint@10.2.0(jiti@2.6.1))(ioredis@5.9.2)(magicast@0.5.2)(rollup@4.55.1)(typescript@5.9.3)(vue@3.5.31(typescript@5.9.3))
       nuxt:
         specifier: ^4.4.2
-        version: 4.4.2(74ca77075a51a4f968a455dc6a9733ca)
+        version: 4.4.2(689f37f0d1815aef70ee617de16836a1)
 
   examples/ui:
     dependencies:
@@ -340,43 +343,25 @@ importers:
         version: link:../..
       '@nuxt/ui':
         specifier: ^4.6.0
-        version: 4.6.0(@nuxt/content@)(@tiptap/extensions@3.20.5(@tiptap/core@3.20.5(@tiptap/pm@3.20.5))(@tiptap/pm@3.20.5))(@tiptap/y-tiptap@3.0.1(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.5)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29))(change-case@5.4.4)(db0@0.3.4(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(better-sqlite3@12.8.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(bun-types@1.3.11)(pg@8.20.0)(sqlite3@5.1.7))(sqlite3@5.1.7))(embla-carousel@8.6.0)(ioredis@5.9.2)(magicast@0.5.2)(tailwindcss@4.2.2)(typescript@5.9.3)(valibot@1.3.1(typescript@5.9.3))(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2))(vue-router@5.0.4(@vue/compiler-sfc@3.5.31)(vue@3.5.31(typescript@5.9.3)))(vue@3.5.31(typescript@5.9.3))(yjs@13.6.29)(zod@4.3.6)
+        version: 4.6.0(4c785400c9e9821a05d84841d06203de)
       nuxt:
         specifier: ^4.4.2
-        version: 4.4.2(74ca77075a51a4f968a455dc6a9733ca)
+        version: 4.4.2(689f37f0d1815aef70ee617de16836a1)
 
   playground:
     devDependencies:
-      '@electric-sql/pglite':
-        specifier: ^0.4.2
-        version: 0.4.2
-      '@libsql/client':
-        specifier: ^0.17.2
-        version: 0.17.2(encoding@0.1.13)
       '@nuxt/content':
         specifier: workspace:*
         version: link:..
       '@nuxt/ui':
         specifier: ^4.6.0
-        version: 4.6.0(@nuxt/content@)(@tiptap/extensions@3.20.5(@tiptap/core@3.20.5(@tiptap/pm@3.20.5))(@tiptap/pm@3.20.5))(@tiptap/y-tiptap@3.0.1(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.5)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29))(change-case@5.4.4)(db0@0.3.4(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(better-sqlite3@12.8.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(bun-types@1.3.11)(pg@8.20.0)(sqlite3@5.1.7))(sqlite3@5.1.7))(embla-carousel@8.6.0)(ioredis@5.9.2)(magicast@0.5.2)(tailwindcss@4.2.2)(typescript@5.9.3)(valibot@1.3.1(typescript@5.9.3))(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2))(vue-router@5.0.4(@vue/compiler-sfc@3.5.31)(vue@3.5.31(typescript@5.9.3)))(vue@3.5.31(typescript@5.9.3))(yjs@13.6.29)(zod@4.3.6)
-      '@nuxthub/core':
-        specifier: ^0.10.7
-        version: 0.10.7(db0@0.3.4(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(better-sqlite3@12.8.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(bun-types@1.3.11)(pg@8.20.0)(sqlite3@5.1.7))(sqlite3@5.1.7))(ioredis@5.9.2)(magicast@0.5.2)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))
-      better-sqlite3:
-        specifier: ^12.8.0
-        version: 12.8.0
-      drizzle-orm:
-        specifier: ^0.45.1
-        version: 0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(bun-types@1.3.11)(pg@8.20.0)(sqlite3@5.1.7)
+        version: 4.6.0(4c785400c9e9821a05d84841d06203de)
       nuxt:
         specifier: ^4.4.2
-        version: 4.4.2(74ca77075a51a4f968a455dc6a9733ca)
+        version: 4.4.2(689f37f0d1815aef70ee617de16836a1)
       nuxt-llms:
         specifier: ^0.2.0
         version: 0.2.0(magicast@0.5.2)
-      pg:
-        specifier: ^8.20.0
-        version: 8.20.0
       remark-code-import:
         specifier: ^1.2.0
         version: 1.2.0
@@ -659,6 +644,9 @@ packages:
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
 
+  '@drizzle-team/brocli@0.10.2':
+    resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
+
   '@dxup/nuxt@0.4.0':
     resolution: {integrity: sha512-28LDotpr9G2knUse3cQYsOo6NJq5yhABv4ByRVRYJUmzf9Q31DI7rpRek4POlKy1aAcYyKgu5J2616pyqLohYg==}
     peerDependencies:
@@ -687,6 +675,14 @@ packages:
     resolution: {integrity: sha512-Q9hjxWI5xBM+qW2enxfe8wDKdFWMfd0Z29k5ZJnuBqD/CasY5Zryj09aCA6owbGATWz+39p5uIdaHXpopOcG8g==}
     engines: {node: '>=10'}
 
+  '@esbuild-kit/core-utils@3.3.2':
+    resolution: {integrity: sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==}
+    deprecated: 'Merged into tsx: https://tsx.is'
+
+  '@esbuild-kit/esm-loader@2.6.5':
+    resolution: {integrity: sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==}
+    deprecated: 'Merged into tsx: https://tsx.is'
+
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
     engines: {node: '>=18'}
@@ -699,6 +695,12 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/android-arm64@0.18.20':
+    resolution: {integrity: sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm64@0.25.12':
     resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
     engines: {node: '>=18'}
@@ -709,6 +711,12 @@ packages:
     resolution: {integrity: sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.18.20':
+    resolution: {integrity: sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==}
+    engines: {node: '>=12'}
+    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.25.12':
@@ -723,6 +731,12 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-x64@0.18.20':
+    resolution: {integrity: sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/android-x64@0.25.12':
     resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
     engines: {node: '>=18'}
@@ -735,6 +749,12 @@ packages:
     cpu: [x64]
     os: [android]
 
+  '@esbuild/darwin-arm64@0.18.20':
+    resolution: {integrity: sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.25.12':
     resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
     engines: {node: '>=18'}
@@ -745,6 +765,12 @@ packages:
     resolution: {integrity: sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.18.20':
+    resolution: {integrity: sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.25.12':
@@ -759,6 +785,12 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/freebsd-arm64@0.18.20':
+    resolution: {integrity: sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.25.12':
     resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
     engines: {node: '>=18'}
@@ -769,6 +801,12 @@ packages:
     resolution: {integrity: sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.18.20':
+    resolution: {integrity: sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.25.12':
@@ -783,6 +821,12 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/linux-arm64@0.18.20':
+    resolution: {integrity: sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.25.12':
     resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
     engines: {node: '>=18'}
@@ -793,6 +837,12 @@ packages:
     resolution: {integrity: sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.18.20':
+    resolution: {integrity: sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.25.12':
@@ -807,6 +857,12 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.18.20':
+    resolution: {integrity: sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.25.12':
     resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
     engines: {node: '>=18'}
@@ -817,6 +873,12 @@ packages:
     resolution: {integrity: sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.18.20':
+    resolution: {integrity: sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.25.12':
@@ -831,6 +893,12 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.18.20':
+    resolution: {integrity: sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.25.12':
     resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
     engines: {node: '>=18'}
@@ -841,6 +909,12 @@ packages:
     resolution: {integrity: sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.18.20':
+    resolution: {integrity: sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.25.12':
@@ -855,6 +929,12 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.18.20':
+    resolution: {integrity: sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.25.12':
     resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
     engines: {node: '>=18'}
@@ -867,6 +947,12 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-s390x@0.18.20':
+    resolution: {integrity: sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.25.12':
     resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
     engines: {node: '>=18'}
@@ -877,6 +963,12 @@ packages:
     resolution: {integrity: sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==}
     engines: {node: '>=18'}
     cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.18.20':
+    resolution: {integrity: sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [linux]
 
   '@esbuild/linux-x64@0.25.12':
@@ -903,6 +995,12 @@ packages:
     cpu: [arm64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.18.20':
+    resolution: {integrity: sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/netbsd-x64@0.25.12':
     resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
     engines: {node: '>=18'}
@@ -925,6 +1023,12 @@ packages:
     resolution: {integrity: sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.18.20':
+    resolution: {integrity: sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.25.12':
@@ -951,6 +1055,12 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
+  '@esbuild/sunos-x64@0.18.20':
+    resolution: {integrity: sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/sunos-x64@0.25.12':
     resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
     engines: {node: '>=18'}
@@ -962,6 +1072,12 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
+
+  '@esbuild/win32-arm64@0.18.20':
+    resolution: {integrity: sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
 
   '@esbuild/win32-arm64@0.25.12':
     resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
@@ -975,6 +1091,12 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.18.20':
+    resolution: {integrity: sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.25.12':
     resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
     engines: {node: '>=18'}
@@ -985,6 +1107,12 @@ packages:
     resolution: {integrity: sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.18.20':
+    resolution: {integrity: sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.25.12':
@@ -5037,6 +5165,10 @@ packages:
     resolution: {integrity: sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==}
     engines: {node: '>=12'}
 
+  drizzle-kit@0.31.10:
+    resolution: {integrity: sha512-7OZcmQUrdGI+DUNNsKBn1aW8qSoKuTH7d0mYgSP8bAzdFzKoovxEFnoGQp2dVs82EOJeYycqRtciopszwUf8bw==}
+    hasBin: true
+
   drizzle-orm@0.45.2:
     resolution: {integrity: sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q==}
     peerDependencies:
@@ -5283,6 +5415,11 @@ packages:
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
+
+  esbuild@0.18.20:
+    resolution: {integrity: sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==}
+    engines: {node: '>=12'}
+    hasBin: true
 
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
@@ -8448,6 +8585,11 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
@@ -9566,6 +9708,8 @@ snapshots:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
 
+  '@drizzle-team/brocli@0.10.2': {}
+
   '@dxup/nuxt@0.4.0(magicast@0.5.2)(typescript@5.9.3)':
     dependencies:
       '@dxup/unimport': 0.1.2
@@ -9607,10 +9751,23 @@ snapshots:
 
   '@es-joy/resolve.exports@1.2.0': {}
 
+  '@esbuild-kit/core-utils@3.3.2':
+    dependencies:
+      esbuild: 0.18.20
+      source-map-support: 0.5.21
+
+  '@esbuild-kit/esm-loader@2.6.5':
+    dependencies:
+      '@esbuild-kit/core-utils': 3.3.2
+      get-tsconfig: 4.13.0
+
   '@esbuild/aix-ppc64@0.25.12':
     optional: true
 
   '@esbuild/aix-ppc64@0.27.3':
+    optional: true
+
+  '@esbuild/android-arm64@0.18.20':
     optional: true
 
   '@esbuild/android-arm64@0.25.12':
@@ -9619,10 +9776,16 @@ snapshots:
   '@esbuild/android-arm64@0.27.3':
     optional: true
 
+  '@esbuild/android-arm@0.18.20':
+    optional: true
+
   '@esbuild/android-arm@0.25.12':
     optional: true
 
   '@esbuild/android-arm@0.27.3':
+    optional: true
+
+  '@esbuild/android-x64@0.18.20':
     optional: true
 
   '@esbuild/android-x64@0.25.12':
@@ -9631,10 +9794,16 @@ snapshots:
   '@esbuild/android-x64@0.27.3':
     optional: true
 
+  '@esbuild/darwin-arm64@0.18.20':
+    optional: true
+
   '@esbuild/darwin-arm64@0.25.12':
     optional: true
 
   '@esbuild/darwin-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/darwin-x64@0.18.20':
     optional: true
 
   '@esbuild/darwin-x64@0.25.12':
@@ -9643,10 +9812,16 @@ snapshots:
   '@esbuild/darwin-x64@0.27.3':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.18.20':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/freebsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.18.20':
     optional: true
 
   '@esbuild/freebsd-x64@0.25.12':
@@ -9655,10 +9830,16 @@ snapshots:
   '@esbuild/freebsd-x64@0.27.3':
     optional: true
 
+  '@esbuild/linux-arm64@0.18.20':
+    optional: true
+
   '@esbuild/linux-arm64@0.25.12':
     optional: true
 
   '@esbuild/linux-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-arm@0.18.20':
     optional: true
 
   '@esbuild/linux-arm@0.25.12':
@@ -9667,10 +9848,16 @@ snapshots:
   '@esbuild/linux-arm@0.27.3':
     optional: true
 
+  '@esbuild/linux-ia32@0.18.20':
+    optional: true
+
   '@esbuild/linux-ia32@0.25.12':
     optional: true
 
   '@esbuild/linux-ia32@0.27.3':
+    optional: true
+
+  '@esbuild/linux-loong64@0.18.20':
     optional: true
 
   '@esbuild/linux-loong64@0.25.12':
@@ -9679,10 +9866,16 @@ snapshots:
   '@esbuild/linux-loong64@0.27.3':
     optional: true
 
+  '@esbuild/linux-mips64el@0.18.20':
+    optional: true
+
   '@esbuild/linux-mips64el@0.25.12':
     optional: true
 
   '@esbuild/linux-mips64el@0.27.3':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.18.20':
     optional: true
 
   '@esbuild/linux-ppc64@0.25.12':
@@ -9691,16 +9884,25 @@ snapshots:
   '@esbuild/linux-ppc64@0.27.3':
     optional: true
 
+  '@esbuild/linux-riscv64@0.18.20':
+    optional: true
+
   '@esbuild/linux-riscv64@0.25.12':
     optional: true
 
   '@esbuild/linux-riscv64@0.27.3':
     optional: true
 
+  '@esbuild/linux-s390x@0.18.20':
+    optional: true
+
   '@esbuild/linux-s390x@0.25.12':
     optional: true
 
   '@esbuild/linux-s390x@0.27.3':
+    optional: true
+
+  '@esbuild/linux-x64@0.18.20':
     optional: true
 
   '@esbuild/linux-x64@0.25.12':
@@ -9715,6 +9917,9 @@ snapshots:
   '@esbuild/netbsd-arm64@0.27.3':
     optional: true
 
+  '@esbuild/netbsd-x64@0.18.20':
+    optional: true
+
   '@esbuild/netbsd-x64@0.25.12':
     optional: true
 
@@ -9725,6 +9930,9 @@ snapshots:
     optional: true
 
   '@esbuild/openbsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.18.20':
     optional: true
 
   '@esbuild/openbsd-x64@0.25.12':
@@ -9739,10 +9947,16 @@ snapshots:
   '@esbuild/openharmony-arm64@0.27.3':
     optional: true
 
+  '@esbuild/sunos-x64@0.18.20':
+    optional: true
+
   '@esbuild/sunos-x64@0.25.12':
     optional: true
 
   '@esbuild/sunos-x64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-arm64@0.18.20':
     optional: true
 
   '@esbuild/win32-arm64@0.25.12':
@@ -9751,10 +9965,16 @@ snapshots:
   '@esbuild/win32-arm64@0.27.3':
     optional: true
 
+  '@esbuild/win32-ia32@0.18.20':
+    optional: true
+
   '@esbuild/win32-ia32@0.25.12':
     optional: true
 
   '@esbuild/win32-ia32@0.27.3':
+    optional: true
+
+  '@esbuild/win32-x64@0.18.20':
     optional: true
 
   '@esbuild/win32-x64@0.25.12':
@@ -10413,19 +10633,19 @@ snapshots:
 
   '@nuxt/devalue@2.0.2': {}
 
-  '@nuxt/devtools-kit@2.7.0(magicast@0.5.2)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2))':
+  '@nuxt/devtools-kit@2.7.0(magicast@0.5.2)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@nuxt/kit': 3.21.2(magicast@0.5.2)
       execa: 8.0.1
-      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/devtools-kit@3.2.4(magicast@0.5.2)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2))':
+  '@nuxt/devtools-kit@3.2.4(magicast@0.5.2)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
       execa: 8.0.1
-      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - magicast
 
@@ -10440,9 +10660,9 @@ snapshots:
       pkg-types: 2.3.0
       semver: 7.7.4
 
-  '@nuxt/devtools@3.2.4(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2))(vue@3.5.31(typescript@5.9.3))':
+  '@nuxt/devtools@3.2.4(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.31(typescript@5.9.3))':
     dependencies:
-      '@nuxt/devtools-kit': 3.2.4(magicast@0.5.2)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2))
+      '@nuxt/devtools-kit': 3.2.4(magicast@0.5.2)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))
       '@nuxt/devtools-wizard': 3.2.4
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
       '@vue/devtools-core': 8.1.1(vue@3.5.31(typescript@5.9.3))
@@ -10470,9 +10690,9 @@ snapshots:
       sirv: 3.0.2
       structured-clone-es: 2.0.0
       tinyglobby: 0.2.15
-      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2)
-      vite-plugin-inspect: 11.3.3(@nuxt/kit@4.4.2(magicast@0.5.2))(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2))
-      vite-plugin-vue-tracer: 1.3.0(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2))(vue@3.5.31(typescript@5.9.3))
+      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2)
+      vite-plugin-inspect: 11.3.3(@nuxt/kit@4.4.2(magicast@0.5.2))(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))
+      vite-plugin-vue-tracer: 1.3.0(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.31(typescript@5.9.3))
       which: 6.0.1
       ws: 8.19.0
     transitivePeerDependencies:
@@ -10521,13 +10741,13 @@ snapshots:
       - supports-color
       - typescript
 
-  '@nuxt/fonts@0.14.0(db0@0.3.4(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(better-sqlite3@12.8.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(bun-types@1.3.11)(pg@8.20.0)(sqlite3@5.1.7))(sqlite3@5.1.7))(ioredis@5.9.2)(magicast@0.5.2)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2))':
+  '@nuxt/fonts@0.14.0(db0@0.3.4(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(better-sqlite3@12.8.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(bun-types@1.3.11)(pg@8.20.0)(sqlite3@5.1.7))(sqlite3@5.1.7))(ioredis@5.9.2)(magicast@0.5.2)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
-      '@nuxt/devtools-kit': 3.2.4(magicast@0.5.2)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2))
+      '@nuxt/devtools-kit': 3.2.4(magicast@0.5.2)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
       consola: 3.4.2
       defu: 6.1.7
-      fontless: 0.2.1(db0@0.3.4(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(better-sqlite3@12.8.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(bun-types@1.3.11)(pg@8.20.0)(sqlite3@5.1.7))(sqlite3@5.1.7))(ioredis@5.9.2)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2))
+      fontless: 0.2.1(db0@0.3.4(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(better-sqlite3@12.8.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(bun-types@1.3.11)(pg@8.20.0)(sqlite3@5.1.7))(sqlite3@5.1.7))(ioredis@5.9.2)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))
       h3: 1.15.10
       magic-regexp: 0.10.0
       ofetch: 1.5.1
@@ -10561,13 +10781,13 @@ snapshots:
       - uploadthing
       - vite
 
-  '@nuxt/icon@2.2.1(magicast@0.5.2)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2))(vue@3.5.31(typescript@5.9.3))':
+  '@nuxt/icon@2.2.1(magicast@0.5.2)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.31(typescript@5.9.3))':
     dependencies:
       '@iconify/collections': 1.0.653
       '@iconify/types': 2.0.0
       '@iconify/utils': 3.1.0
       '@iconify/vue': 5.0.0(vue@3.5.31(typescript@5.9.3))
-      '@nuxt/devtools-kit': 3.2.4(magicast@0.5.2)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2))
+      '@nuxt/devtools-kit': 3.2.4(magicast@0.5.2)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
       consola: 3.4.2
       local-pkg: 1.1.2
@@ -10692,7 +10912,7 @@ snapshots:
       - vue
       - vue-tsc
 
-  '@nuxt/nitro-server@4.4.2(@babel/core@7.29.0)(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(better-sqlite3@12.8.0)(db0@0.3.4(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(better-sqlite3@12.8.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(bun-types@1.3.11)(pg@8.20.0)(sqlite3@5.1.7))(sqlite3@5.1.7))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(bun-types@1.3.11)(pg@8.20.0)(sqlite3@5.1.7))(encoding@0.1.13)(ioredis@5.9.2)(magicast@0.5.2)(nuxt@4.4.2(74ca77075a51a4f968a455dc6a9733ca))(rolldown@1.0.0-beta.60)(sqlite3@5.1.7)(typescript@5.9.3)':
+  '@nuxt/nitro-server@4.4.2(@babel/core@7.29.0)(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(better-sqlite3@12.8.0)(db0@0.3.4(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(better-sqlite3@12.8.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(bun-types@1.3.11)(pg@8.20.0)(sqlite3@5.1.7))(sqlite3@5.1.7))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(bun-types@1.3.11)(pg@8.20.0)(sqlite3@5.1.7))(encoding@0.1.13)(ioredis@5.9.2)(magicast@0.5.2)(nuxt@4.4.2(689f37f0d1815aef70ee617de16836a1))(rolldown@1.0.0-beta.60)(sqlite3@5.1.7)(typescript@5.9.3)':
     dependencies:
       '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
       '@nuxt/devalue': 2.0.2
@@ -10711,7 +10931,7 @@ snapshots:
       klona: 2.0.6
       mocked-exports: 0.1.1
       nitropack: 2.13.1(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(better-sqlite3@12.8.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(bun-types@1.3.11)(pg@8.20.0)(sqlite3@5.1.7))(encoding@0.1.13)(rolldown@1.0.0-beta.60)(sqlite3@5.1.7)
-      nuxt: 4.4.2(74ca77075a51a4f968a455dc6a9733ca)
+      nuxt: 4.4.2(689f37f0d1815aef70ee617de16836a1)
       nypm: 0.6.5
       ohash: 2.0.11
       pathe: 2.0.3
@@ -10760,7 +10980,7 @@ snapshots:
       - uploadthing
       - xml2js
 
-  '@nuxt/nitro-server@4.4.2(@babel/core@7.29.0)(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(better-sqlite3@12.8.0)(db0@0.3.4(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(better-sqlite3@12.8.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(bun-types@1.3.11)(pg@8.20.0)(sqlite3@5.1.7))(sqlite3@5.1.7))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(bun-types@1.3.11)(pg@8.20.0)(sqlite3@5.1.7))(encoding@0.1.13)(ioredis@5.9.2)(magicast@0.5.2)(nuxt@4.4.2(7be7cf16033bc8e0ea270e2ef8ce91a0))(rolldown@1.0.0-beta.57)(sqlite3@5.1.7)(typescript@5.9.3)':
+  '@nuxt/nitro-server@4.4.2(@babel/core@7.29.0)(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(better-sqlite3@12.8.0)(db0@0.3.4(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(better-sqlite3@12.8.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(bun-types@1.3.11)(pg@8.20.0)(sqlite3@5.1.7))(sqlite3@5.1.7))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(bun-types@1.3.11)(pg@8.20.0)(sqlite3@5.1.7))(encoding@0.1.13)(ioredis@5.9.2)(magicast@0.5.2)(nuxt@4.4.2(910e22d445e98b1636c763310179f6e7))(rolldown@1.0.0-beta.57)(sqlite3@5.1.7)(typescript@5.9.3)':
     dependencies:
       '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
       '@nuxt/devalue': 2.0.2
@@ -10779,7 +10999,7 @@ snapshots:
       klona: 2.0.6
       mocked-exports: 0.1.1
       nitropack: 2.13.1(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(better-sqlite3@12.8.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(bun-types@1.3.11)(pg@8.20.0)(sqlite3@5.1.7))(encoding@0.1.13)(rolldown@1.0.0-beta.57)(sqlite3@5.1.7)
-      nuxt: 4.4.2(7be7cf16033bc8e0ea270e2ef8ce91a0)
+      nuxt: 4.4.2(910e22d445e98b1636c763310179f6e7)
       nypm: 0.6.5
       ohash: 2.0.11
       pathe: 2.0.3
@@ -10845,10 +11065,10 @@ snapshots:
       rc9: 3.0.0
       std-env: 3.10.0
 
-  '@nuxt/test-utils@4.0.0(@vue/test-utils@2.4.6)(happy-dom@20.8.9)(magicast@0.5.2)(playwright-core@1.57.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2))(vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(happy-dom@20.8.9)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2)))':
+  '@nuxt/test-utils@4.0.0(@vue/test-utils@2.4.6)(happy-dom@20.8.9)(magicast@0.5.2)(playwright-core@1.57.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(happy-dom@20.8.9)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2)))':
     dependencies:
       '@clack/prompts': 1.0.0
-      '@nuxt/devtools-kit': 2.7.0(magicast@0.5.2)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2))
+      '@nuxt/devtools-kit': 2.7.0(magicast@0.5.2)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))
       '@nuxt/kit': 3.21.2(magicast@0.5.2)
       c12: 3.3.3(magicast@0.5.2)
       consola: 3.4.2
@@ -10874,33 +11094,33 @@ snapshots:
       tinyexec: 1.0.2
       ufo: 1.6.3
       unplugin: 3.0.0
-      vitest-environment-nuxt: 1.0.1(@vue/test-utils@2.4.6)(happy-dom@20.8.9)(magicast@0.5.2)(playwright-core@1.57.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2))(vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(happy-dom@20.8.9)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2)))
+      vitest-environment-nuxt: 1.0.1(@vue/test-utils@2.4.6)(happy-dom@20.8.9)(magicast@0.5.2)(playwright-core@1.57.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(happy-dom@20.8.9)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2)))
       vue: 3.5.31(typescript@5.9.3)
     optionalDependencies:
       '@vue/test-utils': 2.4.6
       happy-dom: 20.8.9
       playwright-core: 1.57.0
-      vitest: 4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(happy-dom@20.8.9)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2))
+      vitest: 4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(happy-dom@20.8.9)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))
     transitivePeerDependencies:
       - crossws
       - magicast
       - typescript
       - vite
 
-  '@nuxt/ui@4.6.0(@nuxt/content@)(@tiptap/extensions@3.20.5(@tiptap/core@3.20.5(@tiptap/pm@3.20.5))(@tiptap/pm@3.20.5))(@tiptap/y-tiptap@3.0.1(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.5)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29))(change-case@5.4.4)(db0@0.3.4(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(better-sqlite3@12.8.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(bun-types@1.3.11)(pg@8.20.0)(sqlite3@5.1.7))(sqlite3@5.1.7))(embla-carousel@8.6.0)(ioredis@5.9.2)(magicast@0.5.2)(tailwindcss@4.2.2)(typescript@5.9.3)(valibot@1.3.1(typescript@5.9.3))(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2))(vue-router@5.0.4(@vue/compiler-sfc@3.5.31)(vue@3.5.31(typescript@5.9.3)))(vue@3.5.31(typescript@5.9.3))(yjs@13.6.29)(zod@4.3.6)':
+  '@nuxt/ui@4.6.0(4c785400c9e9821a05d84841d06203de)':
     dependencies:
       '@floating-ui/dom': 1.7.6
       '@iconify/vue': 5.0.0(vue@3.5.31(typescript@5.9.3))
       '@internationalized/date': 3.12.0
       '@internationalized/number': 3.6.5
-      '@nuxt/fonts': 0.14.0(db0@0.3.4(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(better-sqlite3@12.8.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(bun-types@1.3.11)(pg@8.20.0)(sqlite3@5.1.7))(sqlite3@5.1.7))(ioredis@5.9.2)(magicast@0.5.2)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2))
-      '@nuxt/icon': 2.2.1(magicast@0.5.2)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2))(vue@3.5.31(typescript@5.9.3))
+      '@nuxt/fonts': 0.14.0(db0@0.3.4(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(better-sqlite3@12.8.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(bun-types@1.3.11)(pg@8.20.0)(sqlite3@5.1.7))(sqlite3@5.1.7))(ioredis@5.9.2)(magicast@0.5.2)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))
+      '@nuxt/icon': 2.2.1(magicast@0.5.2)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.31(typescript@5.9.3))
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
       '@nuxt/schema': 4.4.2
       '@nuxtjs/color-mode': 3.5.2(magicast@0.5.2)
       '@standard-schema/spec': 1.1.0
       '@tailwindcss/postcss': 4.2.2
-      '@tailwindcss/vite': 4.2.2(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2))
+      '@tailwindcss/vite': 4.2.2(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))
       '@tanstack/vue-table': 8.21.3(vue@3.5.31(typescript@5.9.3))
       '@tanstack/vue-virtual': 3.13.23(vue@3.5.31(typescript@5.9.3))
       '@tiptap/core': 3.20.5(@tiptap/pm@3.20.5)
@@ -11002,20 +11222,20 @@ snapshots:
       - vue
       - yjs
 
-  '@nuxt/ui@4.6.0(@nuxt/content@)(db0@0.3.4(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(better-sqlite3@12.8.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(bun-types@1.3.11)(pg@8.20.0)(sqlite3@5.1.7))(sqlite3@5.1.7))(ioredis@5.9.2)(magicast@0.5.2)(tailwindcss@4.2.2)(typescript@5.9.3)(valibot@1.3.1(typescript@5.9.3))(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2))(vue-router@4.6.4(vue@3.5.31(typescript@5.9.3)))(vue@3.5.31(typescript@5.9.3))(zod@4.3.6)':
+  '@nuxt/ui@4.6.0(@nuxt/content@)(db0@0.3.4(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(better-sqlite3@12.8.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(bun-types@1.3.11)(pg@8.20.0)(sqlite3@5.1.7))(sqlite3@5.1.7))(ioredis@5.9.2)(magicast@0.5.2)(tailwindcss@4.2.2)(typescript@5.9.3)(valibot@1.3.1(typescript@5.9.3))(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))(vue-router@4.6.4(vue@3.5.31(typescript@5.9.3)))(vue@3.5.31(typescript@5.9.3))(zod@4.3.6)':
     dependencies:
       '@floating-ui/dom': 1.7.6
       '@iconify/vue': 5.0.0(vue@3.5.31(typescript@5.9.3))
       '@internationalized/date': 3.12.0
       '@internationalized/number': 3.6.5
-      '@nuxt/fonts': 0.14.0(db0@0.3.4(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(better-sqlite3@12.8.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(bun-types@1.3.11)(pg@8.20.0)(sqlite3@5.1.7))(sqlite3@5.1.7))(ioredis@5.9.2)(magicast@0.5.2)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2))
-      '@nuxt/icon': 2.2.1(magicast@0.5.2)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2))(vue@3.5.31(typescript@5.9.3))
+      '@nuxt/fonts': 0.14.0(db0@0.3.4(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(better-sqlite3@12.8.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(bun-types@1.3.11)(pg@8.20.0)(sqlite3@5.1.7))(sqlite3@5.1.7))(ioredis@5.9.2)(magicast@0.5.2)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))
+      '@nuxt/icon': 2.2.1(magicast@0.5.2)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.31(typescript@5.9.3))
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
       '@nuxt/schema': 4.4.2
       '@nuxtjs/color-mode': 3.5.2(magicast@0.5.2)
       '@standard-schema/spec': 1.1.0
       '@tailwindcss/postcss': 4.2.2
-      '@tailwindcss/vite': 4.2.2(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2))
+      '@tailwindcss/vite': 4.2.2(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))
       '@tanstack/vue-table': 8.21.3(vue@3.5.31(typescript@5.9.3))
       '@tanstack/vue-virtual': 3.13.23(vue@3.5.31(typescript@5.9.3))
       '@tiptap/core': 3.20.5(@tiptap/pm@3.20.5)
@@ -11117,12 +11337,12 @@ snapshots:
       - vue
       - yjs
 
-  '@nuxt/vite-builder@4.4.2(patch_hash=dbfb7f37d331cee8de42bac0867af36d698e9207ed6dfd1415b4b243177e569e)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.5.0)(eslint@10.2.0(jiti@2.6.1))(lightningcss@1.32.0)(magicast@0.5.2)(meow@13.2.0)(nuxt@4.4.2(74ca77075a51a4f968a455dc6a9733ca))(optionator@0.9.4)(rolldown@1.0.0-beta.60)(rollup-plugin-visualizer@6.0.5(rolldown@1.0.0-beta.60)(rollup@4.55.1))(rollup@4.55.1)(terser@5.45.0)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))(vue@3.5.31(typescript@5.9.3))(yaml@2.8.2)':
+  '@nuxt/vite-builder@4.4.2(patch_hash=dbfb7f37d331cee8de42bac0867af36d698e9207ed6dfd1415b4b243177e569e)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.5.0)(eslint@10.2.0(jiti@2.6.1))(lightningcss@1.32.0)(magicast@0.5.2)(meow@13.2.0)(nuxt@4.4.2(689f37f0d1815aef70ee617de16836a1))(optionator@0.9.4)(rolldown@1.0.0-beta.60)(rollup-plugin-visualizer@6.0.5(rolldown@1.0.0-beta.60)(rollup@4.55.1))(rollup@4.55.1)(terser@5.45.0)(tsx@4.21.0)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))(vue@3.5.31(typescript@5.9.3))(yaml@2.8.2)':
     dependencies:
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
       '@rollup/plugin-replace': 6.0.3(rollup@4.55.1)
-      '@vitejs/plugin-vue': 6.0.5(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2))(vue@3.5.31(typescript@5.9.3))
-      '@vitejs/plugin-vue-jsx': 5.1.5(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2))(vue@3.5.31(typescript@5.9.3))
+      '@vitejs/plugin-vue': 6.0.5(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.31(typescript@5.9.3))
+      '@vitejs/plugin-vue-jsx': 5.1.5(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.31(typescript@5.9.3))
       autoprefixer: 10.4.27(postcss@8.5.8)
       consola: 3.4.2
       cssnano: 7.1.3(postcss@8.5.8)
@@ -11135,7 +11355,7 @@ snapshots:
       magic-string: 0.30.21
       mlly: 1.8.2
       mocked-exports: 0.1.1
-      nuxt: 4.4.2(74ca77075a51a4f968a455dc6a9733ca)
+      nuxt: 4.4.2(689f37f0d1815aef70ee617de16836a1)
       nypm: 0.6.5
       pathe: 2.0.3
       pkg-types: 2.3.0
@@ -11144,9 +11364,9 @@ snapshots:
       std-env: 4.0.0
       ufo: 1.6.3
       unenv: 2.0.0-rc.24
-      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2)
-      vite-node: 5.3.0(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2)
-      vite-plugin-checker: 0.12.0(eslint@10.2.0(jiti@2.6.1))(meow@13.2.0)(optionator@0.9.4)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2))(vue-tsc@3.2.6(typescript@5.9.3))
+      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2)
+      vite-node: 5.3.0(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2)
+      vite-plugin-checker: 0.12.0(eslint@10.2.0(jiti@2.6.1))(meow@13.2.0)(optionator@0.9.4)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))(vue-tsc@3.2.6(typescript@5.9.3))
       vue: 3.5.31(typescript@5.9.3)
       vue-bundle-renderer: 2.2.0
     optionalDependencies:
@@ -11178,12 +11398,12 @@ snapshots:
       - vue-tsc
       - yaml
 
-  '@nuxt/vite-builder@4.4.2(patch_hash=dbfb7f37d331cee8de42bac0867af36d698e9207ed6dfd1415b4b243177e569e)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.5.0)(eslint@10.2.0(jiti@2.6.1))(lightningcss@1.32.0)(magicast@0.5.2)(meow@13.2.0)(nuxt@4.4.2(7be7cf16033bc8e0ea270e2ef8ce91a0))(optionator@0.9.4)(rolldown@1.0.0-beta.57)(rollup-plugin-visualizer@6.0.5(rolldown@1.0.0-beta.57)(rollup@4.55.1))(rollup@4.55.1)(terser@5.45.0)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))(vue@3.5.31(typescript@5.9.3))(yaml@2.8.2)':
+  '@nuxt/vite-builder@4.4.2(patch_hash=dbfb7f37d331cee8de42bac0867af36d698e9207ed6dfd1415b4b243177e569e)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.5.0)(eslint@10.2.0(jiti@2.6.1))(lightningcss@1.32.0)(magicast@0.5.2)(meow@13.2.0)(nuxt@4.4.2(910e22d445e98b1636c763310179f6e7))(optionator@0.9.4)(rolldown@1.0.0-beta.57)(rollup-plugin-visualizer@6.0.5(rolldown@1.0.0-beta.57)(rollup@4.55.1))(rollup@4.55.1)(terser@5.45.0)(tsx@4.21.0)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))(vue@3.5.31(typescript@5.9.3))(yaml@2.8.2)':
     dependencies:
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
       '@rollup/plugin-replace': 6.0.3(rollup@4.55.1)
-      '@vitejs/plugin-vue': 6.0.5(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2))(vue@3.5.31(typescript@5.9.3))
-      '@vitejs/plugin-vue-jsx': 5.1.5(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2))(vue@3.5.31(typescript@5.9.3))
+      '@vitejs/plugin-vue': 6.0.5(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.31(typescript@5.9.3))
+      '@vitejs/plugin-vue-jsx': 5.1.5(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.31(typescript@5.9.3))
       autoprefixer: 10.4.27(postcss@8.5.8)
       consola: 3.4.2
       cssnano: 7.1.3(postcss@8.5.8)
@@ -11196,7 +11416,7 @@ snapshots:
       magic-string: 0.30.21
       mlly: 1.8.2
       mocked-exports: 0.1.1
-      nuxt: 4.4.2(7be7cf16033bc8e0ea270e2ef8ce91a0)
+      nuxt: 4.4.2(910e22d445e98b1636c763310179f6e7)
       nypm: 0.6.5
       pathe: 2.0.3
       pkg-types: 2.3.0
@@ -11205,9 +11425,9 @@ snapshots:
       std-env: 4.0.0
       ufo: 1.6.3
       unenv: 2.0.0-rc.24
-      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2)
-      vite-node: 5.3.0(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2)
-      vite-plugin-checker: 0.12.0(eslint@10.2.0(jiti@2.6.1))(meow@13.2.0)(optionator@0.9.4)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2))(vue-tsc@3.2.6(typescript@5.9.3))
+      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2)
+      vite-node: 5.3.0(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2)
+      vite-plugin-checker: 0.12.0(eslint@10.2.0(jiti@2.6.1))(meow@13.2.0)(optionator@0.9.4)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))(vue-tsc@3.2.6(typescript@5.9.3))
       vue: 3.5.31(typescript@5.9.3)
       vue-bundle-renderer: 2.2.0
     optionalDependencies:
@@ -11491,15 +11711,15 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxtjs/robots@5.7.1(magicast@0.5.2)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2))(vue@3.5.31(typescript@5.9.3))(zod@4.3.6)':
+  '@nuxtjs/robots@5.7.1(magicast@0.5.2)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.31(typescript@5.9.3))(zod@4.3.6)':
     dependencies:
       '@fingerprintjs/botd': 2.0.0
-      '@nuxt/devtools-kit': 3.2.4(magicast@0.5.2)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2))
+      '@nuxt/devtools-kit': 3.2.4(magicast@0.5.2)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
       consola: 3.4.2
       defu: 6.1.7
       h3: 1.15.10
-      nuxt-site-config: 3.2.21(magicast@0.5.2)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2))(vue@3.5.31(typescript@5.9.3))
+      nuxt-site-config: 3.2.21(magicast@0.5.2)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.31(typescript@5.9.3))
       pathe: 2.0.3
       pkg-types: 2.3.0
       sirv: 3.0.2
@@ -12521,12 +12741,12 @@ snapshots:
       postcss: 8.5.8
       tailwindcss: 4.2.2
 
-  '@tailwindcss/vite@4.2.2(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2))':
+  '@tailwindcss/vite@4.2.2(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@tailwindcss/node': 4.2.2
       '@tailwindcss/oxide': 4.2.2
       tailwindcss: 4.2.2
-      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2)
 
   '@tanstack/table-core@8.21.3': {}
 
@@ -13055,9 +13275,9 @@ snapshots:
     dependencies:
       valibot: 1.3.1(typescript@5.9.3)
 
-  '@vercel/analytics@2.0.1(nuxt@4.4.2(7be7cf16033bc8e0ea270e2ef8ce91a0))(vue-router@4.6.4(vue@3.5.31(typescript@5.9.3)))(vue@3.5.31(typescript@5.9.3))':
+  '@vercel/analytics@2.0.1(nuxt@4.4.2(910e22d445e98b1636c763310179f6e7))(vue-router@4.6.4(vue@3.5.31(typescript@5.9.3)))(vue@3.5.31(typescript@5.9.3))':
     optionalDependencies:
-      nuxt: 4.4.2(7be7cf16033bc8e0ea270e2ef8ce91a0)
+      nuxt: 4.4.2(910e22d445e98b1636c763310179f6e7)
       vue: 3.5.31(typescript@5.9.3)
       vue-router: 4.6.4(vue@3.5.31(typescript@5.9.3))
 
@@ -13082,28 +13302,28 @@ snapshots:
 
   '@vercel/oidc@3.1.0': {}
 
-  '@vercel/speed-insights@2.0.0(nuxt@4.4.2(7be7cf16033bc8e0ea270e2ef8ce91a0))(vue-router@4.6.4(vue@3.5.31(typescript@5.9.3)))(vue@3.5.31(typescript@5.9.3))':
+  '@vercel/speed-insights@2.0.0(nuxt@4.4.2(910e22d445e98b1636c763310179f6e7))(vue-router@4.6.4(vue@3.5.31(typescript@5.9.3)))(vue@3.5.31(typescript@5.9.3))':
     optionalDependencies:
-      nuxt: 4.4.2(7be7cf16033bc8e0ea270e2ef8ce91a0)
+      nuxt: 4.4.2(910e22d445e98b1636c763310179f6e7)
       vue: 3.5.31(typescript@5.9.3)
       vue-router: 4.6.4(vue@3.5.31(typescript@5.9.3))
 
-  '@vitejs/plugin-vue-jsx@5.1.5(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2))(vue@3.5.31(typescript@5.9.3))':
+  '@vitejs/plugin-vue-jsx@5.1.5(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.31(typescript@5.9.3))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
       '@babel/plugin-transform-typescript': 7.28.6(@babel/core@7.29.0)
       '@rolldown/pluginutils': 1.0.0-rc.12
       '@vue/babel-plugin-jsx': 2.0.1(@babel/core@7.29.0)
-      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2)
       vue: 3.5.31(typescript@5.9.3)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-vue@6.0.5(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2))(vue@3.5.31(typescript@5.9.3))':
+  '@vitejs/plugin-vue@6.0.5(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.31(typescript@5.9.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.2
-      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2)
       vue: 3.5.31(typescript@5.9.3)
 
   '@vitest/expect@4.1.2':
@@ -13115,13 +13335,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.2(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2))':
+  '@vitest/mocker@4.1.2(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@vitest/spy': 4.1.2
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitest/pretty-format@4.1.2':
     dependencies:
@@ -13340,13 +13560,13 @@ snapshots:
 
   '@vueuse/metadata@14.2.1': {}
 
-  '@vueuse/nuxt@14.2.1(magicast@0.5.2)(nuxt@4.4.2(7be7cf16033bc8e0ea270e2ef8ce91a0))(vue@3.5.31(typescript@5.9.3))':
+  '@vueuse/nuxt@14.2.1(magicast@0.5.2)(nuxt@4.4.2(910e22d445e98b1636c763310179f6e7))(vue@3.5.31(typescript@5.9.3))':
     dependencies:
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
       '@vueuse/core': 14.2.1(vue@3.5.31(typescript@5.9.3))
       '@vueuse/metadata': 14.2.1
       local-pkg: 1.1.2
-      nuxt: 4.4.2(7be7cf16033bc8e0ea270e2ef8ce91a0)
+      nuxt: 4.4.2(910e22d445e98b1636c763310179f6e7)
       vue: 3.5.31(typescript@5.9.3)
     transitivePeerDependencies:
       - magicast
@@ -14151,7 +14371,7 @@ snapshots:
 
   diff@8.0.3: {}
 
-  docus@5.8.1(04cfad179a9a0be44e826fef42864c61):
+  docus@5.8.1(19215eb0f5756d496aad7f2b1d12f74c):
     dependencies:
       '@ai-sdk/gateway': 3.0.82(zod@4.3.6)
       '@ai-sdk/mcp': 1.0.30(zod@4.3.6)
@@ -14162,11 +14382,11 @@ snapshots:
       '@nuxt/content': 'link:'
       '@nuxt/image': 2.0.0(db0@0.3.4(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(better-sqlite3@12.8.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(bun-types@1.3.11)(pg@8.20.0)(sqlite3@5.1.7))(sqlite3@5.1.7))(ioredis@5.9.2)(magicast@0.5.2)
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
-      '@nuxt/ui': 4.6.0(@nuxt/content@)(db0@0.3.4(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(better-sqlite3@12.8.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(bun-types@1.3.11)(pg@8.20.0)(sqlite3@5.1.7))(sqlite3@5.1.7))(ioredis@5.9.2)(magicast@0.5.2)(tailwindcss@4.2.2)(typescript@5.9.3)(valibot@1.3.1(typescript@5.9.3))(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2))(vue-router@4.6.4(vue@3.5.31(typescript@5.9.3)))(vue@3.5.31(typescript@5.9.3))(zod@4.3.6)
+      '@nuxt/ui': 4.6.0(@nuxt/content@)(db0@0.3.4(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(better-sqlite3@12.8.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(bun-types@1.3.11)(pg@8.20.0)(sqlite3@5.1.7))(sqlite3@5.1.7))(ioredis@5.9.2)(magicast@0.5.2)(tailwindcss@4.2.2)(typescript@5.9.3)(valibot@1.3.1(typescript@5.9.3))(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))(vue-router@4.6.4(vue@3.5.31(typescript@5.9.3)))(vue@3.5.31(typescript@5.9.3))(zod@4.3.6)
       '@nuxtjs/i18n': 10.2.4(@vue/compiler-dom@3.5.31)(db0@0.3.4(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(better-sqlite3@12.8.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(bun-types@1.3.11)(pg@8.20.0)(sqlite3@5.1.7))(sqlite3@5.1.7))(eslint@10.2.0(jiti@2.6.1))(ioredis@5.9.2)(magicast@0.5.2)(rollup@4.55.1)(typescript@5.9.3)(vue@3.5.31(typescript@5.9.3))
       '@nuxtjs/mcp-toolkit': 0.7.0(magicast@0.5.2)(zod@4.3.6)
       '@nuxtjs/mdc': 0.20.2(magicast@0.5.2)
-      '@nuxtjs/robots': 5.7.1(magicast@0.5.2)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2))(vue@3.5.31(typescript@5.9.3))(zod@4.3.6)
+      '@nuxtjs/robots': 5.7.1(magicast@0.5.2)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.31(typescript@5.9.3))(zod@4.3.6)
       '@shikijs/core': 3.23.0
       '@shikijs/engine-javascript': 3.23.0
       '@shikijs/langs': 3.23.0
@@ -14178,9 +14398,9 @@ snapshots:
       exsolve: 1.0.8
       git-url-parse: 16.1.0
       motion-v: 1.10.3(@vueuse/core@14.2.1(vue@3.5.31(typescript@5.9.3)))(vue@3.5.31(typescript@5.9.3))
-      nuxt: 4.4.2(7be7cf16033bc8e0ea270e2ef8ce91a0)
+      nuxt: 4.4.2(910e22d445e98b1636c763310179f6e7)
       nuxt-llms: 0.2.0(magicast@0.5.2)
-      nuxt-og-image: 5.1.13(@unhead/vue@2.1.12(vue@3.5.31(typescript@5.9.3)))(magicast@0.5.2)(unstorage@1.17.4(db0@0.3.4(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(better-sqlite3@12.8.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(bun-types@1.3.11)(pg@8.20.0)(sqlite3@5.1.7))(sqlite3@5.1.7))(ioredis@5.9.2))(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2))(vue@3.5.31(typescript@5.9.3))
+      nuxt-og-image: 5.1.13(@unhead/vue@2.1.12(vue@3.5.31(typescript@5.9.3)))(magicast@0.5.2)(unstorage@1.17.4(db0@0.3.4(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(better-sqlite3@12.8.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(bun-types@1.3.11)(pg@8.20.0)(sqlite3@5.1.7))(sqlite3@5.1.7))(ioredis@5.9.2))(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.31(typescript@5.9.3))
       pkg-types: 2.3.0
       scule: 1.3.0
       shiki-stream: 0.1.4(vue@3.5.31(typescript@5.9.3))
@@ -14276,6 +14496,13 @@ snapshots:
       is-obj: 2.0.0
 
   dotenv@17.2.3: {}
+
+  drizzle-kit@0.31.10:
+    dependencies:
+      '@drizzle-team/brocli': 0.10.2
+      '@esbuild-kit/esm-loader': 2.6.5
+      esbuild: 0.25.12
+      tsx: 4.21.0
 
   drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(bun-types@1.3.11)(pg@8.20.0)(sqlite3@5.1.7):
     optionalDependencies:
@@ -14417,6 +14644,31 @@ snapshots:
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
+
+  esbuild@0.18.20:
+    optionalDependencies:
+      '@esbuild/android-arm': 0.18.20
+      '@esbuild/android-arm64': 0.18.20
+      '@esbuild/android-x64': 0.18.20
+      '@esbuild/darwin-arm64': 0.18.20
+      '@esbuild/darwin-x64': 0.18.20
+      '@esbuild/freebsd-arm64': 0.18.20
+      '@esbuild/freebsd-x64': 0.18.20
+      '@esbuild/linux-arm': 0.18.20
+      '@esbuild/linux-arm64': 0.18.20
+      '@esbuild/linux-ia32': 0.18.20
+      '@esbuild/linux-loong64': 0.18.20
+      '@esbuild/linux-mips64el': 0.18.20
+      '@esbuild/linux-ppc64': 0.18.20
+      '@esbuild/linux-riscv64': 0.18.20
+      '@esbuild/linux-s390x': 0.18.20
+      '@esbuild/linux-x64': 0.18.20
+      '@esbuild/netbsd-x64': 0.18.20
+      '@esbuild/openbsd-x64': 0.18.20
+      '@esbuild/sunos-x64': 0.18.20
+      '@esbuild/win32-arm64': 0.18.20
+      '@esbuild/win32-ia32': 0.18.20
+      '@esbuild/win32-x64': 0.18.20
 
   esbuild@0.25.12:
     optionalDependencies:
@@ -14891,7 +15143,7 @@ snapshots:
     dependencies:
       tiny-inflate: 1.0.3
 
-  fontless@0.2.1(db0@0.3.4(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(better-sqlite3@12.8.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(bun-types@1.3.11)(pg@8.20.0)(sqlite3@5.1.7))(sqlite3@5.1.7))(ioredis@5.9.2)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2)):
+  fontless@0.2.1(db0@0.3.4(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(better-sqlite3@12.8.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(bun-types@1.3.11)(pg@8.20.0)(sqlite3@5.1.7))(sqlite3@5.1.7))(ioredis@5.9.2)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
       consola: 3.4.2
       css-tree: 3.1.0
@@ -14907,7 +15159,7 @@ snapshots:
       unifont: 0.7.4
       unstorage: 1.17.4(db0@0.3.4(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(better-sqlite3@12.8.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(bun-types@1.3.11)(pg@8.20.0)(sqlite3@5.1.7))(sqlite3@5.1.7))(ioredis@5.9.2)
     optionalDependencies:
-      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -16802,9 +17054,9 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  nuxt-og-image@5.1.13(@unhead/vue@2.1.12(vue@3.5.31(typescript@5.9.3)))(magicast@0.5.2)(unstorage@1.17.4(db0@0.3.4(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(better-sqlite3@12.8.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(bun-types@1.3.11)(pg@8.20.0)(sqlite3@5.1.7))(sqlite3@5.1.7))(ioredis@5.9.2))(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2))(vue@3.5.31(typescript@5.9.3)):
+  nuxt-og-image@5.1.13(@unhead/vue@2.1.12(vue@3.5.31(typescript@5.9.3)))(magicast@0.5.2)(unstorage@1.17.4(db0@0.3.4(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(better-sqlite3@12.8.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(bun-types@1.3.11)(pg@8.20.0)(sqlite3@5.1.7))(sqlite3@5.1.7))(ioredis@5.9.2))(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.31(typescript@5.9.3)):
     dependencies:
-      '@nuxt/devtools-kit': 3.2.4(magicast@0.5.2)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2))
+      '@nuxt/devtools-kit': 3.2.4(magicast@0.5.2)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
       '@resvg/resvg-js': 2.6.2
       '@resvg/resvg-wasm': 2.6.2
@@ -16818,7 +17070,7 @@ snapshots:
       image-size: 2.0.2
       magic-string: 0.30.21
       mocked-exports: 0.1.1
-      nuxt-site-config: 3.2.21(magicast@0.5.2)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2))(vue@3.5.31(typescript@5.9.3))
+      nuxt-site-config: 3.2.21(magicast@0.5.2)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.31(typescript@5.9.3))
       nypm: 0.6.5
       ofetch: 1.5.1
       ohash: 2.0.11
@@ -16853,9 +17105,9 @@ snapshots:
       - magicast
       - vue
 
-  nuxt-site-config@3.2.21(magicast@0.5.2)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2))(vue@3.5.31(typescript@5.9.3)):
+  nuxt-site-config@3.2.21(magicast@0.5.2)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.31(typescript@5.9.3)):
     dependencies:
-      '@nuxt/devtools-kit': 3.2.4(magicast@0.5.2)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2))
+      '@nuxt/devtools-kit': 3.2.4(magicast@0.5.2)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
       h3: 1.15.10
       nuxt-site-config-kit: 3.2.21(magicast@0.5.2)(vue@3.5.31(typescript@5.9.3))
@@ -16912,16 +17164,16 @@ snapshots:
       - uploadthing
       - vue
 
-  nuxt@4.4.2(74ca77075a51a4f968a455dc6a9733ca):
+  nuxt@4.4.2(689f37f0d1815aef70ee617de16836a1):
     dependencies:
       '@dxup/nuxt': 0.4.0(magicast@0.5.2)(typescript@5.9.3)
       '@nuxt/cli': 3.34.0(@nuxt/schema@4.4.2)(cac@6.7.14)(magicast@0.5.2)
-      '@nuxt/devtools': 3.2.4(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2))(vue@3.5.31(typescript@5.9.3))
+      '@nuxt/devtools': 3.2.4(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.31(typescript@5.9.3))
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
-      '@nuxt/nitro-server': 4.4.2(@babel/core@7.29.0)(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(better-sqlite3@12.8.0)(db0@0.3.4(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(better-sqlite3@12.8.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(bun-types@1.3.11)(pg@8.20.0)(sqlite3@5.1.7))(sqlite3@5.1.7))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(bun-types@1.3.11)(pg@8.20.0)(sqlite3@5.1.7))(encoding@0.1.13)(ioredis@5.9.2)(magicast@0.5.2)(nuxt@4.4.2(74ca77075a51a4f968a455dc6a9733ca))(rolldown@1.0.0-beta.60)(sqlite3@5.1.7)(typescript@5.9.3)
+      '@nuxt/nitro-server': 4.4.2(@babel/core@7.29.0)(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(better-sqlite3@12.8.0)(db0@0.3.4(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(better-sqlite3@12.8.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(bun-types@1.3.11)(pg@8.20.0)(sqlite3@5.1.7))(sqlite3@5.1.7))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(bun-types@1.3.11)(pg@8.20.0)(sqlite3@5.1.7))(encoding@0.1.13)(ioredis@5.9.2)(magicast@0.5.2)(nuxt@4.4.2(689f37f0d1815aef70ee617de16836a1))(rolldown@1.0.0-beta.60)(sqlite3@5.1.7)(typescript@5.9.3)
       '@nuxt/schema': 4.4.2
       '@nuxt/telemetry': 2.7.0(@nuxt/kit@4.4.2(magicast@0.5.2))
-      '@nuxt/vite-builder': 4.4.2(patch_hash=dbfb7f37d331cee8de42bac0867af36d698e9207ed6dfd1415b4b243177e569e)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.5.0)(eslint@10.2.0(jiti@2.6.1))(lightningcss@1.32.0)(magicast@0.5.2)(meow@13.2.0)(nuxt@4.4.2(74ca77075a51a4f968a455dc6a9733ca))(optionator@0.9.4)(rolldown@1.0.0-beta.60)(rollup-plugin-visualizer@6.0.5(rolldown@1.0.0-beta.60)(rollup@4.55.1))(rollup@4.55.1)(terser@5.45.0)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))(vue@3.5.31(typescript@5.9.3))(yaml@2.8.2)
+      '@nuxt/vite-builder': 4.4.2(patch_hash=dbfb7f37d331cee8de42bac0867af36d698e9207ed6dfd1415b4b243177e569e)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.5.0)(eslint@10.2.0(jiti@2.6.1))(lightningcss@1.32.0)(magicast@0.5.2)(meow@13.2.0)(nuxt@4.4.2(689f37f0d1815aef70ee617de16836a1))(optionator@0.9.4)(rolldown@1.0.0-beta.60)(rollup-plugin-visualizer@6.0.5(rolldown@1.0.0-beta.60)(rollup@4.55.1))(rollup@4.55.1)(terser@5.45.0)(tsx@4.21.0)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))(vue@3.5.31(typescript@5.9.3))(yaml@2.8.2)
       '@unhead/vue': 2.1.12(vue@3.5.31(typescript@5.9.3))
       '@vue/shared': 3.5.31
       c12: 3.3.3(magicast@0.5.2)
@@ -17041,16 +17293,16 @@ snapshots:
       - xml2js
       - yaml
 
-  nuxt@4.4.2(7be7cf16033bc8e0ea270e2ef8ce91a0):
+  nuxt@4.4.2(910e22d445e98b1636c763310179f6e7):
     dependencies:
       '@dxup/nuxt': 0.4.0(magicast@0.5.2)(typescript@5.9.3)
       '@nuxt/cli': 3.34.0(@nuxt/schema@4.4.2)(cac@6.7.14)(magicast@0.5.2)
-      '@nuxt/devtools': 3.2.4(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2))(vue@3.5.31(typescript@5.9.3))
+      '@nuxt/devtools': 3.2.4(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.31(typescript@5.9.3))
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
-      '@nuxt/nitro-server': 4.4.2(@babel/core@7.29.0)(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(better-sqlite3@12.8.0)(db0@0.3.4(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(better-sqlite3@12.8.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(bun-types@1.3.11)(pg@8.20.0)(sqlite3@5.1.7))(sqlite3@5.1.7))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(bun-types@1.3.11)(pg@8.20.0)(sqlite3@5.1.7))(encoding@0.1.13)(ioredis@5.9.2)(magicast@0.5.2)(nuxt@4.4.2(7be7cf16033bc8e0ea270e2ef8ce91a0))(rolldown@1.0.0-beta.57)(sqlite3@5.1.7)(typescript@5.9.3)
+      '@nuxt/nitro-server': 4.4.2(@babel/core@7.29.0)(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(better-sqlite3@12.8.0)(db0@0.3.4(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(better-sqlite3@12.8.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(bun-types@1.3.11)(pg@8.20.0)(sqlite3@5.1.7))(sqlite3@5.1.7))(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@electric-sql/pglite@0.4.2)(@libsql/client@0.17.2(encoding@0.1.13))(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(better-sqlite3@12.8.0)(bun-types@1.3.11)(pg@8.20.0)(sqlite3@5.1.7))(encoding@0.1.13)(ioredis@5.9.2)(magicast@0.5.2)(nuxt@4.4.2(910e22d445e98b1636c763310179f6e7))(rolldown@1.0.0-beta.57)(sqlite3@5.1.7)(typescript@5.9.3)
       '@nuxt/schema': 4.4.2
       '@nuxt/telemetry': 2.7.0(@nuxt/kit@4.4.2(magicast@0.5.2))
-      '@nuxt/vite-builder': 4.4.2(patch_hash=dbfb7f37d331cee8de42bac0867af36d698e9207ed6dfd1415b4b243177e569e)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.5.0)(eslint@10.2.0(jiti@2.6.1))(lightningcss@1.32.0)(magicast@0.5.2)(meow@13.2.0)(nuxt@4.4.2(7be7cf16033bc8e0ea270e2ef8ce91a0))(optionator@0.9.4)(rolldown@1.0.0-beta.57)(rollup-plugin-visualizer@6.0.5(rolldown@1.0.0-beta.57)(rollup@4.55.1))(rollup@4.55.1)(terser@5.45.0)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))(vue@3.5.31(typescript@5.9.3))(yaml@2.8.2)
+      '@nuxt/vite-builder': 4.4.2(patch_hash=dbfb7f37d331cee8de42bac0867af36d698e9207ed6dfd1415b4b243177e569e)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@25.5.0)(eslint@10.2.0(jiti@2.6.1))(lightningcss@1.32.0)(magicast@0.5.2)(meow@13.2.0)(nuxt@4.4.2(910e22d445e98b1636c763310179f6e7))(optionator@0.9.4)(rolldown@1.0.0-beta.57)(rollup-plugin-visualizer@6.0.5(rolldown@1.0.0-beta.57)(rollup@4.55.1))(rollup@4.55.1)(terser@5.45.0)(tsx@4.21.0)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.9.3))(vue@3.5.31(typescript@5.9.3))(yaml@2.8.2)
       '@unhead/vue': 2.1.12(vue@3.5.31(typescript@5.9.3))
       '@vue/shared': 3.5.31
       c12: 3.3.3(magicast@0.5.2)
@@ -17507,13 +17759,15 @@ snapshots:
   pg-cloudflare@1.3.0:
     optional: true
 
-  pg-connection-string@2.12.0: {}
+  pg-connection-string@2.12.0:
+    optional: true
 
   pg-int8@1.0.1: {}
 
   pg-pool@3.13.0(pg@8.20.0):
     dependencies:
       pg: 8.20.0
+    optional: true
 
   pg-protocol@1.13.0: {}
 
@@ -17534,10 +17788,12 @@ snapshots:
       pgpass: 1.0.5
     optionalDependencies:
       pg-cloudflare: 1.3.0
+    optional: true
 
   pgpass@1.0.5:
     dependencies:
       split2: 4.2.0
+    optional: true
 
   picocolors@1.1.1: {}
 
@@ -18694,7 +18950,8 @@ snapshots:
 
   spdx-license-ids@3.0.22: {}
 
-  split2@4.2.0: {}
+  split2@4.2.0:
+    optional: true
 
   sqlite3@5.1.7:
     dependencies:
@@ -18981,6 +19238,13 @@ snapshots:
       - vue-tsc
 
   tslib@2.8.1: {}
+
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.3
+      get-tsconfig: 4.13.0
+    optionalDependencies:
+      fsevents: 2.3.3
 
   tunnel-agent@0.6.0:
     dependencies:
@@ -19390,23 +19654,23 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-dev-rpc@1.1.0(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2)):
+  vite-dev-rpc@1.1.0(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
       birpc: 2.9.0
-      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2)
-      vite-hot-client: 2.1.0(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2))
+      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2)
+      vite-hot-client: 2.1.0(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))
 
-  vite-hot-client@2.1.0(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2)):
+  vite-hot-client@2.1.0(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
-      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2)
 
-  vite-node@5.3.0(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2):
+  vite-node@5.3.0(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       cac: 6.7.14
       es-module-lexer: 2.0.0
       obug: 2.1.1
       pathe: 2.0.3
-      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -19420,7 +19684,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-checker@0.12.0(eslint@10.2.0(jiti@2.6.1))(meow@13.2.0)(optionator@0.9.4)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2))(vue-tsc@3.2.6(typescript@5.9.3)):
+  vite-plugin-checker@0.12.0(eslint@10.2.0(jiti@2.6.1))(meow@13.2.0)(optionator@0.9.4)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))(vue-tsc@3.2.6(typescript@5.9.3)):
     dependencies:
       '@babel/code-frame': 7.29.0
       chokidar: 4.0.3
@@ -19429,7 +19693,7 @@ snapshots:
       picomatch: 4.0.3
       tiny-invariant: 1.3.3
       tinyglobby: 0.2.15
-      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2)
       vscode-uri: 3.1.0
     optionalDependencies:
       eslint: 10.2.0(jiti@2.6.1)
@@ -19438,7 +19702,7 @@ snapshots:
       typescript: 5.9.3
       vue-tsc: 3.2.6(typescript@5.9.3)
 
-  vite-plugin-inspect@11.3.3(@nuxt/kit@4.4.2(magicast@0.5.2))(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2)):
+  vite-plugin-inspect@11.3.3(@nuxt/kit@4.4.2(magicast@0.5.2))(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
       ansis: 4.2.0
       debug: 4.4.3
@@ -19448,24 +19712,24 @@ snapshots:
       perfect-debounce: 2.1.0
       sirv: 3.0.2
       unplugin-utils: 0.3.1
-      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2)
-      vite-dev-rpc: 1.1.0(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2))
+      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2)
+      vite-dev-rpc: 1.1.0(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))
     optionalDependencies:
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-vue-tracer@1.3.0(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2))(vue@3.5.31(typescript@5.9.3)):
+  vite-plugin-vue-tracer@1.3.0(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.31(typescript@5.9.3)):
     dependencies:
       estree-walker: 3.0.3
       exsolve: 1.0.8
       magic-string: 0.30.21
       pathe: 2.0.3
       source-map-js: 1.2.1
-      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2)
       vue: 3.5.31(typescript@5.9.3)
 
-  vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2):
+  vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       esbuild: 0.27.3
       fdir: 6.5.0(picomatch@4.0.3)
@@ -19479,11 +19743,12 @@ snapshots:
       jiti: 2.6.1
       lightningcss: 1.32.0
       terser: 5.45.0
+      tsx: 4.21.0
       yaml: 2.8.2
 
-  vitest-environment-nuxt@1.0.1(@vue/test-utils@2.4.6)(happy-dom@20.8.9)(magicast@0.5.2)(playwright-core@1.57.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2))(vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(happy-dom@20.8.9)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2))):
+  vitest-environment-nuxt@1.0.1(@vue/test-utils@2.4.6)(happy-dom@20.8.9)(magicast@0.5.2)(playwright-core@1.57.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(happy-dom@20.8.9)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))):
     dependencies:
-      '@nuxt/test-utils': 4.0.0(@vue/test-utils@2.4.6)(happy-dom@20.8.9)(magicast@0.5.2)(playwright-core@1.57.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2))(vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(happy-dom@20.8.9)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2)))
+      '@nuxt/test-utils': 4.0.0(@vue/test-utils@2.4.6)(happy-dom@20.8.9)(magicast@0.5.2)(playwright-core@1.57.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(happy-dom@20.8.9)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2)))
     transitivePeerDependencies:
       - '@cucumber/cucumber'
       - '@jest/globals'
@@ -19500,10 +19765,10 @@ snapshots:
       - vite
       - vitest
 
-  vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(happy-dom@20.8.9)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2)):
+  vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(happy-dom@20.8.9)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
       '@vitest/expect': 4.1.2
-      '@vitest/mocker': 4.1.2(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2))
+      '@vitest/mocker': 4.1.2(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2))
       '@vitest/pretty-format': 4.1.2
       '@vitest/runner': 4.1.2
       '@vitest/snapshot': 4.1.2
@@ -19520,7 +19785,7 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.45.0)(tsx@4.21.0)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0

--- a/src/module.ts
+++ b/src/module.ts
@@ -134,6 +134,7 @@ export default defineNuxtModule<ModuleOptions>({
       { name: 'queryCollectionSearchSections', from: resolver.resolve('./runtime/client') },
       { name: 'queryCollectionNavigation', from: resolver.resolve('./runtime/client') },
       { name: 'queryCollectionItemSurroundings', from: resolver.resolve('./runtime/client') },
+      { name: 'useSearchCollection', from: resolver.resolve('./runtime/client') },
     ])
     addServerImports([
       { name: 'queryCollection', from: resolver.resolve('./runtime/nitro') },

--- a/src/runtime/client.ts
+++ b/src/runtime/client.ts
@@ -52,6 +52,8 @@ export function useSearchCollection<T extends keyof PageCollections>(
 
   async function init() {
     const collections = resolveCollections()
+    if (!collections.length) return initPromise ?? Promise.resolve(db!)
+
     const hasRemovedCollections = indexedFor.some(c => !collections.includes(c))
     const newCollections = collections.filter(c => !indexedFor.includes(c))
 

--- a/src/runtime/client.ts
+++ b/src/runtime/client.ts
@@ -3,10 +3,11 @@ import { collectionQueryBuilder } from './internal/query'
 import { generateNavigationTree } from './internal/navigation'
 import { generateItemSurround } from './internal/surround'
 import type { GenerateSearchSectionsOptions, SearchCollectionOptions, SearchResult } from './internal/search'
-import { generateSearchSections, buildFTSIndex, queryFTS } from './internal/search'
+import { generateSearchSections, buildFTSIndex, queryFTS, resetFTSIndex } from './internal/search'
 import { fetchQuery } from './internal/api'
 import type { Collections, PageCollections, CollectionQueryBuilder, SurroundOptions, SQLOperator, QueryGroupFunction, ContentNavigationItem, DatabaseAdapter } from '@nuxt/content'
-import { ref, tryUseNuxtApp } from '#imports'
+import { ref, toValue, watch, tryUseNuxtApp } from '#imports'
+import type { MaybeRefOrGetter } from 'vue'
 
 export type { SearchCollectionOptions, SearchResult, GenerateSearchSectionsOptions } from './internal/search'
 
@@ -35,26 +36,43 @@ export function queryCollectionSearchSections<T extends keyof PageCollections>(c
 }
 
 export function useSearchCollection<T extends keyof PageCollections>(
-  collection: T | T[],
+  collection: MaybeRefOrGetter<T | T[]>,
   opts?: GenerateSearchSectionsOptions & { immediate?: boolean },
 ) {
   const { immediate = true, ...indexOpts } = opts || {}
-  const collections = (Array.isArray(collection) ? collection : [collection]).map(String)
   const status = ref<'idle' | 'loading' | 'ready' | 'error'>(immediate ? 'loading' : 'idle')
   let db: DatabaseAdapter | undefined
   let initPromise: Promise<DatabaseAdapter> | undefined
+  let indexedFor: string[] = []
 
-  function init() {
-    if (initPromise) return initPromise
+  function resolveCollections() {
+    const val = toValue(collection)
+    return (Array.isArray(val) ? val : [val]).map(String)
+  }
+
+  async function init() {
+    const collections = resolveCollections()
+    const hasRemovedCollections = indexedFor.some(c => !collections.includes(c))
+    const newCollections = collections.filter(c => !indexedFor.includes(c))
+
+    if (!newCollections.length && !hasRemovedCollections && initPromise) return initPromise
+
     status.value = 'loading'
     initPromise = import('./internal/database.client')
       .then(m => m.loadDatabaseAdapter(collections[0]!))
       .then(async (_db) => {
         db = _db
-        await Promise.all(collections.map((col) => {
+
+        if (hasRemovedCollections) {
+          await resetFTSIndex(_db)
+        }
+
+        const toIndex = hasRemovedCollections ? collections : newCollections
+        await Promise.all(toIndex.map((col) => {
           const qb = queryCollection(col as T)
           return buildFTSIndex(_db, col, qb, indexOpts)
         }))
+        indexedFor = [...collections]
         status.value = 'ready'
         return _db
       })
@@ -65,14 +83,15 @@ export function useSearchCollection<T extends keyof PageCollections>(
     return initPromise
   }
 
-  if (immediate && import.meta.client) {
-    init()
+  if (import.meta.client) {
+    watch(() => toValue(collection), () => init(), { immediate })
   }
 
   async function search(query: string, searchOpts?: SearchCollectionOptions): Promise<SearchResult[]> {
     if (!db) {
       await init()
     }
+    const collections = resolveCollections()
     return queryFTS(db!, collections, query, searchOpts)
   }
 

--- a/src/runtime/client.ts
+++ b/src/runtime/client.ts
@@ -2,14 +2,14 @@ import type { H3Event } from 'h3'
 import { collectionQueryBuilder } from './internal/query'
 import { generateNavigationTree } from './internal/navigation'
 import { generateItemSurround } from './internal/surround'
-import type { GenerateSearchSectionsOptions, SearchCollectionOptions, SearchResult } from './internal/search'
-import { generateSearchSections, buildFTSIndex, queryFTS, resetFTSIndex } from './internal/search'
+import type { GenerateSearchSectionsOptions, SearchCollectionOptions, SearchResult, SearchSection } from './internal/search'
+import { generateSearchSections, buildFTSIndex, queryFTS, resetFTSIndex, insertSections } from './internal/search'
 import { fetchQuery } from './internal/api'
 import type { Collections, PageCollections, CollectionQueryBuilder, SurroundOptions, SQLOperator, QueryGroupFunction, ContentNavigationItem, DatabaseAdapter } from '@nuxt/content'
 import { ref, toValue, watch, tryUseNuxtApp } from '#imports'
 import type { MaybeRefOrGetter } from 'vue'
 
-export type { SearchCollectionOptions, SearchResult, GenerateSearchSectionsOptions } from './internal/search'
+export type { SearchCollectionOptions, SearchResult, SearchSection, GenerateSearchSectionsOptions } from './internal/search'
 
 interface ChainablePromise<T extends keyof PageCollections, R> extends Promise<R> {
   where(field: keyof PageCollections[T] | string, operator: SQLOperator, value?: unknown): ChainablePromise<T, R>
@@ -91,11 +91,22 @@ export function useSearchCollection<T extends keyof PageCollections>(
     if (!db) {
       await init()
     }
-    const collections = resolveCollections()
+    const collections = searchOpts?.collections ?? indexedFor
     return queryFTS(db!, collections, query, searchOpts)
   }
 
-  return { status, search, init }
+  async function addToIndex(name: string, sections: SearchSection[]) {
+    if (!db) {
+      db = await import('./internal/database.client')
+        .then(m => m.loadDatabaseAdapter(resolveCollections()[0]!))
+    }
+    await insertSections(db, name, sections)
+    if (!indexedFor.includes(name)) {
+      indexedFor = [...indexedFor, name]
+    }
+  }
+
+  return { status, search, init, addToIndex }
 }
 
 async function executeContentQuery<T extends keyof Collections, Result = Collections[T]>(event: H3Event | undefined, collection: T, sql: string) {

--- a/src/runtime/client.ts
+++ b/src/runtime/client.ts
@@ -2,10 +2,13 @@ import type { H3Event } from 'h3'
 import { collectionQueryBuilder } from './internal/query'
 import { generateNavigationTree } from './internal/navigation'
 import { generateItemSurround } from './internal/surround'
-import { type GenerateSearchSectionsOptions, generateSearchSections } from './internal/search'
+import type { GenerateSearchSectionsOptions, SearchCollectionOptions, SearchResult } from './internal/search'
+import { generateSearchSections, buildFTSIndex, queryFTS } from './internal/search'
 import { fetchQuery } from './internal/api'
-import type { Collections, PageCollections, CollectionQueryBuilder, SurroundOptions, SQLOperator, QueryGroupFunction, ContentNavigationItem } from '@nuxt/content'
-import { tryUseNuxtApp } from '#imports'
+import type { Collections, PageCollections, CollectionQueryBuilder, SurroundOptions, SQLOperator, QueryGroupFunction, ContentNavigationItem, DatabaseAdapter } from '@nuxt/content'
+import { ref, tryUseNuxtApp } from '#imports'
+
+export type { SearchCollectionOptions, SearchResult, GenerateSearchSectionsOptions } from './internal/search'
 
 interface ChainablePromise<T extends keyof PageCollections, R> extends Promise<R> {
   where(field: keyof PageCollections[T] | string, operator: SQLOperator, value?: unknown): ChainablePromise<T, R>
@@ -29,6 +32,51 @@ export function queryCollectionItemSurroundings<T extends keyof PageCollections>
 
 export function queryCollectionSearchSections<T extends keyof PageCollections>(collection: T, opts?: GenerateSearchSectionsOptions) {
   return chainablePromise(collection, qb => generateSearchSections(qb, opts))
+}
+
+export function useSearchCollection<T extends keyof PageCollections>(
+  collection: T | T[],
+  opts?: GenerateSearchSectionsOptions & { immediate?: boolean },
+) {
+  const { immediate = true, ...indexOpts } = opts || {}
+  const collections = (Array.isArray(collection) ? collection : [collection]).map(String)
+  const status = ref<'idle' | 'loading' | 'ready' | 'error'>(immediate ? 'loading' : 'idle')
+  let db: DatabaseAdapter | undefined
+  let initPromise: Promise<DatabaseAdapter> | undefined
+
+  function init() {
+    if (initPromise) return initPromise
+    status.value = 'loading'
+    initPromise = import('./internal/database.client')
+      .then(m => m.loadDatabaseAdapter(collections[0]!))
+      .then(async (_db) => {
+        db = _db
+        await Promise.all(collections.map((col) => {
+          const qb = queryCollection(col as T)
+          return buildFTSIndex(_db, col, qb, indexOpts)
+        }))
+        status.value = 'ready'
+        return _db
+      })
+      .catch((err) => {
+        status.value = 'error'
+        throw err
+      })
+    return initPromise
+  }
+
+  if (immediate && import.meta.client) {
+    init()
+  }
+
+  async function search(query: string, searchOpts?: SearchCollectionOptions): Promise<SearchResult[]> {
+    if (!db) {
+      await init()
+    }
+    return queryFTS(db!, collections, query, searchOpts)
+  }
+
+  return { status, search, init }
 }
 
 async function executeContentQuery<T extends keyof Collections, Result = Collections[T]>(event: H3Event | undefined, collection: T, sql: string) {

--- a/src/runtime/client.ts
+++ b/src/runtime/client.ts
@@ -52,7 +52,7 @@ export function useSearchCollection<T extends keyof PageCollections>(
 
   async function init() {
     const collections = resolveCollections()
-    if (!collections.length) return initPromise ?? Promise.resolve(db!)
+    if (!collections.length) return initPromise ?? (db ? Promise.resolve(db) : Promise.reject(new Error('No collections to search')))
 
     const hasRemovedCollections = indexedFor.some(c => !collections.includes(c))
     const newCollections = collections.filter(c => !indexedFor.includes(c))

--- a/src/runtime/client.ts
+++ b/src/runtime/client.ts
@@ -44,6 +44,7 @@ export function useSearchCollection<T extends keyof PageCollections>(
   let db: DatabaseAdapter | undefined
   let initPromise: Promise<DatabaseAdapter> | undefined
   let indexedFor: string[] = []
+  const customSections = new Map<string, SearchSection[]>()
 
   function resolveCollections() {
     const val = toValue(collection)
@@ -52,7 +53,7 @@ export function useSearchCollection<T extends keyof PageCollections>(
 
   async function init() {
     const collections = resolveCollections()
-    const hasRemovedCollections = indexedFor.some(c => !collections.includes(c))
+    const hasRemovedCollections = indexedFor.some(c => !collections.includes(c) && !customSections.has(c))
     const newCollections = collections.filter(c => !indexedFor.includes(c))
 
     if (!newCollections.length && !hasRemovedCollections && initPromise) return initPromise
@@ -72,7 +73,14 @@ export function useSearchCollection<T extends keyof PageCollections>(
           const qb = queryCollection(col as T)
           return buildFTSIndex(_db, col, qb, indexOpts)
         }))
-        indexedFor = [...collections]
+
+        if (hasRemovedCollections) {
+          for (const [name, sections] of customSections) {
+            await insertSections(_db, name, sections)
+          }
+        }
+
+        indexedFor = [...collections, ...customSections.keys()]
         status.value = 'ready'
         return _db
       })
@@ -95,18 +103,29 @@ export function useSearchCollection<T extends keyof PageCollections>(
     return queryFTS(db!, collections, query, searchOpts)
   }
 
-  async function addToIndex(name: string, sections: SearchSection[]) {
+  async function add(name: string, sections: SearchSection[]) {
     if (!db) {
       db = await import('./internal/database.client')
         .then(m => m.loadDatabaseAdapter(resolveCollections()[0]!))
     }
+    customSections.set(name, sections)
     await insertSections(db!, name, sections)
     if (!indexedFor.includes(name)) {
       indexedFor = [...indexedFor, name]
     }
   }
 
-  return { status, search, init, addToIndex }
+  async function reset() {
+    if (db) {
+      await resetFTSIndex(db)
+    }
+    customSections.clear()
+    indexedFor = []
+    initPromise = undefined
+    status.value = 'idle'
+  }
+
+  return { status, search, init, add, reset }
 }
 
 async function executeContentQuery<T extends keyof Collections, Result = Collections[T]>(event: H3Event | undefined, collection: T, sql: string) {

--- a/src/runtime/client.ts
+++ b/src/runtime/client.ts
@@ -2,14 +2,14 @@ import type { H3Event } from 'h3'
 import { collectionQueryBuilder } from './internal/query'
 import { generateNavigationTree } from './internal/navigation'
 import { generateItemSurround } from './internal/surround'
-import type { GenerateSearchSectionsOptions, SearchCollectionOptions, SearchResult, SearchSection } from './internal/search'
-import { generateSearchSections, buildFTSIndex, queryFTS, resetFTSIndex, insertSections } from './internal/search'
+import type { GenerateSearchSectionsOptions, SearchCollectionOptions, SearchResult } from './internal/search'
+import { generateSearchSections, buildFTSIndex, queryFTS, resetFTSIndex } from './internal/search'
 import { fetchQuery } from './internal/api'
 import type { Collections, PageCollections, CollectionQueryBuilder, SurroundOptions, SQLOperator, QueryGroupFunction, ContentNavigationItem, DatabaseAdapter } from '@nuxt/content'
 import { ref, toValue, watch, tryUseNuxtApp } from '#imports'
 import type { MaybeRefOrGetter } from 'vue'
 
-export type { SearchCollectionOptions, SearchResult, SearchSection, GenerateSearchSectionsOptions } from './internal/search'
+export type { SearchCollectionOptions, SearchResult, GenerateSearchSectionsOptions } from './internal/search'
 
 interface ChainablePromise<T extends keyof PageCollections, R> extends Promise<R> {
   where(field: keyof PageCollections[T] | string, operator: SQLOperator, value?: unknown): ChainablePromise<T, R>
@@ -44,7 +44,6 @@ export function useSearchCollection<T extends keyof PageCollections>(
   let db: DatabaseAdapter | undefined
   let initPromise: Promise<DatabaseAdapter> | undefined
   let indexedFor: string[] = []
-  const customSections = new Map<string, SearchSection[]>()
 
   function resolveCollections() {
     const val = toValue(collection)
@@ -53,7 +52,7 @@ export function useSearchCollection<T extends keyof PageCollections>(
 
   async function init() {
     const collections = resolveCollections()
-    const hasRemovedCollections = indexedFor.some(c => !collections.includes(c) && !customSections.has(c))
+    const hasRemovedCollections = indexedFor.some(c => !collections.includes(c))
     const newCollections = collections.filter(c => !indexedFor.includes(c))
 
     if (!newCollections.length && !hasRemovedCollections && initPromise) return initPromise
@@ -74,13 +73,7 @@ export function useSearchCollection<T extends keyof PageCollections>(
           return buildFTSIndex(_db, col, qb, indexOpts)
         }))
 
-        if (hasRemovedCollections) {
-          for (const [name, sections] of customSections) {
-            await insertSections(_db, name, sections)
-          }
-        }
-
-        indexedFor = [...collections, ...customSections.keys()]
+        indexedFor = [...collections]
         status.value = 'ready'
         return _db
       })
@@ -99,33 +92,10 @@ export function useSearchCollection<T extends keyof PageCollections>(
     if (!db) {
       await init()
     }
-    const collections = searchOpts?.collections ?? indexedFor
-    return queryFTS(db!, collections, query, searchOpts)
+    return queryFTS(db!, indexedFor, query, searchOpts)
   }
 
-  async function add(name: string, sections: SearchSection[]) {
-    if (!db) {
-      db = await import('./internal/database.client')
-        .then(m => m.loadDatabaseAdapter(resolveCollections()[0]!))
-    }
-    customSections.set(name, sections)
-    await insertSections(db!, name, sections)
-    if (!indexedFor.includes(name)) {
-      indexedFor = [...indexedFor, name]
-    }
-  }
-
-  async function reset() {
-    if (db) {
-      await resetFTSIndex(db)
-    }
-    customSections.clear()
-    indexedFor = []
-    initPromise = undefined
-    status.value = 'idle'
-  }
-
-  return { status, search, init, add, reset }
+  return { status, search, init }
 }
 
 async function executeContentQuery<T extends keyof Collections, Result = Collections[T]>(event: H3Event | undefined, collection: T, sql: string) {

--- a/src/runtime/client.ts
+++ b/src/runtime/client.ts
@@ -100,7 +100,7 @@ export function useSearchCollection<T extends keyof PageCollections>(
       db = await import('./internal/database.client')
         .then(m => m.loadDatabaseAdapter(resolveCollections()[0]!))
     }
-    await insertSections(db, name, sections)
+    await insertSections(db!, name, sections)
     if (!indexedFor.includes(name)) {
       indexedFor = [...indexedFor, name]
     }

--- a/src/runtime/internal/search.ts
+++ b/src/runtime/internal/search.ts
@@ -17,6 +17,14 @@ type Section = {
   content: string
 }
 
+export type SearchSection = {
+  id: string
+  title: string
+  titles?: string[]
+  content: string
+  level?: number
+}
+
 export type SearchResult = {
   collection: string
   id: string
@@ -34,6 +42,8 @@ export type SearchCollectionOptions = {
    * @default 50
    */
   limit?: number
+  /** Filter results to specific collections. Searches all indexed collections when omitted. */
+  collections?: string[]
   /** Restrict search to specific columns. Searches all columns when omitted. */
   fields?: ('title' | 'content')[]
   /**
@@ -234,6 +244,24 @@ export async function buildFTSIndex<T extends PageCollectionItemBase>(
     await db.exec(
       `INSERT INTO ${FTS_TABLE} (collection, id, title, title_normalized, titles, content, level) VALUES (?, ?, ?, ?, ?, ?, ?)`,
       [collection, section.id, section.title, titleNormalized, JSON.stringify(section.titles), section.content, section.level],
+    )
+  }
+
+  indexedCollections.add(collection)
+}
+
+export async function insertSections(db: DatabaseAdapter, collection: string, sections: SearchSection[]) {
+  if (!ftsTableCreated) {
+    await db.exec(`CREATE VIRTUAL TABLE IF NOT EXISTS ${FTS_TABLE} USING fts5(collection UNINDEXED, id UNINDEXED, title, title_normalized, titles UNINDEXED, content, level UNINDEXED)`)
+    ftsTableCreated = true
+  }
+
+  for (const section of sections) {
+    const titleNormalized = section.title.replace(/([a-z])([A-Z])/g, '$1 $2')
+
+    await db.exec(
+      `INSERT INTO ${FTS_TABLE} (collection, id, title, title_normalized, titles, content, level) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      [collection, section.id, section.title, titleNormalized, JSON.stringify(section.titles ?? []), section.content, section.level ?? 1],
     )
   }
 

--- a/src/runtime/internal/search.ts
+++ b/src/runtime/internal/search.ts
@@ -2,7 +2,7 @@ import type { MDCNode, MDCRoot, MDCElement } from '@nuxtjs/mdc'
 import { toHast } from 'minimark/hast'
 import type { MinimarkTree } from 'minimark'
 import { pick } from './utils'
-import type { CollectionQueryBuilder, PageCollectionItemBase } from '~/src/types'
+import type { CollectionQueryBuilder, DatabaseAdapter, PageCollectionItemBase } from '~/src/types'
 
 type Section = {
   // Path to the section
@@ -15,6 +15,50 @@ type Section = {
   level: number
   // Content of the section
   content: string
+}
+
+export type SearchResult = {
+  collection: string
+  id: string
+  title: string
+  titles: string[]
+  level: number
+  content: string
+  rank: number
+  snippet?: string
+}
+
+export type SearchCollectionOptions = {
+  /**
+   * Maximum number of results to return.
+   * @default 50
+   */
+  limit?: number
+  /** Restrict search to specific columns. Searches all columns when omitted. */
+  fields?: ('title' | 'content' | 'titles')[]
+  /**
+   * Ignore search terms shorter than this value.
+   * @default 1
+   */
+  minMatchCharLength?: number
+  /** Return a text snippet with highlighted matches. */
+  snippet?: {
+    /**
+     * Which column to extract the snippet from.
+     * @default 'content'
+     */
+    column?: 'title' | 'content'
+    /**
+     * Number of tokens around the match to include.
+     * @default 30
+     */
+    around?: number
+    /**
+     * HTML tag used to wrap matched terms.
+     * @default 'mark'
+     */
+    tag?: string
+  }
 }
 
 const HEADING = /^h([1-6])$/
@@ -131,4 +175,96 @@ function extractTextFromAst(node: MDCNode, ignoredTags: string[] = []) {
   }
 
   return text
+}
+
+const FTS_TABLE = '_fts_search'
+const indexedCollections = new Set<string>()
+let ftsTableCreated = false
+
+export function _resetFTSState() {
+  indexedCollections.clear()
+  ftsTableCreated = false
+}
+
+export async function buildFTSIndex<T extends PageCollectionItemBase>(
+  db: DatabaseAdapter,
+  collection: string,
+  queryBuilder: CollectionQueryBuilder<T>,
+  opts?: GenerateSearchSectionsOptions,
+) {
+  if (indexedCollections.has(collection)) {
+    return
+  }
+
+  if (!ftsTableCreated) {
+    await db.exec(`CREATE VIRTUAL TABLE IF NOT EXISTS ${FTS_TABLE} USING fts5(collection UNINDEXED, id UNINDEXED, title, titles, content, level UNINDEXED)`)
+    ftsTableCreated = true
+  }
+
+  const sections = await generateSearchSections(queryBuilder, opts)
+
+  for (const section of sections) {
+    await db.exec(
+      `INSERT INTO ${FTS_TABLE} (collection, id, title, titles, content, level) VALUES (?, ?, ?, ?, ?, ?)`,
+      [collection, section.id, section.title, JSON.stringify(section.titles), section.content, section.level],
+    )
+  }
+
+  indexedCollections.add(collection)
+}
+
+export async function queryFTS(
+  db: DatabaseAdapter,
+  collections: string[],
+  query: string,
+  opts?: SearchCollectionOptions,
+): Promise<SearchResult[]> {
+  const { limit = 50, snippet, fields, minMatchCharLength = 1 } = opts || {}
+
+  const tag = snippet?.tag ?? 'mark'
+  const pre = `<${tag}>`
+  const post = `</${tag}>`
+
+  const placeholders = collections.map(() => '?').join(', ')
+  const collectionFilter = `collection IN (${placeholders})`
+
+  let selectClause = `collection, id, title, titles, content, level, rank`
+  if (snippet) {
+    const col = snippet.column === 'title' ? 2 : 4
+    const around = snippet.around ?? 30
+    selectClause += `, snippet(${FTS_TABLE}, ${col}, '${pre}', '${post}', '...', ${around}) as snippet`
+  }
+
+  const terms = query.split(/\s+/).filter(t => t.length >= minMatchCharLength)
+  if (!terms.length) return []
+
+  const ftsQuery = terms.map((term) => {
+    const escaped = term.replace(/"/g, '""')
+    if (fields?.length) {
+      return fields.map(f => `${f} : "${escaped}"*`).join(' OR ')
+    }
+    return `"${escaped}"*`
+  }).join(' ')
+
+  const sql = `SELECT ${selectClause} FROM ${FTS_TABLE} WHERE ${FTS_TABLE} MATCH ? AND ${collectionFilter} ORDER BY rank LIMIT ?`
+  const params = [ftsQuery, ...collections, limit]
+
+  let rows: Record<string, unknown>[]
+  try {
+    rows = await db.all<Record<string, unknown>>(sql, params)
+  }
+  catch {
+    return []
+  }
+
+  return rows.map(row => ({
+    collection: row.collection as string,
+    id: row.id as string,
+    title: row.title as string,
+    titles: JSON.parse((row.titles as string) || '[]'),
+    level: row.level as number,
+    content: row.content as string,
+    rank: row.rank as number,
+    ...(snippet && { snippet: row.snippet as string }),
+  }))
 }

--- a/src/runtime/internal/search.ts
+++ b/src/runtime/internal/search.ts
@@ -205,6 +205,12 @@ export function _resetFTSState() {
   ftsTableCreated = false
 }
 
+export async function resetFTSIndex(db: DatabaseAdapter) {
+  await db.exec(`DROP TABLE IF EXISTS ${FTS_TABLE}`)
+  indexedCollections.clear()
+  ftsTableCreated = false
+}
+
 export async function buildFTSIndex<T extends PageCollectionItemBase>(
   db: DatabaseAdapter,
   collection: string,

--- a/src/runtime/internal/search.ts
+++ b/src/runtime/internal/search.ts
@@ -221,7 +221,7 @@ export async function queryFTS(
 ): Promise<SearchResult[]> {
   const { limit = 50, snippet, fields, minMatchCharLength = 1 } = opts || {}
 
-  const tag = snippet?.tag ?? 'mark'
+  const tag = (snippet?.tag ?? 'mark').replace(/[^a-z0-9]/gi, '')
   const pre = `<${tag}>`
   const post = `</${tag}>`
 
@@ -231,7 +231,7 @@ export async function queryFTS(
   let selectClause = `collection, id, title, titles, content, level, rank`
   if (snippet) {
     const col = snippet.column === 'title' ? 2 : 4
-    const around = snippet.around ?? 30
+    const around = Number(snippet.around) || 30
     selectClause += `, snippet(${FTS_TABLE}, ${col}, '${pre}', '${post}', '...', ${around}) as snippet`
   }
 

--- a/src/runtime/internal/search.ts
+++ b/src/runtime/internal/search.ts
@@ -25,7 +25,7 @@ export type SearchResult = {
   level: number
   content: string
   rank: number
-  snippet?: string
+  snippets?: { title?: string, content?: string }
 }
 
 export type SearchCollectionOptions = {
@@ -35,12 +35,12 @@ export type SearchCollectionOptions = {
    */
   limit?: number
   /** Restrict search to specific columns. Searches all columns when omitted. */
-  fields?: ('title' | 'content' | 'titles')[]
+  fields?: ('title' | 'content')[]
   /**
    * Ignore search terms shorter than this value.
    * @default 1
    */
-  minMatchCharLength?: number
+  minTermLength?: number
   /** Control how matches in different columns and heading levels affect ranking. */
   weights?: {
     /**
@@ -54,24 +54,19 @@ export type SearchCollectionOptions = {
      */
     content?: number
     /**
-     * Boost factor for matches in the titles (breadcrumb) column.
-     * @default 1
-     */
-    titles?: number
-    /**
      * Whether to boost higher-level sections (h1 > h2 > h3...).
      * Set to `false` to disable level-based boosting.
      * @default true
      */
     heading?: boolean
   }
-  /** Return a text snippet with highlighted matches. */
+  /** Return text snippets with highlighted matches for the specified columns. */
   snippet?: {
     /**
-     * Which column to extract the snippet from.
-     * @default 'content'
+     * Which columns to extract snippets from.
+     * @default ['content']
      */
-    column?: 'title' | 'content'
+    columns?: ('title' | 'content')[]
     /**
      * Number of tokens around the match to include.
      * @default 30
@@ -221,7 +216,7 @@ export async function buildFTSIndex<T extends PageCollectionItemBase>(
   }
 
   if (!ftsTableCreated) {
-    await db.exec(`CREATE VIRTUAL TABLE IF NOT EXISTS ${FTS_TABLE} USING fts5(collection UNINDEXED, id UNINDEXED, title, title_normalized, titles, content, level UNINDEXED)`)
+    await db.exec(`CREATE VIRTUAL TABLE IF NOT EXISTS ${FTS_TABLE} USING fts5(collection UNINDEXED, id UNINDEXED, title, title_normalized, titles UNINDEXED, content, level UNINDEXED)`)
     ftsTableCreated = true
   }
 
@@ -245,11 +240,10 @@ export async function queryFTS(
   query: string,
   opts?: SearchCollectionOptions,
 ): Promise<SearchResult[]> {
-  const { limit = 50, snippet, fields, minMatchCharLength = 1, weights } = opts || {}
+  const { limit = 50, snippet, fields, minTermLength = 1, weights } = opts || {}
 
   const titleWeight = weights?.title ?? 10
   const contentWeight = weights?.content ?? 5
-  const titlesWeight = weights?.titles ?? 1
   const headingBoost = weights?.heading !== false
 
   const tag = (snippet?.tag ?? 'mark').replace(/[^a-z0-9]/gi, '')
@@ -259,16 +253,17 @@ export async function queryFTS(
   const placeholders = collections.map(() => '?').join(', ')
   const collectionFilter = `collection IN (${placeholders})`
 
-  const bm25Expr = `bm25(${FTS_TABLE}, 0, 0, ${titleWeight}, ${titleWeight}, ${titlesWeight}, ${contentWeight}, 0)`
+  const bm25Expr = `bm25(${FTS_TABLE}, 0, 0, ${titleWeight}, ${titleWeight}, 0, ${contentWeight}, 0)`
   const rankExpr = headingBoost ? `(${bm25Expr} / level)` : bm25Expr
   let selectClause = `collection, id, title, titles, content, level, ${rankExpr} as rank`
-  if (snippet) {
-    const col = snippet.column === 'title' ? 2 : 5
-    const around = Number(snippet.around) || 30
-    selectClause += `, snippet(${FTS_TABLE}, ${col}, '${pre}', '${post}', '...', ${around}) as snippet`
+  const snippetColumns = snippet?.columns ?? (snippet ? ['content'] : [])
+  const around = Number(snippet?.around) || 30
+  for (const col of snippetColumns) {
+    const colIdx = col === 'title' ? 2 : 5
+    selectClause += `, snippet(${FTS_TABLE}, ${colIdx}, '${pre}', '${post}', '...', ${around}) as snippet_${col}`
   }
 
-  const terms = query.split(/\s+/).filter(t => t.length >= minMatchCharLength)
+  const terms = query.split(/\s+/).filter(t => t.length >= minTermLength)
   if (!terms.length) return []
 
   const ftsQuery = terms.map((term) => {
@@ -298,6 +293,10 @@ export async function queryFTS(
     level: row.level as number,
     content: row.content as string,
     rank: row.rank as number,
-    ...(snippet && { snippet: row.snippet as string }),
+    ...(snippetColumns.length && {
+      snippets: Object.fromEntries(
+        snippetColumns.map(col => [col, row[`snippet_${col}`] as string]),
+      ),
+    }),
   }))
 }

--- a/src/runtime/internal/search.ts
+++ b/src/runtime/internal/search.ts
@@ -258,9 +258,9 @@ export async function queryFTS(
   let selectClause = `collection, id, title, titles, content, level, ${rankExpr} as rank`
   const snippetColumns = snippet?.columns ?? (snippet ? ['content'] : [])
   const around = Number(snippet?.around) || 30
-  for (const col of snippetColumns) {
-    const colIdx = col === 'title' ? 2 : 5
-    selectClause += `, snippet(${FTS_TABLE}, ${colIdx}, '${pre}', '${post}', '...', ${around}) as snippet_${col}`
+  const wantContentSnippet = snippetColumns.includes('content')
+  if (wantContentSnippet) {
+    selectClause += `, snippet(${FTS_TABLE}, 5, '${pre}', '${post}', '...', ${around}) as snippet_content`
   }
 
   const terms = query.split(/\s+/).filter(t => t.length >= minTermLength)
@@ -285,6 +285,11 @@ export async function queryFTS(
     return []
   }
 
+  const wantTitleSnippet = snippetColumns.includes('title')
+  const titleRegex = wantTitleSnippet
+    ? new RegExp(`(${terms.map(t => t.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|')})`, 'gi')
+    : null
+
   return rows.map(row => ({
     collection: row.collection as string,
     id: row.id as string,
@@ -294,9 +299,10 @@ export async function queryFTS(
     content: row.content as string,
     rank: row.rank as number,
     ...(snippetColumns.length && {
-      snippets: Object.fromEntries(
-        snippetColumns.map(col => [col, row[`snippet_${col}`] as string]),
-      ),
+      snippets: {
+        ...(wantTitleSnippet && { title: (row.title as string).replace(titleRegex!, `${pre}$1${post}`) }),
+        ...(wantContentSnippet && { content: row.snippet_content as string }),
+      },
     }),
   }))
 }

--- a/src/runtime/internal/search.ts
+++ b/src/runtime/internal/search.ts
@@ -287,7 +287,10 @@ export async function queryFTS(
   try {
     rows = await db.all<Record<string, unknown>>(sql, params)
   }
-  catch {
+  catch (err) {
+    if (import.meta.dev) {
+      console.warn('[nuxt-content] FTS query failed:', err)
+    }
     return []
   }
 

--- a/src/runtime/internal/search.ts
+++ b/src/runtime/internal/search.ts
@@ -17,14 +17,6 @@ type Section = {
   content: string
 }
 
-export type SearchSection = {
-  id: string
-  title: string
-  titles?: string[]
-  content: string
-  level?: number
-}
-
 export type SearchResult = {
   collection: string
   id: string
@@ -42,8 +34,6 @@ export type SearchCollectionOptions = {
    * @default 50
    */
   limit?: number
-  /** Filter results to specific collections. Searches all indexed collections when omitted. */
-  collections?: string[]
   /** Restrict search to specific columns. Searches all columns when omitted. */
   fields?: ('title' | 'content')[]
   /**
@@ -244,24 +234,6 @@ export async function buildFTSIndex<T extends PageCollectionItemBase>(
     await db.exec(
       `INSERT INTO ${FTS_TABLE} (collection, id, title, title_normalized, titles, content, level) VALUES (?, ?, ?, ?, ?, ?, ?)`,
       [collection, section.id, section.title, titleNormalized, JSON.stringify(section.titles), section.content, section.level],
-    )
-  }
-
-  indexedCollections.add(collection)
-}
-
-export async function insertSections(db: DatabaseAdapter, collection: string, sections: SearchSection[]) {
-  if (!ftsTableCreated) {
-    await db.exec(`CREATE VIRTUAL TABLE IF NOT EXISTS ${FTS_TABLE} USING fts5(collection UNINDEXED, id UNINDEXED, title, title_normalized, titles UNINDEXED, content, level UNINDEXED)`)
-    ftsTableCreated = true
-  }
-
-  for (const section of sections) {
-    const titleNormalized = section.title.replace(/([a-z])([A-Z])/g, '$1 $2')
-
-    await db.exec(
-      `INSERT INTO ${FTS_TABLE} (collection, id, title, title_normalized, titles, content, level) VALUES (?, ?, ?, ?, ?, ?, ?)`,
-      [collection, section.id, section.title, titleNormalized, JSON.stringify(section.titles ?? []), section.content, section.level ?? 1],
     )
   }
 

--- a/src/runtime/internal/search.ts
+++ b/src/runtime/internal/search.ts
@@ -41,6 +41,30 @@ export type SearchCollectionOptions = {
    * @default 1
    */
   minMatchCharLength?: number
+  /** Control how matches in different columns and heading levels affect ranking. */
+  weights?: {
+    /**
+     * Boost factor for matches in the title column.
+     * @default 10
+     */
+    title?: number
+    /**
+     * Boost factor for matches in the content column.
+     * @default 5
+     */
+    content?: number
+    /**
+     * Boost factor for matches in the titles (breadcrumb) column.
+     * @default 1
+     */
+    titles?: number
+    /**
+     * Whether to boost higher-level sections (h1 > h2 > h3...).
+     * Set to `false` to disable level-based boosting.
+     * @default true
+     */
+    heading?: boolean
+  }
   /** Return a text snippet with highlighted matches. */
   snippet?: {
     /**
@@ -197,16 +221,18 @@ export async function buildFTSIndex<T extends PageCollectionItemBase>(
   }
 
   if (!ftsTableCreated) {
-    await db.exec(`CREATE VIRTUAL TABLE IF NOT EXISTS ${FTS_TABLE} USING fts5(collection UNINDEXED, id UNINDEXED, title, titles, content, level UNINDEXED)`)
+    await db.exec(`CREATE VIRTUAL TABLE IF NOT EXISTS ${FTS_TABLE} USING fts5(collection UNINDEXED, id UNINDEXED, title, title_normalized, titles, content, level UNINDEXED)`)
     ftsTableCreated = true
   }
 
   const sections = await generateSearchSections(queryBuilder, opts)
 
   for (const section of sections) {
+    const titleNormalized = section.title.replace(/([a-z])([A-Z])/g, '$1 $2')
+
     await db.exec(
-      `INSERT INTO ${FTS_TABLE} (collection, id, title, titles, content, level) VALUES (?, ?, ?, ?, ?, ?)`,
-      [collection, section.id, section.title, JSON.stringify(section.titles), section.content, section.level],
+      `INSERT INTO ${FTS_TABLE} (collection, id, title, title_normalized, titles, content, level) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      [collection, section.id, section.title, titleNormalized, JSON.stringify(section.titles), section.content, section.level],
     )
   }
 
@@ -219,7 +245,12 @@ export async function queryFTS(
   query: string,
   opts?: SearchCollectionOptions,
 ): Promise<SearchResult[]> {
-  const { limit = 50, snippet, fields, minMatchCharLength = 1 } = opts || {}
+  const { limit = 50, snippet, fields, minMatchCharLength = 1, weights } = opts || {}
+
+  const titleWeight = weights?.title ?? 10
+  const contentWeight = weights?.content ?? 5
+  const titlesWeight = weights?.titles ?? 1
+  const headingBoost = weights?.heading !== false
 
   const tag = (snippet?.tag ?? 'mark').replace(/[^a-z0-9]/gi, '')
   const pre = `<${tag}>`
@@ -228,9 +259,11 @@ export async function queryFTS(
   const placeholders = collections.map(() => '?').join(', ')
   const collectionFilter = `collection IN (${placeholders})`
 
-  let selectClause = `collection, id, title, titles, content, level, rank`
+  const bm25Expr = `bm25(${FTS_TABLE}, 0, 0, ${titleWeight}, ${titleWeight}, ${titlesWeight}, ${contentWeight}, 0)`
+  const rankExpr = headingBoost ? `(${bm25Expr} / level)` : bm25Expr
+  let selectClause = `collection, id, title, titles, content, level, ${rankExpr} as rank`
   if (snippet) {
-    const col = snippet.column === 'title' ? 2 : 4
+    const col = snippet.column === 'title' ? 2 : 5
     const around = Number(snippet.around) || 30
     selectClause += `, snippet(${FTS_TABLE}, ${col}, '${pre}', '${post}', '...', ${around}) as snippet`
   }

--- a/test/unit/searchCollection.test.ts
+++ b/test/unit/searchCollection.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { buildFTSIndex, queryFTS, insertSections, resetFTSIndex, _resetFTSState } from '../../src/runtime/internal/search'
+import { buildFTSIndex, queryFTS, resetFTSIndex, _resetFTSState } from '../../src/runtime/internal/search'
 import type { CollectionQueryBuilder, DatabaseAdapter, PageCollectionItemBase } from '../../src/types'
 
 describe('searchCollection FTS5', () => {
@@ -332,58 +332,6 @@ describe('searchCollection FTS5', () => {
       const insertParams = execCalls[1]!.params!
       expect(insertParams[2]).toBe('Introduction')
       expect(insertParams[3]).toBe('Introduction')
-    })
-  })
-
-  describe('insertSections', () => {
-    it('should create FTS table and insert custom sections', async () => {
-      await insertSections(mockDb, 'modules', [
-        { id: '/modules/pinia', title: 'Pinia', content: 'State management for Vue' },
-        { id: '/modules/image', title: 'Nuxt Image', content: 'Optimized images' },
-      ])
-
-      expect(execCalls[0]!.sql).toContain('CREATE VIRTUAL TABLE')
-
-      expect(execCalls[1]!.params).toEqual([
-        'modules', '/modules/pinia', 'Pinia', 'Pinia', '[]', 'State management for Vue', 1,
-      ])
-      expect(execCalls[2]!.params).toEqual([
-        'modules', '/modules/image', 'Nuxt Image', 'Nuxt Image', '[]', 'Optimized images', 1,
-      ])
-    })
-
-    it('should use provided titles and level', async () => {
-      await insertSections(mockDb, 'custom', [
-        { id: '/custom/page#section', title: 'Section', titles: ['Page'], content: 'Some content', level: 2 },
-      ])
-
-      expect(execCalls[1]!.params).toEqual([
-        'custom', '/custom/page#section', 'Section', 'Section', '["Page"]', 'Some content', 2,
-      ])
-    })
-
-    it('should normalize camelCase titles', async () => {
-      await insertSections(mockDb, 'custom', [
-        { id: '/test', title: 'MyComponent', content: 'A component' },
-      ])
-
-      expect(execCalls[1]!.params![3]).toBe('My Component')
-    })
-  })
-
-  describe('queryFTS collections filter', () => {
-    it('should filter by provided collections', async () => {
-      await queryFTS(mockDb, ['modules'], 'query')
-
-      expect(allCalls[0]!.sql).toContain('collection IN (?)')
-      expect(allCalls[0]!.params).toEqual(['"query"*', 'modules', 50])
-    })
-
-    it('should support filtering multiple collections', async () => {
-      await queryFTS(mockDb, ['docs', 'modules'], 'query')
-
-      expect(allCalls[0]!.sql).toContain('collection IN (?, ?)')
-      expect(allCalls[0]!.params).toEqual(['"query"*', 'docs', 'modules', 50])
     })
   })
 

--- a/test/unit/searchCollection.test.ts
+++ b/test/unit/searchCollection.test.ts
@@ -234,8 +234,8 @@ describe('searchCollection FTS5', () => {
         snippet: { column: 'content', around: 20, tag: 'b' },
       })
 
-      expect(allCalls[0]!.sql).toContain("'<b>'")
-      expect(allCalls[0]!.sql).toContain("'</b>'")
+      expect(allCalls[0]!.sql).toContain('\'<b>\'')
+      expect(allCalls[0]!.sql).toContain('\'</b>\'')
     })
   })
 })

--- a/test/unit/searchCollection.test.ts
+++ b/test/unit/searchCollection.test.ts
@@ -59,6 +59,7 @@ describe('searchCollection FTS5', () => {
         'docs',
         '/docs/intro',
         'Introduction',
+        'Introduction',
         '[]',
         'Getting started guide',
         1,
@@ -68,6 +69,7 @@ describe('searchCollection FTS5', () => {
       expect(execCalls[2]!.params).toEqual([
         'docs',
         '/docs/intro#setup',
+        'Setup',
         'Setup',
         '["Introduction"]',
         'Install the package',
@@ -146,7 +148,7 @@ describe('searchCollection FTS5', () => {
         snippet: { column: 'content', around: 20 },
       })
 
-      expect(allCalls[0]!.sql).toContain('snippet(_fts_search, 4, \'<mark>\', \'</mark>\', \'...\', 20)')
+      expect(allCalls[0]!.sql).toContain('snippet(_fts_search, 5, \'<mark>\', \'</mark>\', \'...\', 20)')
     })
 
     it('should use title column index for snippet when specified', async () => {

--- a/test/unit/searchCollection.test.ts
+++ b/test/unit/searchCollection.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { buildFTSIndex, queryFTS, _resetFTSState } from '../../src/runtime/internal/search'
+import { buildFTSIndex, queryFTS, insertSections, _resetFTSState } from '../../src/runtime/internal/search'
 import type { CollectionQueryBuilder, DatabaseAdapter, PageCollectionItemBase } from '../../src/types'
 
 describe('searchCollection FTS5', () => {
@@ -332,6 +332,58 @@ describe('searchCollection FTS5', () => {
       const insertParams = execCalls[1]!.params!
       expect(insertParams[2]).toBe('Introduction')
       expect(insertParams[3]).toBe('Introduction')
+    })
+  })
+
+  describe('insertSections', () => {
+    it('should create FTS table and insert custom sections', async () => {
+      await insertSections(mockDb, 'modules', [
+        { id: '/modules/pinia', title: 'Pinia', content: 'State management for Vue' },
+        { id: '/modules/image', title: 'Nuxt Image', content: 'Optimized images' },
+      ])
+
+      expect(execCalls[0]!.sql).toContain('CREATE VIRTUAL TABLE')
+
+      expect(execCalls[1]!.params).toEqual([
+        'modules', '/modules/pinia', 'Pinia', 'Pinia', '[]', 'State management for Vue', 1,
+      ])
+      expect(execCalls[2]!.params).toEqual([
+        'modules', '/modules/image', 'Nuxt Image', 'Nuxt Image', '[]', 'Optimized images', 1,
+      ])
+    })
+
+    it('should use provided titles and level', async () => {
+      await insertSections(mockDb, 'custom', [
+        { id: '/custom/page#section', title: 'Section', titles: ['Page'], content: 'Some content', level: 2 },
+      ])
+
+      expect(execCalls[1]!.params).toEqual([
+        'custom', '/custom/page#section', 'Section', 'Section', '["Page"]', 'Some content', 2,
+      ])
+    })
+
+    it('should normalize camelCase titles', async () => {
+      await insertSections(mockDb, 'custom', [
+        { id: '/test', title: 'MyComponent', content: 'A component' },
+      ])
+
+      expect(execCalls[1]!.params![3]).toBe('My Component')
+    })
+  })
+
+  describe('queryFTS collections filter', () => {
+    it('should filter by provided collections', async () => {
+      await queryFTS(mockDb, ['modules'], 'query')
+
+      expect(allCalls[0]!.sql).toContain('collection IN (?)')
+      expect(allCalls[0]!.params).toEqual(['"query"*', 'modules', 50])
+    })
+
+    it('should support filtering multiple collections', async () => {
+      await queryFTS(mockDb, ['docs', 'modules'], 'query')
+
+      expect(allCalls[0]!.sql).toContain('collection IN (?, ?)')
+      expect(allCalls[0]!.params).toEqual(['"query"*', 'docs', 'modules', 50])
     })
   })
 })

--- a/test/unit/searchCollection.test.ts
+++ b/test/unit/searchCollection.test.ts
@@ -268,7 +268,9 @@ describe('searchCollection FTS5', () => {
     })
 
     it('should return empty array on FTS5 syntax error', async () => {
-      mockDb.all = vi.fn(async () => { throw new Error('fts5: syntax error') })
+      mockDb.all = vi.fn(async () => {
+        throw new Error('fts5: syntax error')
+      })
 
       const results = await queryFTS(mockDb, ['docs'], 'test')
 

--- a/test/unit/searchCollection.test.ts
+++ b/test/unit/searchCollection.test.ts
@@ -151,21 +151,29 @@ describe('searchCollection FTS5', () => {
       expect(allCalls[0]!.sql).toContain('snippet(_fts_search, 5, \'<mark>\', \'</mark>\', \'...\', 20) as snippet_content')
     })
 
-    it('should include title snippet when specified', async () => {
-      await queryFTS(mockDb, ['docs'], 'query', {
-        snippet: { columns: ['title'], around: 15 },
+    it('should highlight title with JS regex when title snippet requested', async () => {
+      mockDb.all = vi.fn(async () => [
+        { collection: 'docs', id: '/test', title: 'ColorModeButton', titles: '[]', content: '', level: 1, rank: -5 },
+      ])
+
+      const results = await queryFTS(mockDb, ['docs'], 'button', {
+        snippet: { columns: ['title'] },
       })
 
-      expect(allCalls[0]!.sql).toContain('snippet(_fts_search, 2, \'<mark>\', \'</mark>\', \'...\', 15) as snippet_title')
+      expect(results[0]!.snippets?.title).toBe('ColorMode<mark>Button</mark>')
     })
 
-    it('should include multiple snippets', async () => {
-      await queryFTS(mockDb, ['docs'], 'query', {
-        snippet: { columns: ['title', 'content'], around: 20 },
+    it('should include both title and content snippets', async () => {
+      mockDb.all = vi.fn(async () => [
+        { collection: 'docs', id: '/test', title: 'Avatar', titles: '[]', content: 'An avatar component', level: 1, rank: -5, snippet_content: 'An <mark>avatar</mark> component' },
+      ])
+
+      const results = await queryFTS(mockDb, ['docs'], 'avatar', {
+        snippet: { columns: ['title', 'content'] },
       })
 
-      expect(allCalls[0]!.sql).toContain('snippet_title')
-      expect(allCalls[0]!.sql).toContain('snippet_content')
+      expect(results[0]!.snippets?.title).toBe('<mark>Avatar</mark>')
+      expect(results[0]!.snippets?.content).toBe('An <mark>avatar</mark> component')
     })
 
     it('should parse results correctly', async () => {
@@ -205,7 +213,6 @@ describe('searchCollection FTS5', () => {
           level: 2,
           rank: -1.2,
           snippet_content: '...Install the <mark>package</mark> with npm...',
-          snippet_title: 'Setup',
         },
       ])
 

--- a/test/unit/searchCollection.test.ts
+++ b/test/unit/searchCollection.test.ts
@@ -1,0 +1,251 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { buildFTSIndex, queryFTS, _resetFTSState } from '../../src/runtime/internal/search'
+import type { CollectionQueryBuilder, DatabaseAdapter, PageCollectionItemBase } from '../../src/types'
+
+describe('searchCollection FTS5', () => {
+  let mockDb: DatabaseAdapter
+  let execCalls: Array<{ sql: string, params?: unknown[] }>
+  let allCalls: Array<{ sql: string, params?: unknown[] }>
+
+  beforeEach(() => {
+    _resetFTSState()
+    execCalls = []
+    allCalls = []
+    mockDb = {
+      exec: vi.fn(async (sql: string, params?: unknown[]) => {
+        execCalls.push({ sql, params })
+      }),
+      all: vi.fn(async (sql: string, params?: unknown[]) => {
+        allCalls.push({ sql, params })
+        return []
+      }),
+      first: vi.fn(async () => null),
+    }
+  })
+
+  describe('buildFTSIndex', () => {
+    it('should create FTS5 table and insert sections', async () => {
+      const mockQueryBuilder = createMockQueryBuilder([{
+        path: '/docs/intro',
+        title: 'Introduction',
+        description: 'Getting started guide',
+        body: {
+          type: 'root',
+          children: [
+            {
+              type: 'element',
+              tag: 'h2',
+              props: { id: 'setup' },
+              children: [{ type: 'text', value: 'Setup' }],
+            },
+            {
+              type: 'element',
+              tag: 'p',
+              children: [{ type: 'text', value: 'Install the package' }],
+            },
+          ],
+        },
+      }])
+
+      await buildFTSIndex(mockDb, 'docs', mockQueryBuilder)
+
+      expect(execCalls[0]!.sql).toContain('CREATE VIRTUAL TABLE IF NOT EXISTS _fts_search USING fts5')
+      expect(execCalls[0]!.sql).toContain('collection UNINDEXED')
+      expect(execCalls[0]!.sql).toContain('id UNINDEXED')
+      expect(execCalls[0]!.sql).toContain('level UNINDEXED')
+
+      // First section (page-level)
+      expect(execCalls[1]!.params).toEqual([
+        'docs',
+        '/docs/intro',
+        'Introduction',
+        '[]',
+        'Getting started guide',
+        1,
+      ])
+
+      // Second section (h2)
+      expect(execCalls[2]!.params).toEqual([
+        'docs',
+        '/docs/intro#setup',
+        'Setup',
+        '["Introduction"]',
+        'Install the package',
+        2,
+      ])
+    })
+
+    it('should not rebuild index for already-indexed collection', async () => {
+      const mockQueryBuilder = createMockQueryBuilder([{
+        path: '/test',
+        title: 'Test',
+        description: '',
+        body: { type: 'root', children: [] },
+      }])
+
+      await buildFTSIndex(mockDb, 'blog', mockQueryBuilder)
+      const callsAfterFirst = execCalls.length
+
+      await buildFTSIndex(mockDb, 'blog', mockQueryBuilder)
+
+      expect(execCalls.length).toBe(callsAfterFirst)
+    })
+
+    it('should allow indexing multiple collections into the same table', async () => {
+      const docsQb = createMockQueryBuilder([{
+        path: '/docs/page',
+        title: 'Docs Page',
+        description: 'Docs content',
+        body: { type: 'root', children: [] },
+      }])
+
+      const blogQb = createMockQueryBuilder([{
+        path: '/blog/post',
+        title: 'Blog Post',
+        description: 'Blog content',
+        body: { type: 'root', children: [] },
+      }])
+
+      await buildFTSIndex(mockDb, 'multi-docs', docsQb)
+      await buildFTSIndex(mockDb, 'multi-blog', blogQb)
+
+      const insertCalls = execCalls.filter(c => c.sql.includes('INSERT'))
+      const collections = insertCalls.map(c => c.params?.[0])
+      expect(collections).toContain('multi-docs')
+      expect(collections).toContain('multi-blog')
+    })
+  })
+
+  describe('queryFTS', () => {
+    it('should build correct MATCH query with collection filter', async () => {
+      await queryFTS(mockDb, ['docs'], 'vue composable')
+
+      expect(allCalls[0]!.sql).toContain('FROM _fts_search')
+      expect(allCalls[0]!.sql).toContain('_fts_search MATCH ?')
+      expect(allCalls[0]!.sql).toContain('collection IN (?)')
+      expect(allCalls[0]!.sql).toContain('ORDER BY rank')
+      expect(allCalls[0]!.params).toEqual(['"vue"* "composable"*', 'docs', 50])
+    })
+
+    it('should support multiple collections', async () => {
+      await queryFTS(mockDb, ['docs', 'blog'], 'search term')
+
+      expect(allCalls[0]!.sql).toContain('collection IN (?, ?)')
+      expect(allCalls[0]!.params).toEqual(['"search"* "term"*', 'docs', 'blog', 50])
+    })
+
+    it('should respect limit option', async () => {
+      await queryFTS(mockDb, ['docs'], 'query', { limit: 10 })
+
+      expect(allCalls[0]!.sql).toContain('LIMIT ?')
+      expect(allCalls[0]!.params![allCalls[0]!.params!.length - 1]).toBe(10)
+    })
+
+    it('should include snippet when requested', async () => {
+      await queryFTS(mockDb, ['docs'], 'query', {
+        snippet: { column: 'content', around: 20 },
+      })
+
+      expect(allCalls[0]!.sql).toContain('snippet(_fts_search, 4, \'<mark>\', \'</mark>\', \'...\', 20)')
+    })
+
+    it('should use title column index for snippet when specified', async () => {
+      await queryFTS(mockDb, ['docs'], 'query', {
+        snippet: { column: 'title', around: 15 },
+      })
+
+      expect(allCalls[0]!.sql).toContain('snippet(_fts_search, 2, \'<mark>\', \'</mark>\', \'...\', 15)')
+    })
+
+    it('should parse results correctly', async () => {
+      mockDb.all = vi.fn(async () => [
+        {
+          collection: 'docs',
+          id: '/docs/intro#setup',
+          title: 'Setup',
+          titles: '["Introduction"]',
+          content: 'Install the package',
+          level: 2,
+          rank: -1.5,
+        },
+      ])
+
+      const results = await queryFTS(mockDb, ['docs'], 'setup')
+
+      expect(results).toEqual([{
+        collection: 'docs',
+        id: '/docs/intro#setup',
+        title: 'Setup',
+        titles: ['Introduction'],
+        content: 'Install the package',
+        level: 2,
+        rank: -1.5,
+      }])
+    })
+
+    it('should include snippet in results when requested', async () => {
+      mockDb.all = vi.fn(async () => [
+        {
+          collection: 'docs',
+          id: '/docs/intro#setup',
+          title: 'Setup',
+          titles: '[]',
+          content: 'Install the package with npm',
+          level: 2,
+          rank: -1.2,
+          snippet: '...Install the <mark>package</mark> with npm...',
+        },
+      ])
+
+      const results = await queryFTS(mockDb, ['docs'], 'package', {
+        snippet: { column: 'content', around: 20 },
+      })
+
+      expect(results[0]!.snippet).toBe('...Install the <mark>package</mark> with npm...')
+    })
+
+    it('should filter terms by minMatchCharLength', async () => {
+      await queryFTS(mockDb, ['docs'], 'a vue b', { minMatchCharLength: 2 })
+
+      expect(allCalls[0]!.params![0]).toBe('"vue"*')
+    })
+
+    it('should return empty when all terms are below minMatchCharLength', async () => {
+      const results = await queryFTS(mockDb, ['docs'], 'a b c', { minMatchCharLength: 3 })
+
+      expect(results).toEqual([])
+      expect(allCalls.length).toBe(0)
+    })
+
+    it('should restrict search to specific fields', async () => {
+      await queryFTS(mockDb, ['docs'], 'setup', { fields: ['title'] })
+
+      expect(allCalls[0]!.params![0]).toBe('title : "setup"*')
+    })
+
+    it('should support multiple fields with OR', async () => {
+      await queryFTS(mockDb, ['docs'], 'setup', { fields: ['title', 'content'] })
+
+      expect(allCalls[0]!.params![0]).toBe('title : "setup"* OR content : "setup"*')
+    })
+
+    it('should use custom highlight tag', async () => {
+      await queryFTS(mockDb, ['docs'], 'query', {
+        snippet: { column: 'content', around: 20, tag: 'b' },
+      })
+
+      expect(allCalls[0]!.sql).toContain("'<b>'")
+      expect(allCalls[0]!.sql).toContain("'</b>'")
+    })
+  })
+})
+
+function createMockQueryBuilder(result: unknown[]) {
+  const mockQueryBuilder = {
+    where: () => mockQueryBuilder,
+    select: () => mockQueryBuilder,
+    all: async () => result,
+  } as unknown as CollectionQueryBuilder<PageCollectionItemBase>
+
+  return mockQueryBuilder
+}

--- a/test/unit/searchCollection.test.ts
+++ b/test/unit/searchCollection.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { buildFTSIndex, queryFTS, insertSections, _resetFTSState } from '../../src/runtime/internal/search'
+import { buildFTSIndex, queryFTS, insertSections, resetFTSIndex, _resetFTSState } from '../../src/runtime/internal/search'
 import type { CollectionQueryBuilder, DatabaseAdapter, PageCollectionItemBase } from '../../src/types'
 
 describe('searchCollection FTS5', () => {
@@ -384,6 +384,42 @@ describe('searchCollection FTS5', () => {
 
       expect(allCalls[0]!.sql).toContain('collection IN (?, ?)')
       expect(allCalls[0]!.params).toEqual(['"query"*', 'docs', 'modules', 50])
+    })
+  })
+
+  describe('resetFTSIndex', () => {
+    it('should drop FTS table and clear state', async () => {
+      const mockQueryBuilder = createMockQueryBuilder([{
+        path: '/test',
+        title: 'Test',
+        description: '',
+        body: { type: 'root', children: [] },
+      }])
+
+      await buildFTSIndex(mockDb, 'docs', mockQueryBuilder)
+      const callsBeforeReset = execCalls.length
+
+      await resetFTSIndex(mockDb)
+
+      expect(execCalls[callsBeforeReset]!.sql).toContain('DROP TABLE IF EXISTS _fts_search')
+    })
+
+    it('should allow rebuilding index after reset', async () => {
+      const mockQueryBuilder = createMockQueryBuilder([{
+        path: '/test',
+        title: 'Test',
+        description: '',
+        body: { type: 'root', children: [] },
+      }])
+
+      await buildFTSIndex(mockDb, 'docs', mockQueryBuilder)
+      await resetFTSIndex(mockDb)
+
+      execCalls.length = 0
+      await buildFTSIndex(mockDb, 'docs', mockQueryBuilder)
+
+      expect(execCalls[0]!.sql).toContain('CREATE VIRTUAL TABLE')
+      expect(execCalls[1]!.sql).toContain('INSERT')
     })
   })
 })

--- a/test/unit/searchCollection.test.ts
+++ b/test/unit/searchCollection.test.ts
@@ -143,20 +143,29 @@ describe('searchCollection FTS5', () => {
       expect(allCalls[0]!.params![allCalls[0]!.params!.length - 1]).toBe(10)
     })
 
-    it('should include snippet when requested', async () => {
+    it('should include content snippet when requested', async () => {
       await queryFTS(mockDb, ['docs'], 'query', {
-        snippet: { column: 'content', around: 20 },
+        snippet: { columns: ['content'], around: 20 },
       })
 
-      expect(allCalls[0]!.sql).toContain('snippet(_fts_search, 5, \'<mark>\', \'</mark>\', \'...\', 20)')
+      expect(allCalls[0]!.sql).toContain('snippet(_fts_search, 5, \'<mark>\', \'</mark>\', \'...\', 20) as snippet_content')
     })
 
-    it('should use title column index for snippet when specified', async () => {
+    it('should include title snippet when specified', async () => {
       await queryFTS(mockDb, ['docs'], 'query', {
-        snippet: { column: 'title', around: 15 },
+        snippet: { columns: ['title'], around: 15 },
       })
 
-      expect(allCalls[0]!.sql).toContain('snippet(_fts_search, 2, \'<mark>\', \'</mark>\', \'...\', 15)')
+      expect(allCalls[0]!.sql).toContain('snippet(_fts_search, 2, \'<mark>\', \'</mark>\', \'...\', 15) as snippet_title')
+    })
+
+    it('should include multiple snippets', async () => {
+      await queryFTS(mockDb, ['docs'], 'query', {
+        snippet: { columns: ['title', 'content'], around: 20 },
+      })
+
+      expect(allCalls[0]!.sql).toContain('snippet_title')
+      expect(allCalls[0]!.sql).toContain('snippet_content')
     })
 
     it('should parse results correctly', async () => {
@@ -185,7 +194,7 @@ describe('searchCollection FTS5', () => {
       }])
     })
 
-    it('should include snippet in results when requested', async () => {
+    it('should include snippets in results when requested', async () => {
       mockDb.all = vi.fn(async () => [
         {
           collection: 'docs',
@@ -195,25 +204,29 @@ describe('searchCollection FTS5', () => {
           content: 'Install the package with npm',
           level: 2,
           rank: -1.2,
-          snippet: '...Install the <mark>package</mark> with npm...',
+          snippet_content: '...Install the <mark>package</mark> with npm...',
+          snippet_title: 'Setup',
         },
       ])
 
       const results = await queryFTS(mockDb, ['docs'], 'package', {
-        snippet: { column: 'content', around: 20 },
+        snippet: { columns: ['title', 'content'], around: 20 },
       })
 
-      expect(results[0]!.snippet).toBe('...Install the <mark>package</mark> with npm...')
+      expect(results[0]!.snippets).toEqual({
+        title: 'Setup',
+        content: '...Install the <mark>package</mark> with npm...',
+      })
     })
 
     it('should filter terms by minMatchCharLength', async () => {
-      await queryFTS(mockDb, ['docs'], 'a vue b', { minMatchCharLength: 2 })
+      await queryFTS(mockDb, ['docs'], 'a vue b', { minTermLength: 2 })
 
       expect(allCalls[0]!.params![0]).toBe('"vue"*')
     })
 
     it('should return empty when all terms are below minMatchCharLength', async () => {
-      const results = await queryFTS(mockDb, ['docs'], 'a b c', { minMatchCharLength: 3 })
+      const results = await queryFTS(mockDb, ['docs'], 'a b c', { minTermLength: 3 })
 
       expect(results).toEqual([])
       expect(allCalls.length).toBe(0)
@@ -233,11 +246,83 @@ describe('searchCollection FTS5', () => {
 
     it('should use custom highlight tag', async () => {
       await queryFTS(mockDb, ['docs'], 'query', {
-        snippet: { column: 'content', around: 20, tag: 'b' },
+        snippet: { columns: ['content'], around: 20, tag: 'b' },
       })
 
       expect(allCalls[0]!.sql).toContain('\'<b>\'')
       expect(allCalls[0]!.sql).toContain('\'</b>\'')
+    })
+
+    it('should sanitize highlight tag', async () => {
+      await queryFTS(mockDb, ['docs'], 'query', {
+        snippet: { columns: ['content'], tag: 'script>alert(1)</script' },
+      })
+
+      expect(allCalls[0]!.sql).toContain('\'<scriptalert1script>\'')
+    })
+
+    it('should escape double quotes in query terms', async () => {
+      await queryFTS(mockDb, ['docs'], 'say "hello"')
+
+      expect(allCalls[0]!.params![0]).toBe('"say"* """hello"""*')
+    })
+
+    it('should return empty array on FTS5 syntax error', async () => {
+      mockDb.all = vi.fn(async () => { throw new Error('fts5: syntax error') })
+
+      const results = await queryFTS(mockDb, ['docs'], 'test')
+
+      expect(results).toEqual([])
+    })
+
+    it('should include level boost in rank by default', async () => {
+      await queryFTS(mockDb, ['docs'], 'query')
+
+      expect(allCalls[0]!.sql).toContain('/ level)')
+    })
+
+    it('should disable level boost when heading is false', async () => {
+      await queryFTS(mockDb, ['docs'], 'query', { weights: { heading: false } })
+
+      expect(allCalls[0]!.sql).not.toContain('/ level)')
+    })
+
+    it('should use custom weights', async () => {
+      await queryFTS(mockDb, ['docs'], 'query', { weights: { title: 20, content: 1 } })
+
+      expect(allCalls[0]!.sql).toContain('bm25(_fts_search, 0, 0, 20, 20, 0, 1, 0)')
+    })
+  })
+
+  describe('buildFTSIndex title normalization', () => {
+    it('should split camelCase titles into title_normalized column', async () => {
+      const mockQueryBuilder = createMockQueryBuilder([{
+        path: '/docs/button',
+        title: 'ColorModeButton',
+        description: 'A button component',
+        body: { type: 'root', children: [] },
+      }])
+
+      await buildFTSIndex(mockDb, 'docs', mockQueryBuilder)
+
+      const insertParams = execCalls[1]!.params!
+      expect(insertParams[2]).toBe('ColorModeButton')
+      expect(insertParams[3]).toBe('Color Mode Button')
+    })
+
+    it('should keep title_normalized same as title when no camelCase', async () => {
+      const mockQueryBuilder = createMockQueryBuilder([{
+        path: '/docs/intro',
+        title: 'Introduction',
+        description: '',
+        body: { type: 'root', children: [] },
+      }])
+
+      await buildFTSIndex(mockDb, 'docs', mockQueryBuilder)
+
+      const insertParams = execCalls[1]!.params!
+      expect(insertParams[2]).toBe('Introduction')
+      expect(insertParams[3]).toBe('Introduction')
     })
   })
 })


### PR DESCRIPTION
### 🔗 Linked issue

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Adds `useSearchCollection`, a client-side composable that provides full-text search powered by SQLite FTS5. it builds an inverted index from content sections at runtime and queries it with BM25 ranking, prefix matching, and multi-column snippets. no external dependencies needed.

```ts
const { status, search } = useSearchCollection(['docs', 'blog'])

const results = await search('vue compo', {
  limit: 20,
  snippet: { columns: ['title', 'content'], around: 40 },
  weights: { title: 10, content: 5, heading: true }
})
```

Unified FTS5 table across multiple collections, lazy index building with `immediate: false` option, prefix matching on all terms (typing `compo` matches "composable"), configurable field restriction, BM25 column weights with heading-level boosting, camelCase title normalization for better ranking, and graceful handling of FTS5 syntax errors. `queryCollectionSearchSections` still available for Fuse.js/MiniSearch users who need typo tolerance.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
