### PR TITLE
feat(schema): add relation editor option

### DIFF
--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -47,12 +47,19 @@ export interface ContentConfig {
 }
 
 export interface EditorOptions {
-  input?: 'media' | 'icon' | 'textarea' // Override the default input for the field
+  input?: 'media' | 'icon' | 'textarea' | 'relation' // Override the default input for the field
   hidden?: boolean // Do not display the field in the editor
   iconLibraries?: string[] // List of icon libraries to use for the icon input
+  relation?: RelationOptions // Collection referenced by the field, for the relation input
   label?: string // Override auto-generated label with a custom one
   description?: string // When defined, set a description for the field
   tooltip?: string // When defined, set a tooltip info-bubble next to the label
+}
+
+export interface RelationOptions {
+  collection: string // Name of the referenced collection, as declared in the content config
+  valueField?: 'slug' | 'path' | 'stem' | (string & {}) // Field of the referenced document written to the file, defaults to `slug` (its file name)
+  labelField?: string // Field of the referenced document displayed in the editor, defaults to `name` then `title`
 }
 
 export interface ContentStandardSchemaV1<Input = unknown, Output = Input> extends StandardSchemaV1<Input, Output> {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

- nuxt-content/nuxt-studio#548 — the Studio PR that consumes this
- nuxt-content/nuxt-studio#219 — the feature request behind it

No issue on this repo; happy to open one if you would rather have the discussion here.

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Types only — adds `'relation'` to `EditorOptions.input` and a `relation?: RelationOptions`
option, so a string field can declare that it references a document of another
collection:

```ts
author: property(z.string()).editor({
  input: 'relation',
  relation: { collection: 'authors', labelField: 'name' },
})
```

The picker itself lives in Studio (nuxt-content/nuxt-studio#548), which renders a
searchable list of the referenced collection's documents and stores the chosen
document's slug. Editors currently have to type that slug by hand.

**Nothing here changes at runtime.** `.editor()` already merges its whole
argument into `_def.editor` (`src/utils/schema/zod3.ts:25`, and the same spread in
the `property()` proxy for zod4/valibot), and `toJSONSchema`'s `override` copies
it verbatim into `$content.editor`. So `relation` already reaches Studio today —
this only stops `input: 'relation'` from being a type error, which is otherwise
a cast at every call site.

`RelationOptions` is exported through `export type * from './schema'`, so
consumers can type their own metadata against it.

Additive and non-breaking: one new member on an existing string union, one new
optional key. `ConfigInputsTypes` in `src/utils/preview/data.ts` is deliberately
untouched — that union is for `app.config.ts` `@previewInput` tags, a separate
feature from collection-schema editor metadata.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

On docs: `docs/content/docs/2.collections/4.validators.md` intentionally does not
enumerate the available inputs — it points at the Studio docs for the mapping.
The `relation` option is documented there instead, in
nuxt-content/nuxt-studio#548. Glad to add a short section here too if you would
prefer the list to live in both places.
