### PR TITLE
feat: add `content.llms` option to disable the `nuxt-llms` integration

### DIFF
--- a/docs/content/docs/1.getting-started/3.configuration.md
+++ b/docs/content/docs/1.getting-started/3.configuration.md
@@ -500,6 +500,24 @@ Controls whether content hot reloading is enabled during development.
 The content watcher only runs in development and leverages the Vite dev server to detect content updates and send events to your application for live updates.
 ::
 
+## `llms`
+
+```ts [Default]
+llms: true
+```
+
+Controls the [`nuxt-llms` integration](/docs/integrations/llms). When `nuxt-llms` is installed, Nuxt Content injects your page collections into `llms.txt` and exposes the raw markdown endpoint under `/raw/`.
+
+Set it to `false` to opt out, for example when another module already serves the raw markdown route:
+
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  content: {
+    llms: false,
+  },
+});
+```
+
 ## `experimental`
 
 Experimental features that are not yet stable.

--- a/docs/content/docs/7.integrations/02.llms.md
+++ b/docs/content/docs/7.integrations/02.llms.md
@@ -11,6 +11,8 @@ seo:
 
 The Nuxt Content module integrates `nuxt-llms` to prepare your content for Large Language Models (LLMs). When `nuxt-llms` is detected, Content module automatically extends the LLMs module and inject collections of type [page](https://content.nuxt.com/docs/collections/types#page-type) to the LLMs module.🚀
 
+To opt out of the integration while keeping `nuxt-llms` installed, set [`content.llms`](/docs/getting-started/configuration#llms) to `false`.
+
 ## Setup
 
 ::prose-steps

--- a/src/features/llms/module.ts
+++ b/src/features/llms/module.ts
@@ -11,26 +11,26 @@ export default defineNuxtModule({
 
     addServerPlugin(resolve('runtime/server/content-llms.plugin'))
 
-    const llmsOption = (nuxt.options as unknown as { llms: { contentRawMarkdown: false | { excludeCollections: string[] } } })?.llms
-    if (llmsOption?.contentRawMarkdown !== false) {
+    // This module is installed at `modules:done`, every module has had a chance to set `llms.contentRawMarkdown` by now
+    const llmsOption = (nuxt.options as unknown as { llms?: { contentRawMarkdown?: false | { excludeCollections?: string[] } } }).llms
+    const contentRawMarkdown = llmsOption?.contentRawMarkdown === false
+      ? false
+      : defu(llmsOption?.contentRawMarkdown, {
+          excludeCollections: [],
+        })
+
+    if (contentRawMarkdown !== false) {
       addServerHandler({ route: '/raw/**:slug.md', handler: resolve('runtime/server/routes/raw/[...slug].md.get') })
     }
 
-    nuxt.hook('modules:done', () => {
-      const contentRawMarkdown = llmsOption?.contentRawMarkdown === false
-        ? false
-        : defu(llmsOption?.contentRawMarkdown, {
-            excludeCollections: [],
-          })
-      // @ts-expect-error -- TODO: fix types
-      nuxt.options.llms ||= {}
-      // @ts-expect-error -- TODO: fix types
-      nuxt.options.llms.contentRawMarkdown = contentRawMarkdown
+    // @ts-expect-error -- TODO: fix types
+    nuxt.options.llms ||= {}
+    // @ts-expect-error -- TODO: fix types
+    nuxt.options.llms.contentRawMarkdown = contentRawMarkdown
 
-      nuxt.options.runtimeConfig.llms ||= {}
-      // @ts-expect-error -- TODO: fix types
-      nuxt.options.runtimeConfig.llms.contentRawMarkdown = contentRawMarkdown
-    })
+    nuxt.options.runtimeConfig.llms ||= {}
+    // @ts-expect-error -- TODO: fix types
+    nuxt.options.runtimeConfig.llms.contentRawMarkdown = contentRawMarkdown
 
     const typeTemplate = addTypeTemplate({
       filename: 'content/llms.d.ts' as `${string}.d.ts`,

--- a/src/module.ts
+++ b/src/module.ts
@@ -48,6 +48,7 @@ const moduleDefaults: Partial<ModuleOptions> = {
   },
   preview: {},
   watch: { enabled: true },
+  llms: true,
   renderer: {
     alias: {},
     anchorLinks: {
@@ -220,9 +221,13 @@ export default defineNuxtModule<ModuleOptions>({
       }
     })
 
-    if (hasNuxtModule('nuxt-llms')) {
-      installModule(resolver.resolve('./features/llms'))
-    }
+    // Installed at `modules:done` so a module listed after this one can set `content.llms = false`
+    nuxt.hook('modules:done', async () => {
+      const llms = (nuxt.options as unknown as { content?: ModuleOptions }).content?.llms ?? options.llms
+      if (llms !== false && hasNuxtModule('nuxt-llms')) {
+        await installModule(resolver.resolve('./features/llms'))
+      }
+    })
 
     await configureMDCModule(options, nuxt)
 

--- a/src/types/module.ts
+++ b/src/types/module.ts
@@ -78,6 +78,12 @@ export interface ModuleOptions {
    * @default { enabled: true }
    */
   watch?: { enabled?: boolean }
+  /**
+   * Integration with `nuxt-llms`: injects page collections into `llms.txt` and exposes the raw markdown endpoint when `nuxt-llms` is installed.
+   * Set to `false` to disable it, for example when another module owns the raw markdown route.
+   * @default true
+   */
+  llms?: boolean
 
   renderer: {
     /**


### PR DESCRIPTION
### 🔗 Linked issue

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Adds a `content.llms` option (default `true`) to opt out of the `nuxt-llms` integration entirely, the llms.txt sections and the `/raw/**.md` route. Modules like [nuxt-agent-discovery](https://github.com/benjamincanac/nuxt-agent-discovery) serve the raw markdown route themselves and currently have to strip the content handler and nitro plugin after the fact.

The feature is now installed at `modules:done` instead of during setup, so a module listed after `@nuxt/content` can set `content.llms = false` from its own setup. This also makes `llms.contentRawMarkdown` order independent since it's now read after every module ran, which is why the feature module no longer needs its own `modules:done` hook.

```ts [nuxt.config.ts]
export default defineNuxtConfig({
  content: {
    llms: false,
  },
});
```

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.