### PR TITLE
fix(security): reject SQL function calls in query WHERE clauses

### DIFF
--- a/src/runtime/internal/security.ts
+++ b/src/runtime/internal/security.ts
@@ -4,7 +4,7 @@ const SQL_SELECT_REGEX = /^SELECT (.*) FROM (\w+)( WHERE .*)? ORDER BY (["\w,\s]
 // Parentheses in WHERE are only valid after these keywords (grouping / IN lists).
 // Everything else that looks like `name(` is treated as a disallowed function call.
 const SQL_WHERE_PAREN_KEYWORDS = /\b(?:WHERE|AND|OR|IN)\s*\(/gi
-const SQL_FUNCTION_CALL = /\b[A-Za-z_]\w*\s*\(/
+const SQL_FUNCTION_CALL = /\b[A-Z_]\w*\s*\(/i
 
 /**
  * Assert that the query is safe

--- a/src/runtime/internal/security.ts
+++ b/src/runtime/internal/security.ts
@@ -2,9 +2,9 @@ const SQL_COMMANDS = /SELECT|INSERT|UPDATE|DELETE|DROP|ALTER|\$/i
 const SQL_COUNT_REGEX = /^COUNT\((DISTINCT )?([a-z_]\w+|\*)\) as count$/i
 const SQL_SELECT_REGEX = /^SELECT (.*) FROM (\w+)( WHERE .*)? ORDER BY (["\w,\s]+) (ASC|DESC)( LIMIT \d+)?( OFFSET \d+)?$/
 // Parentheses in WHERE are only valid after these keywords (grouping / IN lists).
-// Everything else that looks like `name(` is treated as a disallowed function call.
+// Anything else that looks like a call (name(, "name"(, [name](, `name`() is disallowed.
 const SQL_WHERE_PAREN_KEYWORDS = /\b(?:WHERE|AND|OR|IN)\s*\(/gi
-const SQL_FUNCTION_CALL = /\b[A-Z_]\w*\s*\(/i
+const SQL_FUNCTION_CALL = /\b[A-Z_]\w*([\]"'(`]*)\s*\(/i
 
 /**
  * Assert that the query is safe
@@ -64,9 +64,12 @@ export function assertSafeQuery(sql: string, collection: string) {
     if (noString.match(SQL_COMMANDS)) {
       throw new Error('Invalid query: WHERE clause contains unsafe SQL commands')
     }
-    // Block SQLite function calls (randomblob, zeroblob, hex, length, …).
+    // Block SQLite function calls (randomblob, zeroblob, hex, length, …),
+    // including quoted/bracketed forms SQLite accepts as identifiers: "abs"(, [abs](, `abs`(.
+    // Only single-quoted value literals are stripped so identifier quotes stay visible to the matcher.
     // The query builder never emits functions in WHERE; only grouping and IN (...).
-    const withoutGroupingParens = noString.replace(SQL_WHERE_PAREN_KEYWORDS, '')
+    const noSingleQuoted = cleanupQuery(where, { removeSingleQuoted: true })
+    const withoutGroupingParens = noSingleQuoted.replace(SQL_WHERE_PAREN_KEYWORDS, ' ')
     if (SQL_FUNCTION_CALL.test(withoutGroupingParens)) {
       throw new Error('Invalid query: WHERE clause contains unsafe SQL expressions')
     }
@@ -91,7 +94,7 @@ export function assertSafeQuery(sql: string, collection: string) {
   return true
 }
 
-function cleanupQuery(query: string, options: { removeString: boolean } = { removeString: false }) {
+function cleanupQuery(query: string, options: { removeString?: boolean, removeSingleQuoted?: boolean } = {}) {
   // Track whether we're inside a string literal
   let inString = false
   let stringFence = ''
@@ -101,8 +104,14 @@ function cleanupQuery(query: string, options: { removeString: boolean } = { remo
     const prevChar = query[i - 1]
     const nextChar = query[i + 1]
 
+    // Keep double-quoted identifiers when only stripping value literals
+    if (char === '"' && options.removeSingleQuoted && !options.removeString && !inString) {
+      result += char
+      continue
+    }
+
     if (char === '\'' || char === '"') {
-      if (!options?.removeString) {
+      if (!options.removeString && !options.removeSingleQuoted) {
         result += char
         continue
       }

--- a/src/runtime/internal/security.ts
+++ b/src/runtime/internal/security.ts
@@ -1,6 +1,10 @@
 const SQL_COMMANDS = /SELECT|INSERT|UPDATE|DELETE|DROP|ALTER|\$/i
 const SQL_COUNT_REGEX = /^COUNT\((DISTINCT )?([a-z_]\w+|\*)\) as count$/i
 const SQL_SELECT_REGEX = /^SELECT (.*) FROM (\w+)( WHERE .*)? ORDER BY (["\w,\s]+) (ASC|DESC)( LIMIT \d+)?( OFFSET \d+)?$/
+// Parentheses in WHERE are only valid after these keywords (grouping / IN lists).
+// Everything else that looks like `name(` is treated as a disallowed function call.
+const SQL_WHERE_PAREN_KEYWORDS = /\b(?:WHERE|AND|OR|IN)\s*\(/gi
+const SQL_FUNCTION_CALL = /\b[A-Za-z_]\w*\s*\(/
 
 /**
  * Assert that the query is safe
@@ -59,6 +63,12 @@ export function assertSafeQuery(sql: string, collection: string) {
     const noString = cleanupQuery(where, { removeString: true })
     if (noString.match(SQL_COMMANDS)) {
       throw new Error('Invalid query: WHERE clause contains unsafe SQL commands')
+    }
+    // Block SQLite function calls (randomblob, zeroblob, hex, length, …).
+    // The query builder never emits functions in WHERE; only grouping and IN (...).
+    const withoutGroupingParens = noString.replace(SQL_WHERE_PAREN_KEYWORDS, '')
+    if (SQL_FUNCTION_CALL.test(withoutGroupingParens)) {
+      throw new Error('Invalid query: WHERE clause contains unsafe SQL expressions')
     }
   }
 

--- a/src/runtime/internal/security.ts
+++ b/src/runtime/internal/security.ts
@@ -4,7 +4,7 @@ const SQL_SELECT_REGEX = /^SELECT (.*) FROM (\w+)( WHERE .*)? ORDER BY (["\w,\s]
 // Parentheses in WHERE are only valid after these keywords (grouping / IN lists).
 // Anything else that looks like a call (name(, "name"(, [name](, `name`() is disallowed.
 const SQL_WHERE_PAREN_KEYWORDS = /\b(?:WHERE|AND|OR|IN)\s*\(/gi
-const SQL_FUNCTION_CALL = /\b[A-Z_]\w*([\]"'(`]*)\s*\(/i
+const SQL_FUNCTION_CALL = /\b[A-Z_]\w*[\]"'(`]*\s*\(/i
 
 /**
  * Assert that the query is safe

--- a/src/runtime/internal/security.ts
+++ b/src/runtime/internal/security.ts
@@ -96,62 +96,85 @@ export function assertSafeQuery(sql: string, collection: string) {
 }
 
 function cleanupQuery(query: string, options: { removeString?: boolean, removeSingleQuoted?: boolean } = {}) {
-  // Track whether we're inside a string literal
-  let inString = false
-  let stringFence = ''
+  // Track every SQL quote fence so comments/apostrophes inside identifiers
+  // ("…", `…`, […]) cannot terminate or re-open the scanner early.
+  let fence: '\'' | '"' | '`' | '[' | null = null
   let result = ''
+  const stripAll = Boolean(options.removeString)
+  const stripSingle = Boolean(options.removeSingleQuoted) && !stripAll
+
+  const strippingFence = (active: NonNullable<typeof fence>) => {
+    if (stripAll) {
+      return true
+    }
+    // removeSingleQuoted only drops value literals; identifiers stay visible
+    return stripSingle && active === '\''
+  }
+
   for (let i = 0; i < query.length; i++) {
     const char = query[i]
     const nextChar = query[i + 1]
 
-    // Keep double-quoted identifiers when only stripping value literals
-    if (char === '"' && options.removeSingleQuoted && !options.removeString && !inString) {
-      result += char
-      continue
-    }
-
-    if (char === '\'' || char === '"') {
-      if (!options.removeString && !options.removeSingleQuoted) {
-        result += char
-        continue
-      }
-
-      if (inString) {
-        if (char === stringFence) {
-          // SQLite escaped quote pair ('' or "") stays inside the literal
-          if (nextChar === stringFence) {
-            i += 1
-            continue
+    if (fence) {
+      if (fence === '[') {
+        if (char === ']') {
+          if (!strippingFence(fence)) {
+            result += char
           }
-          inString = false
-          stringFence = ''
+          fence = null
         }
-        // Skip characters inside the literal
+        else if (!strippingFence(fence)) {
+          result += char
+        }
         continue
       }
 
-      inString = true
-      stringFence = char
+      if (char === fence) {
+        // SQLite escaped quote pair ('' / "" / ``) stays inside the fence
+        if (nextChar === fence) {
+          if (!strippingFence(fence)) {
+            result += char + nextChar
+          }
+          i += 1
+          continue
+        }
+        if (!strippingFence(fence)) {
+          result += char
+        }
+        fence = null
+        continue
+      }
+
+      if (!strippingFence(fence)) {
+        result += char
+      }
       continue
     }
 
-    if (!inString) {
-      if (char === '-' && nextChar === '-') {
-        // everything after this is a comment
-        return result
+    if (char === '\'' || char === '"' || char === '`' || char === '[') {
+      fence = char
+      if (!strippingFence(fence)) {
+        result += char
       }
-
-      if (char === '/' && nextChar === '*') {
-        i += 2
-        while (i < query.length && !(query[i] === '*' && query[i + 1] === '/')) {
-          i += 1
-        }
-        i += 2
-        continue
-      }
-
-      result += char
+      continue
     }
+
+    // Comments are only meaningful outside quoted regions
+    if (char === '-' && nextChar === '-') {
+      // everything after this is a comment
+      return result
+    }
+
+    if (char === '/' && nextChar === '*') {
+      i += 2
+      while (i < query.length && !(query[i] === '*' && query[i + 1] === '/')) {
+        i += 1
+      }
+      i += 2
+      continue
+    }
+
+    result += char
   }
   return result
 }

--- a/src/runtime/internal/security.ts
+++ b/src/runtime/internal/security.ts
@@ -4,7 +4,8 @@ const SQL_SELECT_REGEX = /^SELECT (.*) FROM (\w+)( WHERE .*)? ORDER BY (["\w,\s]
 // Parentheses in WHERE are only valid after these keywords (grouping / IN lists).
 // Anything else that looks like a call (name(, "name"(, [name](, `name`() is disallowed.
 const SQL_WHERE_PAREN_KEYWORDS = /\b(?:WHERE|AND|OR|IN)\s*\(/gi
-const SQL_FUNCTION_CALL = /\b[A-Z_]\w*[\]"'(`]*\s*\(/i
+// Bare identifiers use a word boundary; quoted/bracketed forms match the whole identifier unit.
+const SQL_FUNCTION_CALL = /(?:\b[A-Z_]\w*|(?:["`[][A-Z_]\w*["`\]]))\s*\(/i
 
 /**
  * Assert that the query is safe
@@ -101,7 +102,6 @@ function cleanupQuery(query: string, options: { removeString?: boolean, removeSi
   let result = ''
   for (let i = 0; i < query.length; i++) {
     const char = query[i]
-    const prevChar = query[i - 1]
     const nextChar = query[i + 1]
 
     // Keep double-quoted identifiers when only stripping value literals
@@ -117,20 +117,22 @@ function cleanupQuery(query: string, options: { removeString?: boolean, removeSi
       }
 
       if (inString) {
-        if (char !== stringFence || nextChar === stringFence || prevChar === stringFence) {
-          // skip character, it's part of a string
-          continue
+        if (char === stringFence) {
+          // SQLite escaped quote pair ('' or "") stays inside the literal
+          if (nextChar === stringFence) {
+            i += 1
+            continue
+          }
+          inString = false
+          stringFence = ''
         }
+        // Skip characters inside the literal
+        continue
+      }
 
-        inString = false
-        stringFence = ''
-        continue
-      }
-      else {
-        inString = true
-        stringFence = char
-        continue
-      }
+      inString = true
+      stringFence = char
+      continue
     }
 
     if (!inString) {

--- a/src/runtime/internal/security.ts
+++ b/src/runtime/internal/security.ts
@@ -5,7 +5,7 @@ const SQL_SELECT_REGEX = /^SELECT (.*) FROM (\w+)( WHERE .*)? ORDER BY (["\w,\s]
 // Anything else that looks like a call (name(, "name"(, [name](, `name`() is disallowed.
 const SQL_WHERE_PAREN_KEYWORDS = /\b(?:WHERE|AND|OR|IN)\s*\(/gi
 // Bare identifiers use a word boundary; quoted/bracketed forms match the whole identifier unit.
-const SQL_FUNCTION_CALL = /(?:\b[A-Z_]\w*|(?:["`[][A-Z_]\w*["`\]]))\s*\(/i
+const SQL_FUNCTION_CALL = /(?:\b[A-Z_]\w*|["`[][A-Z_]\w*["`\]])\s*\(/i
 
 /**
  * Assert that the query is safe

--- a/test/unit/assertSafeQuery.test.ts
+++ b/test/unit/assertSafeQuery.test.ts
@@ -55,8 +55,17 @@ describe('decompressSQLDump', () => {
     'SELECT * FROM _content_test WHERE ("abs"(1) > 0) ORDER BY stem ASC': false,
     'SELECT * FROM _content_test WHERE ([abs](1) > 0) ORDER BY stem ASC': false,
     'SELECT * FROM _content_test WHERE (`abs`(1) > 0) ORDER BY stem ASC': false,
+    'SELECT * FROM _content_test WHERE ("randomblob"(100000000) IS NOT NULL) ORDER BY stem ASC': false,
+    'SELECT * FROM _content_test WHERE ([randomblob](100000000) IS NOT NULL) ORDER BY stem ASC': false,
     'SELECT * FROM _content_test WHERE ("id" IN (abs(1))) ORDER BY stem ASC': false,
     'SELECT * FROM _content_test WHERE ("id" IN ("abs"(1))) ORDER BY stem ASC': false,
+    // Escaped quotes must not hide trailing function calls from the scanner
+    'SELECT * FROM _content_test WHERE ("id" = \'\'\'\' || randomblob(1)) ORDER BY stem ASC': false,
+    'SELECT * FROM _content_test WHERE ("id" = \'\' || randomblob(1) || \'\') ORDER BY stem ASC': false,
+    'SELECT * FROM _content_test WHERE ("x" = \'foo\'\'\' AND randomblob(1) IS NOT NULL AND "y" = \'\'\'bar\') ORDER BY stem ASC': false,
+    // Legitimate values with escaped quotes remain allowed
+    'SELECT * FROM _content_test WHERE ("id" = \'it\'\'s\') ORDER BY stem ASC': true,
+    'SELECT * FROM _content_test WHERE ("id" = \'\'\'\'\'\') ORDER BY stem ASC': true,
     // Legitimate IN / nested grouping parentheses remain allowed
     'SELECT * FROM _content_test WHERE ("id" IN (\'a\', \'b\')) ORDER BY stem ASC': true,
     'SELECT * FROM _content_test WHERE ("id" NOT IN (\'a\', \'b\')) ORDER BY stem ASC': true,

--- a/test/unit/assertSafeQuery.test.ts
+++ b/test/unit/assertSafeQuery.test.ts
@@ -45,6 +45,20 @@ describe('decompressSQLDump', () => {
     'SELECT "id", "id" FROM _content_docs WHERE (1=\' \\\') UNION SELECT tbl_name,tbl_name FROM sqlite_master-- \') ORDER BY id ASC': false,
     'SELECT "id" FROM _content_test WHERE (x=$\'$ OR x IN (SELECT BLAH) OR x=$\'$) ORDER BY id ASC': false,
     'SELECT COUNT(*) as c,(SELECT group_concat(name,\'|\') FROM sqlite_master WHERE type=\'table\') AS leak FROM _content_content ORDER BY stem ASC': false,
+    // SQLite function calls in WHERE must be rejected (DoS via randomblob/zeroblob/hex/length)
+    'SELECT * FROM _content_test WHERE (length(hex(randomblob(100000000))) > 0) ORDER BY stem ASC LIMIT 1': false,
+    'SELECT * FROM _content_test WHERE (zeroblob(500000000) IS NOT NULL) ORDER BY stem ASC LIMIT 1': false,
+    'SELECT * FROM _content_test WHERE (hex(\'a\') = \'61\') ORDER BY stem ASC': false,
+    'SELECT * FROM _content_test WHERE (abs(1) > 0) ORDER BY stem ASC': false,
+    'SELECT * FROM _content_test WHERE ("id" = \'1\' AND length("id") > 0) ORDER BY stem ASC': false,
+    // Legitimate IN / nested grouping parentheses remain allowed
+    'SELECT * FROM _content_test WHERE ("id" IN (\'a\', \'b\')) ORDER BY stem ASC': true,
+    'SELECT * FROM _content_test WHERE ("id" NOT IN (\'a\', \'b\')) ORDER BY stem ASC': true,
+    'SELECT * FROM _content_test WHERE (("id" = \'1\') AND ("stem" = \'abc\')) ORDER BY stem ASC': true,
+    'SELECT * FROM _content_test WHERE ("path" LIKE \'%foo%\') ORDER BY stem ASC': true,
+    'SELECT * FROM _content_test WHERE ("x" BETWEEN \'1\' AND \'2\') ORDER BY stem ASC': true,
+    'SELECT * FROM _content_test WHERE ("x" IS NULL) ORDER BY stem ASC': true,
+    'SELECT * FROM _content_test WHERE ("x" IS NOT NULL) ORDER BY stem ASC': true,
   }
 
   Object.entries(queries).forEach(([query, isValid]) => {

--- a/test/unit/assertSafeQuery.test.ts
+++ b/test/unit/assertSafeQuery.test.ts
@@ -63,6 +63,13 @@ describe('decompressSQLDump', () => {
     'SELECT * FROM _content_test WHERE ("id" = \'\'\'\' || randomblob(1)) ORDER BY stem ASC': false,
     'SELECT * FROM _content_test WHERE ("id" = \'\' || randomblob(1) || \'\') ORDER BY stem ASC': false,
     'SELECT * FROM _content_test WHERE ("x" = \'foo\'\'\' AND randomblob(1) IS NOT NULL AND "y" = \'\'\'bar\') ORDER BY stem ASC': false,
+    // Apostrophes / -- inside identifier fences must not mask trailing calls
+    'SELECT * FROM _content_test WHERE ("it\'s" = \'x\' OR randomblob(1) IS NOT NULL) ORDER BY stem ASC': false,
+    'SELECT * FROM _content_test WHERE ("a--b" = \'x\' OR randomblob(1) IS NOT NULL) ORDER BY stem ASC': false,
+    'SELECT * FROM _content_test WHERE (`it\'s` = \'x\' OR randomblob(1) IS NOT NULL) ORDER BY stem ASC': false,
+    'SELECT * FROM _content_test WHERE (`a--b` = \'x\' OR randomblob(1) IS NOT NULL) ORDER BY stem ASC': false,
+    'SELECT * FROM _content_test WHERE ([it\'s] = \'x\' OR randomblob(1) IS NOT NULL) ORDER BY stem ASC': false,
+    'SELECT * FROM _content_test WHERE ([a--b] = \'x\' OR randomblob(1) IS NOT NULL) ORDER BY stem ASC': false,
     // Legitimate values with escaped quotes remain allowed
     'SELECT * FROM _content_test WHERE ("id" = \'it\'\'s\') ORDER BY stem ASC': true,
     'SELECT * FROM _content_test WHERE ("id" = \'\'\'\'\'\') ORDER BY stem ASC': true,

--- a/test/unit/assertSafeQuery.test.ts
+++ b/test/unit/assertSafeQuery.test.ts
@@ -45,12 +45,18 @@ describe('decompressSQLDump', () => {
     'SELECT "id", "id" FROM _content_docs WHERE (1=\' \\\') UNION SELECT tbl_name,tbl_name FROM sqlite_master-- \') ORDER BY id ASC': false,
     'SELECT "id" FROM _content_test WHERE (x=$\'$ OR x IN (SELECT BLAH) OR x=$\'$) ORDER BY id ASC': false,
     'SELECT COUNT(*) as c,(SELECT group_concat(name,\'|\') FROM sqlite_master WHERE type=\'table\') AS leak FROM _content_content ORDER BY stem ASC': false,
-    // SQLite function calls in WHERE must be rejected (DoS via randomblob/zeroblob/hex/length)
+    // SQLite function calls in WHERE must be rejected
     'SELECT * FROM _content_test WHERE (length(hex(randomblob(100000000))) > 0) ORDER BY stem ASC LIMIT 1': false,
     'SELECT * FROM _content_test WHERE (zeroblob(500000000) IS NOT NULL) ORDER BY stem ASC LIMIT 1': false,
     'SELECT * FROM _content_test WHERE (hex(\'a\') = \'61\') ORDER BY stem ASC': false,
     'SELECT * FROM _content_test WHERE (abs(1) > 0) ORDER BY stem ASC': false,
     'SELECT * FROM _content_test WHERE ("id" = \'1\' AND length("id") > 0) ORDER BY stem ASC': false,
+    // Quoted / bracketed function identifiers (SQLite treats these as calls)
+    'SELECT * FROM _content_test WHERE ("abs"(1) > 0) ORDER BY stem ASC': false,
+    'SELECT * FROM _content_test WHERE ([abs](1) > 0) ORDER BY stem ASC': false,
+    'SELECT * FROM _content_test WHERE (`abs`(1) > 0) ORDER BY stem ASC': false,
+    'SELECT * FROM _content_test WHERE ("id" IN (abs(1))) ORDER BY stem ASC': false,
+    'SELECT * FROM _content_test WHERE ("id" IN ("abs"(1))) ORDER BY stem ASC': false,
     // Legitimate IN / nested grouping parentheses remain allowed
     'SELECT * FROM _content_test WHERE ("id" IN (\'a\', \'b\')) ORDER BY stem ASC': true,
     'SELECT * FROM _content_test WHERE ("id" NOT IN (\'a\', \'b\')) ORDER BY stem ASC': true,


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The content query API validates client-built SQL against the query builder shape. WHERE validation previously only blocked a small set of SQL command keywords, so expressions like function calls could still pass through.

This change strips known safe parenthesized constructs (`WHERE`/`AND`/`OR`/`IN` groups) and rejects any remaining `name(` patterns, which the query builder never emits.


<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
