### PR TITLE
fix(cache): await development cache replacement

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -379,7 +379,7 @@ async function processCollectionItems(nuxt: Nuxt, collections: ResolvedCollectio
                 collectionType: collection.type,
               })
               if (parsedContent) {
-                db.insertDevelopmentCache(keyInCollection, JSON.stringify(parsedContent), checksum)
+                await db.insertDevelopmentCache(keyInCollection, JSON.stringify(parsedContent), checksum)
               }
             }
 

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -17,8 +17,8 @@ export type DatabaseAdapterFactory<Options> = (otps?: Options) => DatabaseAdapte
 export interface LocalDevelopmentDatabase {
   fetchDevelopmentCache(): Promise<Record<string, CacheEntry>>
   fetchDevelopmentCacheForKey(key: string): Promise<CacheEntry | undefined>
-  insertDevelopmentCache(id: string, checksum: string, parsedContent: string): void
-  deleteDevelopmentCache(id: string): void
+  insertDevelopmentCache(id: string, value: string, checksum: string): Promise<void>
+  deleteDevelopmentCache(id: string): Promise<void>
   dropContentTables(): void
   exec(sql: string): void
   close(): void

--- a/src/utils/database.ts
+++ b/src/utils/database.ts
@@ -127,7 +127,7 @@ export async function getLocalDatabase(database: SqliteDatabaseConfig | D1Databa
   }
 
   const insertDevelopmentCache = async (id: string, value: string, checksum: string) => {
-    deleteDevelopmentCache(id)
+    await deleteDevelopmentCache(id)
     const insert = generateCollectionInsert(cacheCollection, { id, value, checksum })
     for (const query of insert.queries) {
       await db.exec(query)
@@ -135,7 +135,7 @@ export async function getLocalDatabase(database: SqliteDatabaseConfig | D1Databa
   }
 
   const deleteDevelopmentCache = async (id: string) => {
-    db.prepare(`DELETE FROM _development_cache WHERE id = ?`).run(id)
+    await db.prepare(`DELETE FROM _development_cache WHERE id = ?`).run(id)
   }
 
   const dropContentTables = async () => {

--- a/src/utils/dev.ts
+++ b/src/utils/dev.ts
@@ -164,7 +164,7 @@ export function watchContents(nuxt: Nuxt, options: ModuleOptions, manifest: Mani
             collectionType: collection.type,
           }).then(result => JSON.stringify(result))
 
-          db.insertDevelopmentCache(keyInCollection, checksum, parsedContent)
+          await db.insertDevelopmentCache(keyInCollection, parsedContent, checksum)
         }
 
         const insert = generateCollectionInsert(collection, JSON.parse(parsedContent))

--- a/test/unit/developmentCacheOrdering.test.ts
+++ b/test/unit/developmentCacheOrdering.test.ts
@@ -1,0 +1,98 @@
+import { randomUUID } from 'node:crypto'
+import { setImmediate } from 'node:timers/promises'
+import { describe, expect, onTestFinished, test, vi } from 'vitest'
+import type { Connector } from 'db0'
+import betterSqliteConnector from 'db0/connectors/better-sqlite3'
+import nodeSqliteConnector from 'db0/connectors/node-sqlite'
+import { getLocalDatabase } from '../../src/utils/database'
+import { MAX_SQL_QUERY_SIZE } from '../../src/utils/collection'
+
+async function openDatabase(connector: Connector) {
+  const db = await getLocalDatabase({ type: 'sqlite', filename: randomUUID() }, { connector })
+  onTestFinished(async () => {
+    try {
+      db.close()
+    }
+    finally {
+      await connector.dispose?.()
+    }
+  })
+  return db
+}
+
+describe('development cache write ordering', () => {
+  test('waits for deletion to finish before inserting the replacement', async () => {
+    const connector = nodeSqliteConnector({ name: ':memory:' })
+    const db = await openDatabase(connector)
+    await db.insertDevelopmentCache('document', 'old value', 'old checksum')
+    const deletion = Promise.withResolvers<undefined>()
+    const prepare = connector.prepare.bind(connector)
+    vi.spyOn(connector, 'prepare').mockImplementation((sql) => {
+      const statement = prepare(sql)
+      if (sql.startsWith('DELETE FROM _development_cache')) {
+        const run = statement.run.bind(statement)
+        vi.spyOn(statement, 'run').mockImplementation(async (...params) => {
+          await deletion.promise
+          return run(...params)
+        })
+      }
+      return statement
+    })
+    const exec = vi.spyOn(connector, 'exec')
+    let settled = false
+    const write = Promise.resolve(db.insertDevelopmentCache('document', 'new value', 'new checksum'))
+      .then(() => { settled = true }, (error) => {
+        settled = true
+        return error
+      })
+    // Drain microtasks while the actual deletion remains blocked.
+    await setImmediate()
+    const insertedBeforeDeletion = exec.mock.calls.length
+    const settledBeforeDeletion = settled
+    deletion.resolve(undefined)
+    const error = await write
+    expect(insertedBeforeDeletion).toBe(0)
+    expect(settledBeforeDeletion).toBe(false)
+    expect(error).toBeUndefined()
+    expect(await db.fetchDevelopmentCacheForKey('document')).toMatchObject({
+      id: 'document', value: 'new value', checksum: 'new checksum',
+    })
+  })
+
+  test('propagates deletion failure without inserting a replacement', async () => {
+    const connector = nodeSqliteConnector({ name: ':memory:' })
+    const db = await openDatabase(connector)
+    await db.insertDevelopmentCache('document', 'old value', 'old checksum')
+    const failure = new Error('cache deletion failed')
+    const prepare = connector.prepare.bind(connector)
+    vi.spyOn(connector, 'prepare').mockImplementation((sql) => {
+      const statement = prepare(sql)
+      if (sql.startsWith('DELETE FROM _development_cache')) {
+        vi.spyOn(statement, 'run').mockRejectedValue(failure)
+      }
+      return statement
+    })
+    const exec = vi.spyOn(connector, 'exec')
+    await expect(db.insertDevelopmentCache('document', 'new value', 'new checksum')).rejects.toBe(failure)
+    expect(exec).not.toHaveBeenCalled()
+    expect(await db.fetchDevelopmentCacheForKey('document')).toMatchObject({
+      id: 'document', value: 'old value', checksum: 'old checksum',
+    })
+  })
+
+  test.each([
+    ['better-sqlite3', betterSqliteConnector],
+    ['node-sqlite', nodeSqliteConnector],
+  ] as const)('retains replacements and split values with %s', async (_name, createConnector) => {
+    const db = await openDatabase(createConnector({ name: ':memory:' }))
+    await db.insertDevelopmentCache('document', 'old value', 'old checksum')
+    expect(await db.fetchDevelopmentCacheForKey('document')).toMatchObject({
+      id: 'document', value: 'old value', checksum: 'old checksum',
+    })
+    const value = 'a'.repeat(MAX_SQL_QUERY_SIZE * 2)
+    await db.insertDevelopmentCache('document', value, 'new checksum')
+    expect(await db.fetchDevelopmentCacheForKey('document')).toMatchObject({
+      id: 'document', value, checksum: 'new checksum',
+    })
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

No linked issue.

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Await development-cache deletion before inserting replacement rows, and await callers before initialization or HMR continues. Async db0 connectors could otherwise execute the delete after the insert, leaving a cold cache on the next startup; the HMR caller also stored its value and checksum in reverse order.

| | Description | GitHub |
| --- | --- | --- |
| Before | Second initialization reparses all 30 documents. | [Source](https://github.com/onmax/repros/tree/repro/nuxt-content-cache-order/nuxt-content-cache-order) |
| After | Second initialization loads all 30 documents from cache. | [Source](https://github.com/onmax/repros/tree/repro/nuxt-content-cache-order/nuxt-content-cache-order-fix) |

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
