### PR TITLE
fix(search): softer heading-level boost curve and tuned defaults

### DIFF
--- a/docs/content/docs/4.utils/5.use-search-collection.md
+++ b/docs/content/docs/4.utils/5.use-search-collection.md
@@ -54,13 +54,13 @@ function useSearchCollection<T extends keyof PageCollections>(
 - `search(query, opts?)`: Execute a search query. Returns a promise with ranked results.
   - `query`: The search string. Supports prefix matching automatically (typing `compo` matches "composable").
   - `opts`: (Optional) Search options:
-    - `limit`: Maximum results. Default is `50`.
+    - `limit`: Maximum results. Default is `20`.
     - `fields`: Restrict search to specific columns (`'title'` or `'content'`).
     - `minTermLength`: Skip terms shorter than this value. Default is `1`.
     - `weights`: Control ranking behavior.
-      - `title`: Boost factor for title matches. Default is `10`.
+      - `title`: Boost factor for title matches. Default is `20`.
       - `content`: Boost factor for content matches. Default is `5`.
-      - `heading`: Whether higher-level sections (h1 > h2 > h3) rank higher. Default is `true`.
+      - `heading`: Exponent controlling heading-level boost (`0.5` = sqrt curve, `1` = linear, `0` = disabled). Default is `0.5`.
     - `snippet`: Return highlighted text excerpts.
       - `columns`: Which columns to snippet (`['title']`, `['content']`, or both). Default is `['content']`.
       - `around`: Number of tokens around the match. Default is `30`.

--- a/src/runtime/internal/search.ts
+++ b/src/runtime/internal/search.ts
@@ -31,7 +31,7 @@ export type SearchResult = {
 export type SearchCollectionOptions = {
   /**
    * Maximum number of results to return.
-   * @default 50
+   * @default 20
    */
   limit?: number
   /** Restrict search to specific columns. Searches all columns when omitted. */
@@ -45,7 +45,7 @@ export type SearchCollectionOptions = {
   weights?: {
     /**
      * Boost factor for matches in the title column.
-     * @default 10
+     * @default 20
      */
     title?: number
     /**
@@ -54,11 +54,15 @@ export type SearchCollectionOptions = {
      */
     content?: number
     /**
-     * Whether to boost higher-level sections (h1 > h2 > h3...).
-     * Set to `false` to disable level-based boosting.
-     * @default true
+     * Exponent controlling heading-level boost.
+     * Higher-level sections (h1 > h2 > h3...) are boosted by dividing the
+     * BM25 score by `pow(level, heading)`.
+     * - `0.5` (default): sqrt curve — gentler falloff
+     * - `1`: linear penalty (h4 gets 1/4 the score of h1)
+     * - `0`: no level-based penalty
+     * @default 0.5
      */
-    heading?: boolean
+    heading?: number
   }
   /** Return text snippets with highlighted matches for the specified columns. */
   snippet?: {
@@ -246,11 +250,11 @@ export async function queryFTS(
   query: string,
   opts?: SearchCollectionOptions,
 ): Promise<SearchResult[]> {
-  const { limit = 50, snippet, fields, minTermLength = 1, weights } = opts || {}
+  const { limit = 20, snippet, fields, minTermLength = 1, weights } = opts || {}
 
-  const titleWeight = weights?.title ?? 10
+  const titleWeight = weights?.title ?? 20
   const contentWeight = weights?.content ?? 5
-  const headingBoost = weights?.heading !== false
+  const headingExponent = weights?.heading ?? 0.5
 
   const tag = (snippet?.tag ?? 'mark').replace(/[^a-z0-9]/gi, '')
   const pre = `<${tag}>`
@@ -260,7 +264,9 @@ export async function queryFTS(
   const collectionFilter = `collection IN (${placeholders})`
 
   const bm25Expr = `bm25(${FTS_TABLE}, 0, 0, ${titleWeight}, ${titleWeight}, 0, ${contentWeight}, 0)`
-  const rankExpr = headingBoost ? `(${bm25Expr} / level)` : bm25Expr
+  const rankExpr = headingExponent > 0
+    ? `(${bm25Expr} / pow(level, ${headingExponent}))`
+    : bm25Expr
   let selectClause = `collection, id, title, titles, content, level, ${rankExpr} as rank`
   const snippetColumns = snippet?.columns ?? (snippet ? ['content'] : [])
   const around = Number(snippet?.around) || 30

--- a/test/unit/searchCollection.test.ts
+++ b/test/unit/searchCollection.test.ts
@@ -126,14 +126,14 @@ describe('searchCollection FTS5', () => {
       expect(allCalls[0]!.sql).toContain('_fts_search MATCH ?')
       expect(allCalls[0]!.sql).toContain('collection IN (?)')
       expect(allCalls[0]!.sql).toContain('ORDER BY rank')
-      expect(allCalls[0]!.params).toEqual(['"vue"* "composable"*', 'docs', 50])
+      expect(allCalls[0]!.params).toEqual(['"vue"* "composable"*', 'docs', 20])
     })
 
     it('should support multiple collections', async () => {
       await queryFTS(mockDb, ['docs', 'blog'], 'search term')
 
       expect(allCalls[0]!.sql).toContain('collection IN (?, ?)')
-      expect(allCalls[0]!.params).toEqual(['"search"* "term"*', 'docs', 'blog', 50])
+      expect(allCalls[0]!.params).toEqual(['"search"* "term"*', 'docs', 'blog', 20])
     })
 
     it('should respect limit option', async () => {
@@ -284,16 +284,28 @@ describe('searchCollection FTS5', () => {
       expect(results).toEqual([])
     })
 
-    it('should include level boost in rank by default', async () => {
+    it('should use sqrt heading boost by default', async () => {
       await queryFTS(mockDb, ['docs'], 'query')
 
-      expect(allCalls[0]!.sql).toContain('/ level)')
+      expect(allCalls[0]!.sql).toContain('/ pow(level, 0.5))')
     })
 
-    it('should disable level boost when heading is false', async () => {
-      await queryFTS(mockDb, ['docs'], 'query', { weights: { heading: false } })
+    it('should disable level boost when heading is 0', async () => {
+      await queryFTS(mockDb, ['docs'], 'query', { weights: { heading: 0 } })
 
-      expect(allCalls[0]!.sql).not.toContain('/ level)')
+      expect(allCalls[0]!.sql).not.toContain('pow(level')
+    })
+
+    it('should use linear heading boost when heading is 1', async () => {
+      await queryFTS(mockDb, ['docs'], 'query', { weights: { heading: 1 } })
+
+      expect(allCalls[0]!.sql).toContain('/ pow(level, 1))')
+    })
+
+    it('should use custom heading exponent', async () => {
+      await queryFTS(mockDb, ['docs'], 'query', { weights: { heading: 0.3 } })
+
+      expect(allCalls[0]!.sql).toContain('/ pow(level, 0.3))')
     })
 
     it('should use custom weights', async () => {


### PR DESCRIPTION
### 🔗 Linked issue

Follow-up to #3787

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

the FTS5 heading boost from #3787 divides BM25 score by `level`, which is too aggressive — a h4 section gets 1/4 the score of a h1. disabling it entirely (`heading: false`) overcorrects the other way.

this replaces the binary `heading: boolean` with a numeric exponent. the rank expression becomes `bm25(...) / pow(level, heading)` where `heading` defaults to `0.5` (sqrt curve). a h4 section now gets half the score instead of a quarter, which keeps API reference pages above subsections for queries like "useFetch" while not crushing deep sections for queries like "module dependencies".

also bumps default title weight from 10 to 20 (BM25 saturates around there, higher values don't help) and lowers default limit from 50 to 20.

| heading value | effect |
|---|---|
| `0.5` (default) | sqrt curve, gentler falloff |
| `1` | old linear penalty |
| `0` | no level-based penalty |

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.