### PR TITLE
fix(query): tolerate trailing slashes in path-based lookups

### DIFF
--- a/src/runtime/internal/surround.ts
+++ b/src/runtime/internal/surround.ts
@@ -1,3 +1,4 @@
+import { withoutTrailingSlash } from 'ufo'
 import { generateNavigationTree } from './navigation'
 import type { ContentNavigationItem, PageCollectionItemBase, SurroundOptions } from '@nuxt/content'
 import type { CollectionQueryBuilder } from '~/src/types'
@@ -7,7 +8,8 @@ export async function generateItemSurround<T extends PageCollectionItemBase>(que
   const navigation = await generateNavigationTree(queryBuilder, fields)
 
   const flatData = flattedData(navigation)
-  const index = flatData.findIndex(item => item.path === path)
+  const normalizedPath = withoutTrailingSlash(path)
+  const index = flatData.findIndex(item => item.path === normalizedPath)
   const beforeItems = index === -1 ? [] : flatData.slice(index - before, index)
   const afterItems = index === -1 ? [] : flatData.slice(index + 1, index + after + 1)
 

--- a/src/runtime/utils/index.ts
+++ b/src/runtime/utils/index.ts
@@ -1,3 +1,4 @@
+import { withoutTrailingSlash } from 'ufo'
 import type { ContentNavigationItem } from '../../types'
 
 type FindPageBreadcrumbOptions = { current?: boolean, indexAsChild?: boolean }
@@ -6,6 +7,8 @@ export function findPageBreadcrumb(navigation?: ContentNavigationItem[], path?: 
   if (!navigation?.length || !path) {
     return []
   }
+
+  path = withoutTrailingSlash(path)
 
   return navigation.reduce((breadcrumb: ContentNavigationItem[], link: ContentNavigationItem) => {
     if (path && (path + '/').startsWith(link.path + '/')) {
@@ -27,6 +30,8 @@ export function findPageChildren(navigation?: ContentNavigationItem[], path?: st
     return []
   }
 
+  path = withoutTrailingSlash(path)
+
   return navigation.reduce((children: ContentNavigationItem[], link: ContentNavigationItem) => {
     if (link.children) {
       if (path === link.path) {
@@ -46,6 +51,8 @@ export function findPageSiblings(navigation?: ContentNavigationItem[], path?: st
     return []
   }
 
+  path = withoutTrailingSlash(path)
+
   const parentPath = path.substring(0, path.lastIndexOf('/'))
 
   return findPageChildren(navigation, parentPath, options).filter(c => c.path !== path)
@@ -55,6 +62,8 @@ export function findPageHeadline(navigation?: ContentNavigationItem[], path?: st
   if (!navigation?.length || !path) {
     return
   }
+
+  path = withoutTrailingSlash(path)
 
   for (const link of navigation) {
     if (options?.indexAsChild) {

--- a/test/unit/collectionQueryBuilder.test.ts
+++ b/test/unit/collectionQueryBuilder.test.ts
@@ -180,4 +180,28 @@ describe('collectionQueryBuilder', () => {
       'SELECT * FROM _articles WHERE ("path" = \'/blog/my-article\') ORDER BY stem ASC',
     )
   })
+
+  it('ignores trailing slash in path', async () => {
+    const query = collectionQueryBuilder('articles' as never, mockFetch)
+    await query
+      .path('/foo/bar/')
+      .all()
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'articles',
+      'SELECT * FROM _articles WHERE ("path" = \'/foo/bar\') ORDER BY stem ASC',
+    )
+  })
+
+  it('keeps root path', async () => {
+    const query = collectionQueryBuilder('articles' as never, mockFetch)
+    await query
+      .path('/')
+      .all()
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'articles',
+      'SELECT * FROM _articles WHERE ("path" = \'/\') ORDER BY stem ASC',
+    )
+  })
 })

--- a/test/unit/generateItemSurround.test.ts
+++ b/test/unit/generateItemSurround.test.ts
@@ -234,6 +234,14 @@ describe('generateItemSurround', () => {
     expect(result[1]).toMatchObject({ path: '/section' })
   })
 
+  it('ignores trailing slash in path', async () => {
+    const result = await generateItemSurround(mockQueryBuilder, '/item-2/')
+
+    expect(result).toHaveLength(2)
+    expect(result[0]).toMatchObject({ path: '/item-1' })
+    expect(result[1]).toMatchObject({ path: '/section' })
+  })
+
   it('handles start of list', async () => {
     const result = await generateItemSurround(mockQueryBuilder, '/item-1')
 

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -87,6 +87,12 @@ describe('utils', () => {
     expect(breadcrumb).toEqual([])
   })
 
+  it('findPageBreadcrumb ignores trailing slash', async () => {
+    const breadcrumb = removeChildren(findPageBreadcrumb(navigation, '/guide/getting-started/'))
+
+    expect(breadcrumb).toEqual(removeChildren(findPageBreadcrumb(navigation, '/guide/getting-started')))
+  })
+
   it('findPageBreadcrumb index with indexAsChild option', async () => {
     const breadcrumb = removeChildren(findPageBreadcrumb(navigation, '/guide', { indexAsChild: true }))
 
@@ -174,6 +180,23 @@ describe('utils', () => {
     ])
   })
 
+  it('findPageChildren ignores trailing slash', async () => {
+    const pages = removeChildren(findPageChildren(navigation, '/guide/'))
+
+    expect(pages).toEqual([
+      {
+        title: 'Getting Started',
+        path: '/guide/getting-started',
+        stem: 'guide/getting-started',
+      },
+      {
+        title: 'Introduction',
+        path: '/guide/introduction',
+        stem: 'guide/introduction',
+      },
+    ])
+  })
+
   it('findPageChildren with indexAsChild option', async () => {
     const pages = removeChildren(findPageChildren(navigation, '/guide', { indexAsChild: true }))
 
@@ -208,6 +231,18 @@ describe('utils', () => {
     ])
   })
 
+  it('findPageSiblings ignores trailing slash', async () => {
+    const pages = removeChildren(findPageSiblings(navigation, '/guide/getting-started/'))
+
+    expect(pages).toEqual([
+      {
+        title: 'Introduction',
+        path: '/guide/introduction',
+        stem: 'guide/introduction',
+      },
+    ])
+  })
+
   it('findPageSiblings with indexAsChild option', async () => {
     const pages = removeChildren(findPageSiblings(navigation, '/guide/getting-started', { indexAsChild: true }))
 
@@ -227,6 +262,12 @@ describe('utils', () => {
 
   it('findPageHeadline', async () => {
     const headline = findPageHeadline(navigation2, '/guide/getting-started')
+
+    expect(headline).toEqual('Guide Dir')
+  })
+
+  it('findPageHeadline ignores trailing slash', async () => {
+    const headline = findPageHeadline(navigation2, '/guide/getting-started/')
 
     expect(headline).toEqual('Guide Dir')
   })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

context: https://github.com/nuxt/nuxt/issues/36111
https://gitlab.com/eu-os/eu-os.gitlab.io/-/merge_requests/19

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

nuxt/content is sensitive to trailing slashes, which means that any user passing `route.path` on a deployment which _adds_ trailing slashes will lead to a 404 until nuxt redirects them to a version of the page without a trailing slash.

fwiw, `.path()` was already trailing-slash tolerant, so I think the fact that query wasn't is unintentional rather than a design decision

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
