### PR TITLE
fix(ContentRenderer): keep async component identity stable across re-resolves

### DIFF
--- a/src/runtime/components/ContentRenderer.vue
+++ b/src/runtime/components/ContentRenderer.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { kebabCase, pascalCase } from 'scule'
 import { resolveComponent, toRaw, defineAsyncComponent, computed } from 'vue'
+import type { Component } from 'vue'
 import type { MDCComment, MDCElement, MDCRoot, MDCText } from '@nuxtjs/mdc'
 import htmlTags from '@nuxtjs/mdc/runtime/parser/utils/html-tags-list'
 import MDCRenderer from '@nuxtjs/mdc/runtime/components/MDCRenderer.vue'
@@ -112,18 +113,29 @@ const componentsMap = computed(() => {
   return body.value ? resolveContentComponents(body.value, { tags: tags.value }) : {}
 })
 
+const asyncLocalComponents = new Map<string, Component>()
+const asyncWrappedComponents = new WeakMap<Renderable, Component>()
+
 function resolveVueComponent(component: string | Renderable) {
   let _component: unknown = component
   if (typeof component === 'string') {
     if (htmlTags.has(component)) {
       return component
     }
-    if (globalComponents.includes(pascalCase(component))) {
+    const pascalName = pascalCase(component)
+    if (globalComponents.includes(pascalName)) {
       _component = resolveComponent(component, false)
     }
-    else if (localComponents.includes(pascalCase(component))) {
-      const loader = localComponentLoaders[pascalCase(component) as keyof typeof localComponentLoaders]
-      _component = loader ? defineAsyncComponent(loader) : undefined
+    else if (localComponents.includes(pascalName)) {
+      let asyncComponent = asyncLocalComponents.get(pascalName)
+      if (!asyncComponent) {
+        const loader = localComponentLoaders[pascalName as keyof typeof localComponentLoaders]
+        asyncComponent = loader ? defineAsyncComponent(loader) : undefined
+        if (asyncComponent) {
+          asyncLocalComponents.set(pascalName, asyncComponent)
+        }
+      }
+      _component = asyncComponent
     }
     if (typeof _component === 'string') {
       return _component
@@ -140,7 +152,12 @@ function resolveVueComponent(component: string | Renderable) {
   }
 
   if ('setup' in componentObject) {
-    return defineAsyncComponent(() => Promise.resolve(componentObject as Renderable))
+    let asyncComponent = asyncWrappedComponents.get(componentObject)
+    if (!asyncComponent) {
+      asyncComponent = defineAsyncComponent(() => Promise.resolve(componentObject as Renderable))
+      asyncWrappedComponents.set(componentObject, asyncComponent)
+    }
+    return asyncComponent
   }
 
   return componentObject


### PR DESCRIPTION
### 🔗 Linked issue

Ref nuxt-content/nuxt-studio#383

### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

`defineAsyncComponent` returns a **new component type** on every call. `resolveVueComponent` calls it in two places, and it is reached from `componentsMap`, a `computed` that re-resolves whenever `props.value` changes identity:

```js
const componentsMap = computed(() => {
  return body.value ? resolveContentComponents(body.value, { tags: tags.value }) : {}
})
```

```js
else if (localComponents.includes(pascalCase(component))) {
  const loader = localComponentLoaders[pascalCase(component)]
  _component = loader ? defineAsyncComponent(loader) : undefined  // new type every time
}
```

So every re-resolve hands `MDCRenderer` a fresh component type for each local component. Vue sees a different type at the same vnode position, so it cannot patch — it unmounts and remounts, and the async wrapper renders nothing for a tick while it re-resolves.

This is what makes Studio's live preview flash the entire article on every keystroke: Studio calls `app:data:refresh`, `useAsyncData` hands back a new document object, and the whole rendered tree is destroyed and recreated. Because the DOM is torn down, page height momentarily collapses and the scroll position is lost too — that's the "jumps back to the top" half of nuxt-content/nuxt-studio#383.

Projects that mark their content components `global` don't hit this, because `resolveComponent` returns a stable definition. Local components are a supported (and bundle-size-motivated) configuration, so they should behave the same.

The fix caches both wrappers — a `Map` keyed by pascal name for the loader branch, a `WeakMap` keyed by the component object for the `setup` branch — so repeated resolutions return the same instance and Vue patches the tree.

I also hoisted the repeated `pascalCase(component)` into a local, since it's now used three times.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have added tests (none — this is a component-identity fix with no observable output change; happy to add a regression test if you'd like one, though asserting "same vnode type across re-resolves" needs a bit of test scaffolding that doesn't exist yet).
