### PR TITLE
fix(content): import zod-to-json-schema only for zod v3 schemas

### DIFF
--- a/src/utils/dependencies.ts
+++ b/src/utils/dependencies.ts
@@ -78,6 +78,8 @@ export async function initiateValidatorsContext() {
     nuxtContentContext().set('valibot', await import('./schema/valibot'))
   }
   if (await isPackageInstalled('zod')) {
+    // The zod3 converter statically imports `zod-to-json-schema`, so only
+    // register it when that package is actually reachable.
     if (await isPackageInstalled('zod-to-json-schema')) {
       nuxtContentContext().set('zod3', await import('./schema/zod3'))
     }

--- a/src/utils/dependencies.ts
+++ b/src/utils/dependencies.ts
@@ -78,7 +78,9 @@ export async function initiateValidatorsContext() {
     nuxtContentContext().set('valibot', await import('./schema/valibot'))
   }
   if (await isPackageInstalled('zod')) {
-    nuxtContentContext().set('zod3', await import('./schema/zod3'))
+    if (await isPackageInstalled('zod-to-json-schema')) {
+      nuxtContentContext().set('zod3', await import('./schema/zod3'))
+    }
     nuxtContentContext().set('zod4', await import('./schema/zod4'))
   }
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -6,4 +6,4 @@ export { defineTransformer } from './content/transformers/utils'
 /**
  * This is only for backward compatibility with Zod v3. Consider using direct import from 'zod' instead. This will be removed in the next major version.
  */
-export { z } from './schema/zod3'
+export { z } from './schema/zod3-legacy'

--- a/src/utils/schema/zod3-legacy.ts
+++ b/src/utils/schema/zod3-legacy.ts
@@ -1,0 +1,20 @@
+import { z as zod } from 'zod'
+import type { EditorOptions } from '../../types'
+
+declare module 'zod' {
+  interface ZodTypeDef {
+    editor?: EditorOptions
+  }
+
+  interface ZodType {
+    editor(options: EditorOptions): this
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(zod.ZodType as any).prototype.editor = function (options: EditorOptions) {
+  this._def.editor = { ...this._def.editor, ...options }
+  return this
+}
+
+export const z = zod

--- a/src/utils/schema/zod3.ts
+++ b/src/utils/schema/zod3.ts
@@ -1,7 +1,7 @@
 import { zodToJsonSchema, ignoreOverride } from 'zod-to-json-schema'
-import { z as zod } from 'zod'
+import type { ZodSchema } from 'zod'
 import { createDefu } from 'defu'
-import type { Draft07, EditorOptions } from '../../types'
+import type { Draft07 } from '../../types'
 
 const defu = createDefu((obj, key, value) => {
   if (Array.isArray(obj[key]) && Array.isArray(value)) {
@@ -10,26 +10,8 @@ const defu = createDefu((obj, key, value) => {
   }
 })
 
-declare module 'zod' {
-  interface ZodTypeDef {
-    editor?: EditorOptions
-  }
-
-  interface ZodType {
-    editor(options: EditorOptions): this
-  }
-}
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-(zod.ZodType as any).prototype.editor = function (options: EditorOptions) {
-  this._def.editor = { ...this._def.editor, ...options }
-  return this
-}
-
-export const z = zod
-
 export function toJSONSchema(_schema: unknown, name: string): Draft07 {
-  const schema = _schema as zod.ZodSchema
+  const schema = _schema as ZodSchema
   const jsonSchema = zodToJsonSchema(schema, { name, $refStrategy: 'none', dateStrategy: 'format:date' }) as Draft07
   const jsonSchemaWithEditorMeta = zodToJsonSchema(
     schema,

--- a/test/unit/validatorLazyLoading.test.ts
+++ b/test/unit/validatorLazyLoading.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test, vi } from 'vitest'
+
+const converter = vi.hoisted(() => ({ loaded: vi.fn() }))
+
+vi.mock('zod-to-json-schema', async (importOriginal) => {
+  converter.loaded()
+  return await importOriginal<typeof import('zod-to-json-schema')>()
+})
+
+describe('validator lazy loading', () => {
+  test('loads zod-to-json-schema only when the zod3 validator is initialized', async () => {
+    await import('../../src/utils/index.ts')
+
+    expect(converter.loaded).not.toHaveBeenCalled()
+
+    const { initiateValidatorsContext } = await import('../../src/utils/dependencies.ts')
+    await initiateValidatorsContext()
+
+    expect(converter.loaded).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

Closes #3825

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`initiateValidatorsContext()` imports the zod3 validator dynamically, behind an `isPackageInstalled('zod')` check, but `src/utils/index.ts` re-exports `z` from that same module. The static re-export wins, so `dist/module.mjs` ends up with a top-level `import { zodToJsonSchema, ignoreOverride } from 'zod-to-json-schema'` and the module cannot load at all unless that package resolves, even for apps whose collections are all zod v4 and go through the native `toJSONSchema()` path.

The legacy `z` export and its `.editor()` prototype patch move to `schema/zod3-legacy.ts`, which leaves `schema/zod3.ts` as a converter-only module like `zod4.ts` and `valibot.ts`. It stays out of the eager graph and is loaded only when both `zod` and `zod-to-json-schema` are present, so a missing converter now surfaces as the existing "install `zod` and `zod-to-json-schema`" error instead of a module resolution crash.

This only covers the first suggestion in the issue. Widening the zod range and moving zod/zod-to-json-schema to optional peer dependencies changes the dependency contract, so I left it out; `zod` itself is still imported eagerly for the legacy `z` export.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
