### PR TITLE
docs: update deprecated nativeSqlite anchor link in installation page

### DIFF
--- a/docs/content/docs/1.getting-started/2.installation.md
+++ b/docs/content/docs/1.getting-started/2.installation.md
@@ -68,7 +68,7 @@ You can choose to install `better-sqlite3` or `sqlite3` package.
 :br
 
 If you don't want to install any package, you can use native SQLite from Node.js\@v22.5.0 or newer.
-Checkout [`experimental.nativeConnector` configuration](/docs/getting-started/configuration#experimentalsqliteconnector).
+Checkout [`experimental.sqliteConnector` configuration](/docs/getting-started/configuration#experimentalsqliteconnector).
 ::
 
 ::note{color="warning"}

--- a/docs/content/docs/1.getting-started/2.installation.md
+++ b/docs/content/docs/1.getting-started/2.installation.md
@@ -68,7 +68,7 @@ You can choose to install `better-sqlite3` or `sqlite3` package.
 :br
 
 If you don't want to install any package, you can use native SQLite from Node.js\@v22.5.0 or newer.
-Checkout [`experimental.nativeSqlite` configuration](/docs/getting-started/configuration#experimentalnativesqlite-deprecated-use-sqliteconnector).
+Checkout [`experimental.nativeConnector` configuration](/docs/getting-started/configuration#experimentalsqliteconnector).
 ::
 
 ::note{color="warning"}


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Replace outdated `#experimentalnativesqlite-deprecated-use-sqliteconnector` anchor with the current `#experimentalsqliteconnector` in the installation getting-started page.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
