### PR TITLE
perf(cache): avoid repeated cache index copies

### DIFF
--- a/src/utils/database.ts
+++ b/src/utils/database.ts
@@ -119,7 +119,7 @@ export async function getLocalDatabase(database: SqliteDatabaseConfig | D1Databa
 
   const fetchDevelopmentCache = async () => {
     const result = await db.prepare('SELECT * FROM _development_cache').all() as CacheEntry[]
-    return result.reduce((acc, cur) => ({ ...acc, [cur.id]: cur }), {} as Record<string, CacheEntry>)
+    return Object.fromEntries(result.map(cur => [cur.id, cur]))
   }
 
   const fetchDevelopmentCacheForKey = async (id: string) => {

--- a/test/unit/developmentCacheIndex.test.ts
+++ b/test/unit/developmentCacheIndex.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from 'vitest'
+import type { Connector } from 'db0'
+import type { CacheEntry } from '../../src/types'
+import { databaseVersion, getLocalDatabase } from '../../src/utils/database'
+
+async function fetchCache(rows: CacheEntry[]) {
+  const connector = {
+    exec: async () => {},
+    prepare: () => ({
+      get: async () => ({ value: databaseVersion }),
+      all: async () => rows,
+    }),
+  } as unknown as Connector
+  const db = await getLocalDatabase({ type: 'sqlite', filename: ':cache-index-test:' }, { connector })
+  try {
+    return await db.fetchDevelopmentCache()
+  }
+  finally {
+    db.close()
+  }
+}
+
+describe('fetchDevelopmentCache', () => {
+  test('returns an ordinary empty object for no rows', async () => {
+    const cache = await fetchCache([])
+    expect(cache).toEqual({})
+    expect(Object.getPrototypeOf(cache)).toBe(Object.prototype)
+  })
+
+  test('indexes complete rows by id, keeping the last duplicate', async () => {
+    const first = { id: 'first', value: 'old', checksum: 'old-checksum' }
+    const second = { id: 'second', value: 'other', checksum: 'other-checksum' }
+    const replacement = { id: 'first', value: 'new', checksum: 'new-checksum' }
+    const cache = await fetchCache([first, second, replacement])
+    expect(Object.keys(cache)).toEqual(['first', 'second'])
+    expect(cache.first).toBe(replacement)
+    expect(cache.second).toBe(second)
+  })
+
+  test('preserves special ids as ordinary own properties', async () => {
+    const rows = ['__proto__', 'constructor'].map(id => ({ id, value: id, checksum: id }))
+    const cache = await fetchCache(rows)
+    expect(Object.getPrototypeOf(cache)).toBe(Object.prototype)
+    for (const row of rows) {
+      expect(Object.getOwnPropertyDescriptor(cache, row.id)).toEqual({
+        value: row,
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      })
+    }
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

No linked issue.

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Build the development-cache lookup without copying every prior property for each row. This preserves last-row-wins behavior and special IDs.

| | Description | GitHub |
| --- | --- | --- |
| Before | Indexing 300 cached documents copies 45,150 existing properties. | [Source](https://github.com/onmax/repros/tree/repro/nuxt-content-perf-cache-index/nuxt-content-perf-cache-index) |
| After | Indexing the same 300 documents copies no existing properties. | [Source](https://github.com/onmax/repros/tree/repro/nuxt-content-perf-cache-index/nuxt-content-perf-cache-index-fix) |

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
