### PR TITLE
fix: avoid install prompt in non-interactive environments

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "@electric-sql/pglite": "*",
     "@libsql/client": "*",
     "@valibot/to-json-schema": "^1.5.0",
-    "better-sqlite3": "^12.5.0",
+    "better-sqlite3": "^12.5.0 || ^13.0.0",
     "sqlite3": "*",
     "valibot": "^1.2.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,7 +38,7 @@ importers:
         specifier: ^1.1.1
         version: 1.1.1
       better-sqlite3:
-        specifier: ^12.5.0
+        specifier: ^12.5.0 || ^13.0.0
         version: 12.10.0
       c12:
         specifier: ^3.3.4

--- a/src/utils/dependencies.ts
+++ b/src/utils/dependencies.ts
@@ -1,5 +1,6 @@
 import { addDependency } from 'nypm'
 import { resolvePackageJSON } from 'pkg-types'
+import { hasTTY, isCI } from 'std-env'
 import { logger } from './dev'
 import nuxtContentContext from './context'
 import { tryUseNuxt } from '@nuxt/kit'
@@ -22,11 +23,13 @@ export async function ensurePackageInstalled(pkg: string) {
   if (!await isPackageInstalled(pkg)) {
     logger.error(`Nuxt Content requires \`${pkg}\` module to operate.`)
 
-    const confirm = await logger.prompt(`Do you want to install \`${pkg}\` package?`, {
-      type: 'confirm',
-      name: 'confirm',
-      initial: true,
-    })
+    const confirm = hasTTY && !isCI
+      ? await logger.prompt(`Do you want to install \`${pkg}\` package?`, {
+          type: 'confirm',
+          name: 'confirm',
+          initial: true,
+        })
+      : false
 
     if (!confirm) {
       logger.error(`Nuxt Content requires \`${pkg}\` module to operate. Please install \`${pkg}\` package manually and try again. \`npm install ${pkg}\``)

--- a/test/unit/ensurePackageInstalled.test.ts
+++ b/test/unit/ensurePackageInstalled.test.ts
@@ -1,0 +1,29 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+const logger = { error: vi.fn(), prompt: vi.fn() }
+const addDependency = vi.fn()
+
+vi.mock('std-env', async importOriginal => ({
+  ...(await importOriginal<typeof import('std-env')>()),
+  hasTTY: false,
+  isCI: true,
+}))
+vi.mock('../../src/utils/dev', () => ({ logger }))
+vi.mock('nypm', () => ({ addDependency }))
+
+describe('ensurePackageInstalled', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  test('reports how to install the package instead of prompting when there is no TTY', async () => {
+    const exit = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never)
+    const { ensurePackageInstalled } = await import('../../src/utils/dependencies')
+
+    await ensurePackageInstalled('@nuxt/content-not-installed')
+
+    expect(logger.prompt).not.toHaveBeenCalled()
+    expect(logger.error).toHaveBeenLastCalledWith(expect.stringContaining('npm install @nuxt/content-not-installed'))
+    expect(exit).toHaveBeenCalledWith(1)
+  })
+})

--- a/test/unit/ensurePackageInstalled.test.ts
+++ b/test/unit/ensurePackageInstalled.test.ts
@@ -3,20 +3,21 @@ import { afterEach, describe, expect, test, vi } from 'vitest'
 const logger = { error: vi.fn(), prompt: vi.fn() }
 const addDependency = vi.fn()
 
-vi.mock('std-env', async importOriginal => ({
-  ...(await importOriginal<typeof import('std-env')>()),
-  hasTTY: false,
-  isCI: true,
-}))
 vi.mock('../../src/utils/dev', () => ({ logger }))
 vi.mock('nypm', () => ({ addDependency }))
 
 describe('ensurePackageInstalled', () => {
   afterEach(() => {
     vi.restoreAllMocks()
+    vi.resetModules()
   })
 
   test('reports how to install the package instead of prompting when there is no TTY', async () => {
+    vi.doMock('std-env', async importOriginal => ({
+      ...(await importOriginal<typeof import('std-env')>()),
+      hasTTY: false,
+      isCI: false,
+    }))
     const exit = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never)
     const { ensurePackageInstalled } = await import('../../src/utils/dependencies')
 
@@ -25,5 +26,35 @@ describe('ensurePackageInstalled', () => {
     expect(logger.prompt).not.toHaveBeenCalled()
     expect(logger.error).toHaveBeenLastCalledWith(expect.stringContaining('npm install @nuxt/content-not-installed'))
     expect(exit).toHaveBeenCalledWith(1)
+  })
+
+  test('reports how to install the package instead of prompting in CI', async () => {
+    vi.doMock('std-env', async importOriginal => ({
+      ...(await importOriginal<typeof import('std-env')>()),
+      hasTTY: true,
+      isCI: true,
+    }))
+    const exit = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never)
+    const { ensurePackageInstalled } = await import('../../src/utils/dependencies')
+
+    await ensurePackageInstalled('@nuxt/content-not-installed')
+
+    expect(logger.prompt).not.toHaveBeenCalled()
+    expect(logger.error).toHaveBeenLastCalledWith(expect.stringContaining('npm install @nuxt/content-not-installed'))
+    expect(exit).toHaveBeenCalledWith(1)
+  })
+
+  test('prompts to install the package when interactive and not in CI', async () => {
+    vi.doMock('std-env', async importOriginal => ({
+      ...(await importOriginal<typeof import('std-env')>()),
+      hasTTY: true,
+      isCI: false,
+    }))
+    vi.spyOn(process, 'exit').mockImplementation(() => undefined as never)
+    const { ensurePackageInstalled } = await import('../../src/utils/dependencies')
+
+    await ensurePackageInstalled('@nuxt/content-not-installed')
+
+    expect(logger.prompt).toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
### 🔗 Linked issue

Fixes #3832

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When `better-sqlite3` is missing, `ensurePackageInstalled` asks `consola` to prompt for confirmation. On a CI runner there is no TTY, so instead of the message telling you to install the package, the build dies with `TTY initialization failed: uv_tty_init returned EINVAL`. The prompt is now skipped when `hasTTY` is false or `isCI` is set, which falls through to the existing "please install it manually" error.

The `peerOptional` range for `better-sqlite3` also stayed on `^12.5.0`, so installing v13 to work around the crash gave an `ERESOLVE` error on npm. It now accepts v13 as well.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
