### PR TITLE
perf(navigation): skip unused leaf sibling searches

### DIFF
--- a/src/runtime/internal/navigation.ts
+++ b/src/runtime/internal/navigation.ts
@@ -46,6 +46,24 @@ export async function generateNavigationTree<T extends PageCollectionItemBase>(q
     ...(isObject(content?.navigation) ? (content.navigation as Record<string, unknown>) : {}),
   })
 
+  const checkedChildren = new WeakMap<ContentNavigationItem[], number | false>()
+
+  // Existing child arrays only grow by appending; merges create new arrays.
+  function findPlaceholder(nodes: ContentNavigationItem[], path: string) {
+    let checked = checkedChildren.get(nodes) ?? 0
+    if (checked !== false) {
+      while (checked < nodes.length && nodes[checked]!.page !== false) {
+        checked++
+      }
+      if (checked === nodes.length) {
+        checkedChildren.set(nodes, checked)
+        return
+      }
+      checkedChildren.set(nodes, false)
+    }
+    return nodes.find(item => item.path === path && item.page === false)
+  }
+
   // Create navigation object
   const nav = contents
     .reduce((nav, content) => {
@@ -146,7 +164,7 @@ export async function generateNavigationTree<T extends PageCollectionItemBase>(q
       }, nav)
 
       // Check for duplicate link
-      const existed = siblings.find(item => item.path === navItem.path && item.page === false)
+      const existed = findPlaceholder(siblings, navItem.path)
       if (existed) {
         Object.assign(existed, {
           ...navItem,

--- a/src/runtime/internal/navigation.ts
+++ b/src/runtime/internal/navigation.ts
@@ -95,7 +95,7 @@ export async function generateNavigationTree<T extends PageCollectionItemBase>(q
       // First-level item, push it straight to nav
       if (parts.length === 1) {
         // Check for duplicate link
-        const existed = nav.find(item => item.path === navItem.path && item.page === false)
+        const existed = isIndex && nav.find(item => item.path === navItem.path && item.page === false)
         if (isIndex && existed) {
           Object.assign(existed, {
             page: undefined,

--- a/test/unit/generateNavigationTree.test.ts
+++ b/test/unit/generateNavigationTree.test.ts
@@ -17,6 +17,83 @@ describe('generateNavigationTree', () => {
     all: async () => items,
   } as unknown as CollectionQueryBuilder<PageCollectionItemBase>)
 
+  const queryInOrder = (items: Partial<PageCollectionItemBase>[]) => ({
+    __params: { orderBy: ['caller order'] },
+    orWhere() { return this },
+    select() { return this },
+    all: async () => items,
+  } as unknown as CollectionQueryBuilder<PageCollectionItemBase>)
+
+  it.each([false, true])('skips leaf sibling searches with an explicit index: %s', async (withIndex) => {
+    const pages = Array.from({ length: 100 }, (_, i) => ({
+      title: `Page ${i}`,
+      path: `/guide/page-${100 - i}`,
+      stem: `guide/page-${100 - i}`,
+    }))
+    const items = withIndex ? [{ title: 'Guide', path: '/guide', stem: 'guide/index' }, ...pages] : pages
+    const find = vi.spyOn(Array.prototype, 'find')
+    try {
+      const tree = await generateNavigationTree(queryInOrder(items))
+      const searches = find.mock.calls.length
+      expect(searches).toBe(pages.length + Number(withIndex))
+      expect(tree[0]?.children?.map(item => item.path)).toEqual(items.map(item => item.path))
+    }
+    finally {
+      find.mockRestore()
+    }
+  })
+
+  it.each([false, true])('merges a placeholder appended after a leaf, from metadata: %s', async (fromMetadata) => {
+    const tree = await generateNavigationTree(queryInOrder([
+      { title: 'First', path: '/guide/first', stem: 'guide/first' },
+      fromMetadata
+        ? { title: 'Placeholder', path: '/guide/topic', stem: 'guide/topic', navigation: { page: false } }
+        : { title: 'Child', path: '/guide/topic/child', stem: 'guide/topic/child' },
+      { title: 'Topic', path: '/guide/topic', stem: 'guide/topic' },
+    ]))
+
+    expect(tree[0]?.children?.map(item => item.path)).toEqual(['/guide/first', '/guide/topic'])
+    expect(tree[0]?.children?.[1]).toMatchObject({ title: 'Topic', page: undefined })
+    expect(tree[0]?.children?.[1]?.children?.map(item => item.path)).toEqual(fromMetadata ? undefined : ['/guide/topic/child'])
+  })
+
+  it.each([false, true])('merges supplied duplicate placeholders in order, from directory config: %s', async (fromConfig) => {
+    const children = ['First', 'Second'].map(title => ({
+      title,
+      path: '/guide/topic',
+      page: false,
+      children: [{ title, path: `/guide/topic/${title.toLowerCase()}` }],
+    }))
+    const roots = fromConfig
+      ? [
+          { title: 'Config', path: '/guide/.navigation', stem: 'guide/.navigation', meta: { children } },
+          { title: 'Guide', path: '/guide', stem: 'guide/index' },
+        ]
+      : [{ title: 'Guide', path: '/guide', stem: 'guide', navigation: { children } }]
+    const tree = await generateNavigationTree(queryInOrder([
+      ...roots,
+      { title: 'Replacement 1', path: '/guide/topic', stem: 'guide/topic' },
+      { title: 'Replacement 2', path: '/guide/topic', stem: 'guide/topic' },
+    ]))
+
+    expect(tree[0]?.children?.map(item => item.title)).toEqual(['Replacement 1', 'Replacement 2'])
+    expect(tree[0]?.children?.map(item => item.page)).toEqual([undefined, undefined])
+    expect(tree[0]?.children?.map(item => item.children?.[0]?.path)).toEqual(['/guide/topic/first', '/guide/topic/second'])
+  })
+
+  it.each([false, true])('preserves index merging and later siblings, child first: %s', async (childFirst) => {
+    const index = { title: 'Topic', path: '/guide/topic', stem: 'guide/topic/index' }
+    const child = { title: 'First', path: '/guide/topic/first', stem: 'guide/topic/first' }
+    const tree = await generateNavigationTree(queryInOrder([
+      ...(childFirst ? [child, index] : [index, child]),
+      { title: 'Second', path: '/guide/topic/second', stem: 'guide/topic/second' },
+    ]))
+
+    expect(tree[0]?.children?.[0]?.children?.map(item => item.path)).toEqual([
+      '/guide/topic', '/guide/topic/first', '/guide/topic/second',
+    ])
+  })
+
   it('should generate a basic navigation tree', async () => {
     const items = [
       {

--- a/test/unit/generateNavigationTree.test.ts
+++ b/test/unit/generateNavigationTree.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { generateNavigationTree } from '../../src/runtime/internal/navigation'
 import type { CollectionQueryBuilder, PageCollectionItemBase } from '@nuxt/content'
 
@@ -45,6 +45,26 @@ describe('generateNavigationTree', () => {
         stem: 'index',
       },
     ])
+  })
+
+  it('does not search siblings when appending ordinary root pages', async () => {
+    const items = Array.from({ length: 100 }, (_, i) => ({
+      title: `Page ${i}`,
+      path: `/page-${i}`,
+      stem: `page-${i}`,
+    })) as PageCollectionItemBase[]
+    const find = vi.spyOn(Array.prototype, 'find')
+
+    try {
+      const tree = await generateNavigationTree(mockQueryBuilder(items))
+      const siblingSearches = find.mock.calls.length
+
+      expect(tree).toEqual(items)
+      expect(siblingSearches).toBe(0)
+    }
+    finally {
+      find.mockRestore()
+    }
   })
 
   it('should generate a basic navigation tree with order', async () => {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

No linked issue or discussion. Reproduction below.

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Navigation scanned earlier siblings when adding leaf pages. Skip the unused root lookup and check only newly appended children for placeholders. Once an array contains a placeholder, keep the original lookup and merge behavior.

```diff
 ordinary root page
-  search siblings, discard the result
 nested leaf page
-  search all earlier siblings
+  skip lookup while no placeholders exist
```

For 5,000 pages, the pinned fixtures count these `find` predicate calls:

| Pages | Before | After | Repro |
| --- | ---: | ---: | --- |
| Flat root pages | 12,497,500 | 0 | [Before](https://github.com/onmax/repros/tree/repro/nuxt-content-navigation-scan/nuxt-content-navigation-scan) · [After](https://github.com/onmax/repros/tree/repro/nuxt-content-navigation-scan/nuxt-content-navigation-scan-fix) |
| Pages under `/guide` | 12,502,499 | 4,999 | [Before](https://github.com/onmax/repros/tree/repro/nuxt-content-nested-navigation/nuxt-content-nested-navigation) · [After](https://github.com/onmax/repros/tree/repro/nuxt-content-nested-navigation/nuxt-content-nested-navigation-fix) |

Index merging and caller order stay unchanged. Parent lookups and child arrays that have contained placeholders retain their existing cost.

Navigation generation time for the exact PR base and head, on Node 24.19.0 / Linux / AMD EPYC 7452. Medians of 25 samples after five warmups, alternating before and after. Brackets show the middle 50% of samples.

| Layout | Pages | Before, ms | After, ms |
| --- | ---: | ---: | ---: |
| Flat root pages | 1,000 | 18.9 [13.7, 25.3] | 4.5 [2.9, 6.4] |
| Flat root pages | 5,000 | 457.0 [360.7, 635.5] | 25.5 [22.2, 30.9] |
| Under `/guide` | 1,000 | 31.8 [23.2, 37.0] | 10.8 [7.6, 14.5] |
| Under `/guide` | 5,000 | 540.7 [457.5, 634.2] | 40.5 [33.7, 47.0] |

Both versions produce equal trees for each input. Timings exclude SQL, input cloning, and setup. This shared machine has variable load; these are local navigation timings, not page-load measurements. [Benchmark script, command, and raw samples](https://github.com/onmax/repros/blob/repro/nuxt-content-nested-navigation/BENCHMARK.md).


<details>
<summary>Copy and run both comparisons with Node 24.19.0 and Corepack</summary>

```sh
for repro in nuxt-content-navigation-scan nuxt-content-nested-navigation; do
  (
    set -e
    git clone --depth 1 --filter=blob:none --sparse --branch "repro/$repro" https://github.com/onmax/repros.git "$repro-repro"
    cd "$repro-repro"
    git sparse-checkout set "$repro" "$repro-fix"
    cd "$repro"
    corepack pnpm install --frozen-lockfile --ignore-scripts
    corepack pnpm verify
    cd "../$repro-fix"
    corepack pnpm install --frozen-lockfile --ignore-scripts
    corepack pnpm verify
  ) || exit 1
done
```

</details>

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

Documentation: not applicable; public navigation behavior is unchanged.

